### PR TITLE
docs: Add example eval packs and guide

### DIFF
--- a/examples/README.md
+++ b/examples/README.md
@@ -1,0 +1,50 @@
+# Verdict Examples
+
+This directory contains example eval packs to help you get started with Verdict.
+
+## Quick Start
+
+Run any example:
+
+```bash
+verdict run --pack examples/basic-comparison.yaml
+```
+
+## Available Examples
+
+### `basic-comparison.yaml`
+Simple 3-case eval pack for testing basic model capabilities:
+- Factual recall
+- Technical explanation  
+- Creative writing
+
+**Use when:** Getting started with Verdict, testing new models
+
+### `code-quality.yaml`
+Code-focused eval pack testing:
+- Code generation
+- Code review
+- Technical explanations
+
+**Use when:** Comparing models for coding tasks
+
+## Creating Your Own
+
+1. Copy an example as a template
+2. Modify the cases for your use case
+3. Run: `verdict run --pack your-pack.yaml`
+
+See the [main README](../README.md#eval-packs) for full eval pack syntax.
+
+## Tips
+
+- **Start small:** 3-5 cases to iterate quickly
+- **Clear criteria:** Specific pass/fail conditions work best
+- **Tag your cases:** Makes filtering easier later
+- **Test first:** Run on one model before comparing multiple
+
+## More Examples
+
+For more eval packs, see:
+- `eval-packs/general.yaml` - Comprehensive general capabilities
+- `eval-packs/moe.yaml` - Mixture-of-experts specific tests

--- a/examples/basic-comparison.yaml
+++ b/examples/basic-comparison.yaml
@@ -1,0 +1,22 @@
+# Basic Model Comparison Example
+# Compare two models on simple tasks
+
+name: Basic Comparison Example
+version: 1.0.0
+description: Simple example comparing two local models
+
+cases:
+  - id: basic-001
+    prompt: "What is the capital of France?"
+    criteria: "Answer should be Paris"
+    tags: [factual, easy]
+
+  - id: basic-002
+    prompt: "Explain recursion in one sentence."
+    criteria: "Clear definition mentioning function calling itself"
+    tags: [technical, medium]
+
+  - id: basic-003
+    prompt: "Write a haiku about coding."
+    criteria: "3 lines, 5-7-5 syllable pattern, coding-related"
+    tags: [creative, easy]

--- a/examples/code-quality.yaml
+++ b/examples/code-quality.yaml
@@ -1,0 +1,22 @@
+# Code Quality Evaluation Example
+# Test models on code generation and review tasks
+
+name: Code Quality Evaluation
+version: 1.0.0
+description: Evaluate code generation and review capabilities
+
+cases:
+  - id: code-001
+    prompt: "Write a Python function to reverse a string"
+    criteria: "Working function, handles edge cases, clear variable names"
+    tags: [coding, python, easy]
+
+  - id: code-002
+    prompt: "Review this code: `for i in range(len(arr)): print(arr[i])`"
+    criteria: "Suggests using `for item in arr`, explains why it's better"
+    tags: [review, python, medium]
+
+  - id: code-003
+    prompt: "Explain the difference between == and === in JavaScript"
+    criteria: "Mentions type coercion, provides examples, recommends ==="
+    tags: [explanation, javascript, medium]


### PR DESCRIPTION
## Description

Adds an `examples/` directory with starter eval packs and documentation to help new users get started quickly.

## Contents

**Example eval packs:**
- `basic-comparison.yaml` - Simple 3-case starter (factual, technical, creative)
- `code-quality.yaml` - Code generation and review focused

**Documentation:**
- `examples/README.md` - How to use examples, tips for creating your own

## Benefits

- New users can run `verdict run --pack examples/basic-comparison.yaml` immediately
- Examples demonstrate eval pack structure without reading full docs
- Provides templates for common use cases (general testing, code evaluation)

## Usage

```bash
# Try an example
verdict run --pack examples/basic-comparison.yaml

# Copy and modify
cp examples/basic-comparison.yaml my-eval.yaml
```