### PR TITLE
fix: Handle negative scores in terminal reporter

### DIFF
--- a/src/reporter/terminal.ts
+++ b/src/reporter/terminal.ts
@@ -72,7 +72,9 @@ export function printCaseDetail(
 ): void {
   console.log(chalk.dim(`\n  [${caseId}] ${prompt.slice(0, 72)}${prompt.length > 72 ? '...' : ''}`))
   for (const [id, score] of Object.entries(scores)) {
-    const bar = '|'.repeat(Math.round(score.total)) + chalk.dim('.'.repeat(10 - Math.round(score.total)))
+    // Clamp score to 0-10 range to prevent negative repeat counts
+    const scoreDisplay = Math.max(0, Math.min(10, Math.round(score.total)))
+    const bar = '|'.repeat(scoreDisplay) + chalk.dim('.'.repeat(10 - scoreDisplay))
     console.log(`    ${chalk.dim(id.padEnd(22))} ${bar} ${score.total.toFixed(1)}  ${chalk.dim(score.reasoning.slice(0, 60))}`)
   }
 }


### PR DESCRIPTION
## Problem

When a judge returns a negative score, the terminal reporter crashes with:
```
RangeError: Invalid count value: -90
    at printCaseDetail terminal.ts:75
```

This happens because `String.repeat()` throws when given negative values.

## Solution

Clamp the score display to the 0-10 range while preserving the actual score value in the output.

## Changes

```typescript
// Before:
const bar = '|'.repeat(Math.round(score.total)) + ...

// After:
const scoreDisplay = Math.max(0, Math.min(10, Math.round(score.total)))
const bar = '|'.repeat(scoreDisplay) + ...
```

## Testing

Tested with qwen-7b judge that returned a -90 score. Before fix: crash. After fix: displays score as -90.0 with visual bar clamped to 0.

```
qwen-7b                .......... -90.0  reasoning text
```

Ran full test suite with 3 cases, 2 models. All results generated successfully:
- JSON output saved
- Markdown report generated
- Leaderboard displayed

## Impact

Fixes blocking bug that prevents verdict from completing any eval run where a judge returns a negative score.