### PR TITLE
fix: MLX MoE eval pack redesign + concurrency warnings + discover routing

### DIFF
--- a/COMPILED-BUILD-FIX.md
+++ b/COMPILED-BUILD-FIX.md
@@ -1,0 +1,53 @@
+# verdict compiled build fix — compiled binary hangs on Ollama
+
+## What was broken
+
+`node dist/cli/index.js run` hung indefinitely when making API calls to Ollama.
+`npx tsx src/cli/index.ts run` worked fine.
+`--dry-run` worked fine (no API calls made).
+
+## Root cause
+
+`tsup` was bundling the `openai` SDK inline into the compiled output. When bundled, the SDK loses access to its internal `undici` HTTP client. Calls to Ollama (or any local inference server) silently hang — no error, no timeout, no output.
+
+The `shims: true` option was also injecting a `fetch` polyfill that conflicted with the openai SDK's own HTTP handling.
+
+## Fix
+
+Two changes to `tsup.config.ts`:
+
+```diff
+export default defineConfig({
+  entry: ['src/cli/index.ts'],
+  format: ['esm'],
+- target: 'node20',
++ target: 'node22',
+  outDir: 'dist/cli',
+  clean: true,
+- shims: true,
++ // shims: false — do not inject fetch polyfill, conflicts with openai SDK internals
++ shims: false,
++ // external: ['openai'] — load from node_modules at runtime, not bundled inline
++ external: ['openai'],
+  banner: {
+    js: '#!/usr/bin/env node',
+  },
+})
+```
+
+That's it. Rebuild and the compiled binary works.
+
+```bash
+npm run build
+node dist/cli/index.js run   # works
+```
+
+## Why this works
+
+Marking `openai` as `external` means tsup emits `import OpenAI from "openai"` in the bundle and Node.js resolves it from `node_modules` at runtime. The full SDK loads correctly with `undici` intact. HTTP connections to Ollama work as expected.
+
+Since `openai` is already in `dependencies` (not `devDependencies`), it's always present when the package is installed — no runtime dependency change needed.
+
+## Affected versions
+
+Any version of verdict built with tsup and `openai` as a direct dependency, when running against local inference servers (Ollama, MLX, LM Studio). Cloud providers (OpenRouter, OpenAI direct) may have been affected too but are harder to reproduce since their connections typically error vs. hang.

--- a/eval-packs/moe.yaml
+++ b/eval-packs/moe.yaml
@@ -1,30 +1,108 @@
 # eval-packs/moe.yaml
 name: MoE Benchmark
-version: 1.0.0
-description: Tasks that highlight Mixture-of-Experts model strengths. MoE models activate different experts per token, excelling at tasks that require switching between domains.
+version: 2.0.0
+description: |
+  Tasks designed to reveal MoE (Mixture-of-Experts) model advantages over dense models.
+  MoE models activate different expert sub-networks per token, excelling at tasks that
+  require simultaneous deep expertise across multiple domains. These cases are chosen to
+  expose that advantage — a capable dense model should score lower on average.
+  
+  Run this pack against a MoE model AND a comparable dense model to see the delta.
 
 cases:
   - id: moe-001
-    prompt: "Explain how mRNA vaccines work, then write a Python function that simulates a simple S-curve adoption model."
-    criteria: "Correct mRNA mechanism (spike protein, immune training). Working Python S-curve function (sigmoid or logistic), accepts time parameter."
-    tags: [multi-domain, biology, coding]
+    prompt: |
+      In a single response, do all three:
+      1. Explain how Transformer attention works mathematically (include the softmax(QK^T/sqrt(d_k))V formula)
+      2. Write a working Python implementation of scaled dot-product attention
+      3. Explain what goes wrong biologically when the blood-brain barrier breaks down in Alzheimer's disease
+      
+      Do not separate these into sections — weave all three into one coherent explanation.
+    criteria: |
+      All three present and correct:
+      - Correct attention formula with scaling factor sqrt(d_k) explained
+      - Working Python: Q, K, V matrices, softmax over scaled dot products, returns weighted V
+      - Correct Alzheimer's/BBB explanation: tight junction disruption, neuroinflammation, amyloid accumulation
+      - Response is coherent, not just three separate answers stapled together
+    tags: [multi-domain, ml, neuroscience, coding, simultaneous-expertise]
 
   - id: moe-002
-    prompt: "Solve: if x^2 - 5x + 6 = 0, find x. Then describe one real-world system this equation could model."
-    criteria: "Correct roots: x=2, x=3. Reasonable real-world application (spring, projectile, population model, etc.)"
-    tags: [math, reasoning, applied]
+    prompt: |
+      A startup is building a distributed system. Answer these simultaneously:
+      - What CAP theorem tradeoff should they make for a financial ledger? Why?
+      - Write the SQL schema (PostgreSQL) for that ledger with proper constraints
+      - What Byzantine fault tolerance approach makes sense at 100 nodes?
+      - Name the one musical concept (from jazz theory) that best describes how distributed consensus works
+    criteria: |
+      - CAP: correctly chooses CP over AP for financial data, explains consistency requirement
+      - Valid PostgreSQL schema: accounts + transactions tables, CHECK constraints, DECIMAL for amounts, foreign keys
+      - BFT: mentions PBFT or threshold signatures, explains 3f+1 node requirement
+      - Jazz analogy: valid (e.g., call-and-response, trading fours, unison) with defensible reasoning
+    tags: [multi-domain, systems, sql, distributed, music, simultaneous-expertise]
 
   - id: moe-003
-    prompt: "Translate this Python code to TypeScript, then explain the main type safety difference: def add(a, b): return a + b"
-    criteria: "Correct TypeScript with type annotations (number params + return type). Explanation mentions static typing."
-    tags: [coding, multi-language]
+    prompt: |
+      Translate this Python to idiomatic Rust, then explain:
+      1. Why the Rust version is memory-safe without garbage collection
+      2. The equivalent concept in immunology (how the immune system "borrows" and "returns" resources without leaking)
+      
+      Python:
+      def process_items(items: list[str]) -> dict[str, int]:
+          result = {}
+          for item in items:
+              result[item] = len(item)
+          return result
+    criteria: |
+      - Correct idiomatic Rust: HashMap<String, usize>, ownership transferred into map, no clone abuse
+      - Memory safety explanation: ownership, no dangling pointers, stack allocation
+      - Immunology analogy: valid (e.g., cytokine signaling, receptor recycling, endocytosis/exocytosis) correctly mapped to borrow/return concept
+    tags: [coding, rust, immunology, analogy, multi-domain]
 
   - id: moe-004
-    prompt: "Describe the French Revolution in 3 sentences, then identify 2 parallels to a modern political movement."
-    criteria: "Historically accurate summary. Two specific, defensible modern parallels named."
-    tags: [history, analysis, reasoning]
+    prompt: |
+      You are debugging two separate issues at the same time:
+      
+      Issue A — Python traceback:
+      ```
+      KeyError: 'user_id'
+      at line 47: return data['user_id']
+      ```
+      The data dict comes from JSON parsed from an API that sometimes returns snake_case and sometimes camelCase.
+      
+      Issue B — A patient's blood test shows: elevated creatinine (2.8 mg/dL), low GFR (28), normal blood pressure.
+      
+      For each: give the root cause and the fix. Then explain what these two problems have in common structurally.
+    criteria: |
+      - Issue A: root cause is inconsistent API key naming; fix is .get('user_id') or .get('userId') with fallback, or key normalization
+      - Issue B: root cause is chronic kidney disease stage 3b; elevated creatinine + low GFR with normal BP suggests intrinsic renal disease, not hypertensive
+      - Structural parallel: valid (both are schema/format inconsistency problems; external system produces unpredictable output; defensive handling needed)
+    tags: [debugging, coding, medicine, pattern-matching, multi-domain]
 
   - id: moe-005
-    prompt: "Write a SQL query to find the top 3 customers by revenue from an orders table (customer_id, amount, date). Then explain what index would speed it up."
-    criteria: "Correct SQL with GROUP BY, SUM, ORDER BY DESC, LIMIT 3. Reasonable index suggestion (customer_id or composite)."
-    tags: [coding, sql, performance]
+    prompt: |
+      Design a minimal but complete content moderation system for a social platform. Cover:
+      - The ML pipeline (what models, what features, what training signal)
+      - The legal/policy layer (GDPR, CSAM, jurisdiction conflicts)
+      - The human review queue design (prioritization, appeals, reviewer burnout)
+      - One adversarial attack on this system and how to defend it
+      
+      Be concrete. No generic "use machine learning" answers.
+    criteria: |
+      - ML: specific model types (text classifier, image hash, embedding similarity), training signal (human labels + user reports), threshold calibration
+      - Legal: mentions hash-matching for CSAM (PhotoDNA or equivalent), GDPR right to explanation, jurisdiction conflicts for political speech
+      - Human review: prioritization by severity/velocity, appeals chain, rotation to prevent burnout
+      - Adversarial: specific attack (adversarial text, pixel perturbation, ban evasion via paraphrase) with concrete defense
+    tags: [ml, policy, systems-design, security, multi-domain]
+
+  - id: moe-006
+    prompt: |
+      Three rapid-fire expert questions. Answer all three with full precision:
+      
+      1. (Cardiology) What is the mechanism by which ACE inhibitors reduce cardiac remodeling after MI?
+      2. (Compiler theory) What is the halting problem and why does it make general static analysis impossible?
+      3. (Options trading) What does a negative vega position mean and when would you want one?
+    criteria: |
+      - ACE inhibitors: blocks angiotensin II, reduces aldosterone, lowers preload/afterload, prevents fibrosis via RAAS inhibition
+      - Halting problem: undecidable by Turing's proof; no algorithm can determine for all programs whether they terminate; implies static analysis must be conservative or incomplete
+      - Negative vega: short volatility exposure; profits when implied vol decreases; desired when you expect volatility to compress (e.g., post-earnings, range-bound markets)
+    tags: [medicine, cs-theory, finance, breadth, simultaneous-expertise]

--- a/src/cli/commands/models.ts
+++ b/src/cli/commands/models.ts
@@ -77,16 +77,52 @@ export async function discoverCommand(): Promise<void> {
   // MLX
   const mlxPort = Number(process.env['MLX_PORT']) || 8080
   const mlxRunning = await isMLXRunning(mlxPort)
+  let foundMoE = false
+
   if (mlxRunning) {
     const models = await discoverMLX([mlxPort])
     console.log(chalk.green(`  MLX           localhost:${mlxPort}      running (Apple Silicon)`))
     for (const m of models) {
       const moeTag = m.is_moe ? chalk.cyan(' [MoE]') : ''
       console.log(`    ${m.model.padEnd(50)}${moeTag}`)
+      if (m.is_moe) foundMoE = true
+    }
+    if (models.length > 0) {
+      console.log()
+      console.log(chalk.dim('  Add to verdict.yaml:'))
+      for (const m of models.slice(0, 2)) {
+        const concurrency = m.is_moe ? 1 : 2
+        const timeout = m.is_moe ? 180000 : 60000
+        const moeComment = m.is_moe ? '  # MoE: use concurrency:1, long timeout' : ''
+        console.log(chalk.dim(`    - id: ${m.id}${moeComment}`))
+        console.log(chalk.dim(`      provider: mlx`))
+        console.log(chalk.dim(`      model: ${m.model}`))
+        console.log(chalk.dim(`      tags: [${m.tags.join(', ')}]`))
+        if (m.is_moe) {
+          console.log(chalk.dim(`      timeout_ms: ${timeout}  # MoE models are slow — give them time`))
+          console.log(chalk.dim(`  # In run config: concurrency: ${concurrency}  # avoid memory pressure`))
+        }
+      }
     }
   } else {
     console.log(chalk.dim(`  MLX           localhost:${mlxPort}      not running`))
     console.log(chalk.dim('    Start: mlx_lm.server --model mlx-community/Llama-3.2-3B-Instruct-4bit'))
+  }
+
+  // Ollama MoE routing hint
+  const ollamaHosts2 = ['localhost:11434']
+  const ollamaRunning2 = await isOllamaRunning(ollamaHosts2[0])
+  if (ollamaRunning2) {
+    const ollamaModels = await discoverOllama(ollamaHosts2)
+    if (ollamaModels.some(m => m.is_moe)) foundMoE = true
+  }
+
+  if (foundMoE) {
+    console.log()
+    console.log(chalk.cyan('  MoE models detected.'))
+    console.log(chalk.dim('  Run the MoE benchmark to see expert-switching advantages vs dense models:'))
+    console.log(chalk.dim('    verdict run --pack moe'))
+    console.log(chalk.dim('  Tip: also run general.yaml on a comparable dense model to see the delta.'))
   }
 
   console.log()

--- a/src/cli/commands/run.ts
+++ b/src/cli/commands/run.ts
@@ -69,6 +69,15 @@ export async function runCommand(opts: RunOptions): Promise<void> {
     return
   }
 
+  // MoE concurrency warning
+  const moeModels = config.models.filter(m => m.tags?.includes('moe'))
+  if (moeModels.length > 0 && config.run.concurrency > 1) {
+    console.log(chalk.yellow(`  ⚠  MoE model(s) detected: ${moeModels.map(m => m.id).join(', ')}`))
+    console.log(chalk.yellow(`     concurrency is ${config.run.concurrency} — MoE models are memory-intensive.`))
+    console.log(chalk.yellow('     Set concurrency: 1 in your config to avoid memory pressure on Apple Silicon.'))
+    console.log()
+  }
+
   const spinner = ora({ prefixText: '  ', text: 'Starting...' }).start()
   let result
   try {


### PR DESCRIPTION
Three fixes for MLX / MoE support:

**1. moe.yaml v2 — actually tests MoE advantages**

The previous pack was 5 generic multi-domain tasks that any capable dense model would score equally on. v2 has 6 cases specifically designed to expose the MoE expert-switching advantage:
- ML theory + neuroscience in one coherent answer
- Distributed systems + SQL + Byzantine fault tolerance + jazz theory simultaneously
- Rust translation + memory safety + immunology analogy
- Debugging code + diagnosing a blood test + finding the structural parallel
- Full content moderation system design (ML + legal + ops + adversarial)
- Rapid expert switching: cardiology + halting problem + options trading in one pass

Run this against a MoE model AND a comparable dense model to see the delta.

**2. `verdict models discover` — MoE-aware config output**

When a MoE model is discovered, the YAML snippet now includes `timeout_ms: 180000` and a comment to set `concurrency: 1`. Also shows a routing hint: "MoE models detected — run `verdict run --pack moe`".

**3. `verdict run` — concurrency warning**

If a model tagged `moe` is in the config and `concurrency > 1`, verdict now warns before the run. MoE models (Mixtral, DeepSeek-R1, Qwen-MoE) running on Apple Silicon with concurrency > 1 causes memory pressure and crashes.

---

`npm run typecheck` passes clean. No breaking changes.