### PR TITLE
feat: vision, tool calling, jsonschema scorer, multi-turn conversations (issues #6 #7 #8 #9)

### DIFF
--- a/SPRINT-CONTRACT-2.md
+++ b/SPRINT-CONTRACT-2.md
@@ -1,0 +1,164 @@
+# Sprint Contract: verdict feature issues #6 #7 #8 #9
+
+**Question:** Can verdict evaluate vision, tool calling, JSON schema compliance, and multi-turn conversations?
+
+---
+
+## Feature #8: jsonschema scorer (simplest — do first)
+
+Add `scorer: jsonschema` + inline `schema:` field to case config.
+
+**Case format:**
+```yaml
+- id: extract-001
+  prompt: "Extract name and price from: 'Blue widget, $12.99'"
+  scorer: jsonschema
+  schema:
+    type: object
+    required: [name, price]
+    properties:
+      name: { type: string }
+      price: { type: number, minimum: 0 }
+  criteria: "Output must match schema"
+```
+
+**Scoring:**
+- All required fields present + correct types: 10/10
+- Each missing required field: -2pts
+- Each field with wrong type: -1pt
+- Valid JSON but zero required fields: 2/10
+- Invalid JSON: 0/10
+
+**Files:**
+- `src/judge/deterministic.ts` — add `scoreJsonSchema(output, schema)` function
+- `src/types/index.ts` — add `schema?: Record<string, unknown>` to EvalCase
+- `isDeterministic()` — add `jsonschema` to the list
+
+No external JSON Schema library needed — implement lightweight field/type checking directly.
+
+---
+
+## Feature #9: Multi-turn conversations
+
+Add optional `turns` array to case config. When present, runner sends the full conversation history and scores the final model response.
+
+**Case format:**
+```yaml
+- id: context-001
+  turns:
+    - role: user
+      content: "My name is Alex and I'm building a SaaS for lawyers."
+    - role: assistant
+      content: "__model__"   # model responds here
+    - role: user
+      content: "What was my name and what am I building?"
+  criteria: "Correctly recalls Alex and SaaS for lawyers"
+  scorer: contains
+  expected: "Alex"
+```
+
+**How it works:**
+- Runner detects `turns` vs `prompt` on a case
+- For `__model__` turns: call the model with conversation history up to that point, inject the response
+- Final user turn is the one that gets scored
+- Use the last assistant response as the scored output
+
+**Files:**
+- `src/types/index.ts` — add `turns?: Array<{role: 'user'|'assistant', content: string}>` to EvalCase
+- `src/providers/compat.ts` — add `callModelMultiTurn(config, messages)` that accepts full message array
+- `src/core/runner.ts` — detect `case.turns`, call multi-turn path, extract final response for scoring
+- Existing scorers (json, exact, contains, llm judge) all work unchanged on the final response
+
+---
+
+## Feature #6: Vision support
+
+Add optional `image` field to case config (local file path or URL). When present, sends as base64 image alongside the text prompt.
+
+**Case format:**
+```yaml
+- id: design-001
+  prompt: "Score this homepage design for conversion effectiveness. What are the top 3 friction points?"
+  image: ./screenshots/homepage-v1.png
+  criteria: "Identifies CTA placement, above-fold clarity, and trust signals"
+```
+
+**How it works:**
+- In `callModel()`: if `case.image` is set, read file (or fetch URL) → base64 encode → send as multipart content:
+  ```json
+  { "role": "user", "content": [
+    { "type": "text", "text": "prompt" },
+    { "type": "image_url", "image_url": { "url": "data:image/png;base64,..." } }
+  ]}
+  ```
+- If model doesn't support vision (no response or API error on vision content): log warning, skip image, retry with text-only
+- `image` path is resolved relative to the eval pack file location
+
+**Files:**
+- `src/types/index.ts` — add `image?: string` to EvalCase; add `imagePath?: string` to resolved case
+- `src/core/config.ts` — resolve image path relative to pack file location at load time
+- `src/providers/compat.ts` — in `callModel()`, check for image, encode, build multipart content array
+- `src/cli/commands/run.ts` — pass pack dir to runner for image resolution
+
+---
+
+## Feature #7: Tool calling eval
+
+Add `tools` array and `scorer: tool_call` to case config. Runner passes tools to model via OpenAI tools API, captures tool_calls from response, scores on name + params.
+
+**Case format:**
+```yaml
+- id: tool-001
+  prompt: "Get the weather in San Francisco"
+  tools:
+    - name: get_weather
+      description: "Get current weather for a city"
+      parameters:
+        type: object
+        required: [city]
+        properties:
+          city: { type: string, description: "City name" }
+  scorer: tool_call
+  expected_tool: get_weather
+  expected_args:
+    city: "San Francisco"
+```
+
+**Scoring (scorer: tool_call):**
+- Correct tool name called: +4pts
+- Each expected arg present + correct: +2pts each (up to 4pts total)
+- Valid tool_calls format: +2pts
+- No tool called at all: 0/10
+- Wrong tool called: 2/10
+
+**Files:**
+- `src/types/index.ts` — add `tools?`, `expected_tool?`, `expected_args?` to EvalCase; new `ToolDef` type
+- `src/providers/compat.ts` — add `callModelWithTools(config, prompt, tools)` — passes tools to API, returns tool_calls array
+- `src/judge/deterministic.ts` — add `scoreToolCall(toolCalls, expectedTool, expectedArgs)` function
+- `src/core/runner.ts` — detect `scorer === 'tool_call'`, call tool path, score deterministically
+- `isDeterministic()` — add `tool_call`
+
+---
+
+## Acceptance criteria
+
+| # | Criterion | Feature |
+|---|-----------|---------|
+| 1 | `scorer: jsonschema` with valid schema passes correct output | #8 |
+| 2 | `scorer: jsonschema` fails when required field missing | #8 |
+| 3 | `scorer: jsonschema` gives partial credit for partial compliance | #8 |
+| 4 | `turns` case runs multi-turn, scores final response | #9 |
+| 5 | `__model__` placeholder is replaced by actual model response | #9 |
+| 6 | Multi-turn works with existing scorers (contains, json, llm) | #9 |
+| 7 | `image` field loads local PNG and sends as base64 | #6 |
+| 8 | Vision case works with Ollama llava / GPT-4o | #6 |
+| 9 | Non-vision model gracefully skips image with warning | #6 |
+| 10 | `tools` case passes tool definitions to model API | #7 |
+| 11 | `scorer: tool_call` scores correct tool + args | #7 |
+| 12 | Wrong tool called = 2/10, no tool called = 0/10 | #7 |
+| 13 | All existing cases still work unchanged | all |
+| 14 | `npm run typecheck` passes clean | all |
+
+## Definition of done
+
+All 14 criteria pass. `npm run typecheck` clean. Changes committed to `feature/issues-6-7-8-9`. No breaking changes.

--- a/src/core/config.ts
+++ b/src/core/config.ts
@@ -62,5 +62,14 @@ export function loadEvalPack(packPath: string, configDir: string): EvalPack {
     const issues = result.error.issues.map(i => `  ${i.path.join('.')}: ${i.message}`).join('\n')
     throw new Error(`Invalid eval pack ${packPath}:\n${issues}`)
   }
+
+  // Resolve image paths relative to pack file directory
+  const packDir = path.dirname(fullPath)
+  for (const evalCase of result.data.cases) {
+    if (evalCase.image && !evalCase.image.startsWith('http://') && !evalCase.image.startsWith('https://')) {
+      evalCase.image = path.resolve(packDir, evalCase.image)
+    }
+  }
+
   return result.data
 }

--- a/src/core/runner.ts
+++ b/src/core/runner.ts
@@ -2,9 +2,9 @@ import fs from 'fs'
 import path from 'path'
 import crypto from 'crypto'
 import type { Config, EvalPack, RunResult, ModelSummary, CaseResult, Checkpoint } from '../types/index.js'
-import { callModel } from '../providers/compat.js'
+import { callModel, callModelMultiTurn, callModelWithTools } from '../providers/compat.js'
 import { judgeResponse } from '../judge/llm.js'
-import { scoreDeterministic, isDeterministic } from '../judge/deterministic.js'
+import { scoreDeterministic, isDeterministic, scoreToolCall } from '../judge/deterministic.js'
 
 export function computeConfigHash(config: Config): string {
   const key = JSON.stringify({ models: config.models.map(m => m.id), judge: config.judge.model, packs: config.packs })
@@ -35,6 +35,41 @@ function saveCheckpoint(outputDir: string, checkpoint: Checkpoint): void {
 function deleteCheckpoint(outputDir: string): void {
   const cpPath = getCheckpointPath(outputDir)
   if (fs.existsSync(cpPath)) fs.unlinkSync(cpPath)
+}
+
+async function runMultiTurn(
+  modelConfig: import('../types/index.js').ModelConfig,
+  turns: Array<{ role: 'user' | 'assistant'; content: string }>
+): Promise<import('../types/index.js').ModelResponse> {
+  const messages: Array<{ role: string; content: string }> = []
+  let lastResponse: import('../types/index.js').ModelResponse | null = null
+
+  for (const turn of turns) {
+    if (turn.role === 'assistant' && turn.content === '__model__') {
+      // Call the model with conversation history so far
+      const resp = await callModelMultiTurn(modelConfig, messages)
+      messages.push({ role: 'assistant', content: resp.text })
+      lastResponse = resp
+    } else {
+      messages.push({ role: turn.role, content: turn.content })
+    }
+  }
+
+  // If the last turn is a user message, we need one final model call
+  const lastTurn = turns[turns.length - 1]
+  if (lastTurn.role === 'user') {
+    const resp = await callModelMultiTurn(modelConfig, messages)
+    lastResponse = resp
+  }
+
+  if (!lastResponse) {
+    return {
+      model_id: modelConfig.id, text: '', input_tokens: 0,
+      output_tokens: 0, latency_ms: 0, error: 'No model response generated in multi-turn',
+    }
+  }
+
+  return lastResponse
 }
 
 export async function runEvals(
@@ -114,7 +149,14 @@ export async function runEvals(
 
     // Run all models concurrently (chunked)
     const jobs = config.models.map(m => async () => {
-      const resp = await callModel(m, evalCase.prompt)
+      let resp
+      if (evalCase.scorer === 'tool_call' && evalCase.tools && evalCase.tools.length > 0) {
+        resp = await callModelWithTools(m, evalCase.prompt, evalCase.tools)
+      } else if (evalCase.turns && evalCase.turns.length > 0) {
+        resp = await runMultiTurn(m, evalCase.turns)
+      } else {
+        resp = await callModel(m, evalCase.prompt, 0, evalCase.image)
+      }
       caseResult.responses[m.id] = resp
       if (resp.cost_usd) summary[m.id].total_cost_usd += resp.cost_usd
       summary[m.id].avg_latency_ms += resp.latency_ms
@@ -137,8 +179,10 @@ export async function runEvals(
       }
       try {
         let score
-        if (usesDeterministic) {
-          score = scoreDeterministic(evalCase.scorer, resp.text, evalCase.expected)!
+        if (evalCase.scorer === 'tool_call') {
+          score = scoreToolCall(resp.tool_calls, evalCase.expected_tool ?? '', evalCase.expected_args)
+        } else if (usesDeterministic) {
+          score = scoreDeterministic(evalCase.scorer, resp.text, evalCase.expected, evalCase.schema)!
         } else {
           score = await judgeResponse(judgeModel, config.judge, evalCase.prompt, evalCase.criteria, resp.text)
         }

--- a/src/judge/deterministic.ts
+++ b/src/judge/deterministic.ts
@@ -1,4 +1,4 @@
-import type { JudgeScore } from '../types/index.js'
+import type { JudgeScore, ToolCallResult } from '../types/index.js'
 
 /**
  * Deterministic scorers that don't require an LLM.
@@ -68,15 +68,129 @@ export function scoreContains(output: string, expected: string): JudgeScore {
   }
 }
 
+export function scoreToolCall(
+  toolCalls: ToolCallResult[] | undefined,
+  expectedTool: string,
+  expectedArgs?: Record<string, unknown>
+): JudgeScore {
+  if (!toolCalls || toolCalls.length === 0) {
+    return {
+      accuracy: 0, completeness: 0, conciseness: 0, total: 0,
+      reasoning: 'No tool calls made.',
+    }
+  }
+
+  // Check if any tool call matches the expected tool
+  const matchingCall = toolCalls.find(tc => tc.name === expectedTool)
+  if (!matchingCall) {
+    return {
+      accuracy: 2, completeness: 2, conciseness: 2, total: 2,
+      reasoning: `Wrong tool called: got '${toolCalls[0].name}', expected '${expectedTool}'.`,
+    }
+  }
+
+  // Correct tool: +4pts
+  let score = 4
+  // Valid format: +2pts
+  score += 2
+
+  // Each expected arg present with correct value: +2pts (cap at 4pts total from args)
+  let argPoints = 0
+  const reasons: string[] = [`Correct tool: ${expectedTool}`]
+  if (expectedArgs) {
+    for (const [key, expectedVal] of Object.entries(expectedArgs)) {
+      if (argPoints >= 4) break
+      const actualVal = matchingCall.arguments[key]
+      if (JSON.stringify(actualVal) === JSON.stringify(expectedVal)) {
+        argPoints += 2
+        reasons.push(`arg '${key}' correct`)
+      } else {
+        reasons.push(`arg '${key}': expected ${JSON.stringify(expectedVal)}, got ${JSON.stringify(actualVal)}`)
+      }
+    }
+  }
+  score += argPoints
+
+  const total = Math.min(score, 10)
+  return {
+    accuracy: total, completeness: total, conciseness: total, total,
+    reasoning: reasons.join('; '),
+  }
+}
+
+export function scoreJsonSchema(output: string, schema: Record<string, unknown>): JudgeScore {
+  const text = output.trim()
+  const stripped = text
+    .replace(/^```(?:json)?\s*/i, '')
+    .replace(/\s*```$/, '')
+    .trim()
+
+  let parsed: Record<string, unknown>
+  try {
+    parsed = JSON.parse(stripped)
+  } catch {
+    return {
+      accuracy: 0, completeness: 0, conciseness: 0, total: 0,
+      reasoning: `Invalid JSON: ${stripped.slice(0, 60)}`,
+    }
+  }
+
+  if (typeof parsed !== 'object' || parsed === null || Array.isArray(parsed)) {
+    return {
+      accuracy: 0, completeness: 0, conciseness: 0, total: 0,
+      reasoning: 'JSON output is not an object.',
+    }
+  }
+
+  let missingRequired = 0
+  let wrongType = 0
+  const reasons: string[] = []
+
+  const required = Array.isArray(schema.required) ? schema.required as string[] : []
+  for (const field of required) {
+    if (!(field in parsed)) {
+      missingRequired++
+      reasons.push(`missing required field: ${field}`)
+    }
+  }
+
+  const properties = (schema.properties ?? {}) as Record<string, Record<string, unknown>>
+  for (const [key, propSchema] of Object.entries(properties)) {
+    if (!(key in parsed)) continue
+    const expectedType = propSchema.type as string | undefined
+    if (!expectedType) continue
+    const value = parsed[key]
+    let actualType: string
+    if (Array.isArray(value)) actualType = 'array'
+    else if (value === null) actualType = 'null'
+    else actualType = typeof value
+    if (actualType !== expectedType) {
+      wrongType++
+      reasons.push(`field '${key}': expected ${expectedType}, got ${actualType}`)
+    }
+  }
+
+  const total = Math.max(0, 10 - (2 * missingRequired) - (1 * wrongType))
+  const reasoning = total === 10
+    ? 'JSON matches schema: all required fields present with correct types.'
+    : `Schema violations: ${reasons.join('; ')}`
+
+  return {
+    accuracy: total, completeness: total, conciseness: total, total,
+    reasoning,
+  }
+}
+
 export function isDeterministic(scorer: string): boolean {
-  return scorer === 'json' || scorer === 'exact' || scorer === 'contains'
+  return scorer === 'json' || scorer === 'exact' || scorer === 'contains' || scorer === 'jsonschema' || scorer === 'tool_call'
 }
 
 export function scoreDeterministic(
-  scorer: string, output: string, expected?: string
+  scorer: string, output: string, expected?: string, schema?: Record<string, unknown>
 ): JudgeScore | null {
   if (scorer === 'json') return scoreJson(output)
   if (scorer === 'exact') return scoreExact(output, expected ?? '')
   if (scorer === 'contains') return scoreContains(output, expected ?? '')
+  if (scorer === 'jsonschema') return scoreJsonSchema(output, schema ?? {})
   return null
 }

--- a/src/providers/compat.ts
+++ b/src/providers/compat.ts
@@ -7,12 +7,46 @@
  */
 
 import OpenAI from 'openai'
-import type { ModelConfig, ModelResponse } from '../types/index.js'
+import fs from 'fs'
+import type { ModelConfig, ModelResponse, ToolDef } from '../types/index.js'
+
+function loadImageAsBase64(imagePath: string): string | null {
+  try {
+    if (imagePath.startsWith('http://') || imagePath.startsWith('https://')) {
+      // URL images are handled synchronously via fetch in the caller
+      return null
+    }
+    const data = fs.readFileSync(imagePath)
+    const ext = imagePath.split('.').pop()?.toLowerCase() ?? 'png'
+    const mime = ext === 'jpg' || ext === 'jpeg' ? 'image/jpeg'
+      : ext === 'gif' ? 'image/gif'
+      : ext === 'webp' ? 'image/webp'
+      : 'image/png'
+    return `data:${mime};base64,${data.toString('base64')}`
+  } catch {
+    return null
+  }
+}
+
+async function loadImageAsBase64Async(imagePath: string): Promise<string | null> {
+  if (imagePath.startsWith('http://') || imagePath.startsWith('https://')) {
+    try {
+      const response = await fetch(imagePath)
+      const buffer = Buffer.from(await response.arrayBuffer())
+      const contentType = response.headers.get('content-type') ?? 'image/png'
+      return `data:${contentType};base64,${buffer.toString('base64')}`
+    } catch {
+      return null
+    }
+  }
+  return loadImageAsBase64(imagePath)
+}
 
 export async function callModel(
   config: ModelConfig,
   prompt: string,
-  attempt = 0
+  attempt = 0,
+  imagePath?: string
 ): Promise<ModelResponse> {
   const baseURL = config.base_url
   if (!baseURL) throw new Error(`Model '${config.id}' has no base_url`)
@@ -30,10 +64,79 @@ export async function callModel(
 
   const start = Date.now()
 
+  // Build message content — with or without vision
+  let messageContent: string | OpenAI.ChatCompletionContentPart[] = prompt
+  if (imagePath) {
+    const dataUrl = await loadImageAsBase64Async(imagePath)
+    if (dataUrl) {
+      messageContent = [
+        { type: 'text' as const, text: prompt },
+        { type: 'image_url' as const, image_url: { url: dataUrl } },
+      ]
+    }
+  }
+
   try {
     const response = await client.chat.completions.create({
       model: config.model,
-      messages: [{ role: 'user', content: prompt }],
+      messages: [{ role: 'user', content: messageContent }],
+      max_tokens: config.max_tokens,
+      temperature: 0.0,
+    })
+
+    const latency_ms = Date.now() - start
+    const text = response.choices[0]?.message?.content ?? ''
+    const input_tokens = response.usage?.prompt_tokens ?? 0
+    const output_tokens = response.usage?.completion_tokens ?? 0
+    const cost_usd = config.cost_per_1m_input && config.cost_per_1m_output
+      ? (input_tokens / 1_000_000) * config.cost_per_1m_input
+        + (output_tokens / 1_000_000) * config.cost_per_1m_output
+      : 0
+
+    return { model_id: config.id, text, input_tokens, output_tokens, latency_ms, cost_usd }
+
+  } catch (err: unknown) {
+    const msg = err instanceof Error ? err.message : String(err)
+    // If vision content failed, retry without image
+    if (imagePath && attempt === 0) {
+      console.warn(`[verdict] Vision not supported by ${config.model}, retrying text-only`)
+      return callModel(config, prompt, attempt + 1)
+    }
+    if (attempt < 2) {
+      await new Promise(r => setTimeout(r, 1000 * (attempt + 1)))
+      return callModel(config, prompt, attempt + 1, imagePath)
+    }
+    return {
+      model_id: config.id, text: '', input_tokens: 0,
+      output_tokens: 0, latency_ms: Date.now() - start, error: msg
+    }
+  }
+}
+
+export async function callModelMultiTurn(
+  config: ModelConfig,
+  messages: Array<{ role: string; content: string }>,
+  attempt = 0
+): Promise<ModelResponse> {
+  const baseURL = config.base_url
+  if (!baseURL) throw new Error(`Model '${config.id}' has no base_url`)
+
+  const client = new OpenAI({
+    baseURL,
+    apiKey: config.api_key === 'none' ? 'no-key-required' : config.api_key,
+    timeout: config.timeout_ms,
+    defaultHeaders: {
+      'HTTP-Referer': 'https://github.com/hnshah/verdict',
+      'X-Title': 'verdict',
+    },
+  })
+
+  const start = Date.now()
+
+  try {
+    const response = await client.chat.completions.create({
+      model: config.model,
+      messages: messages as OpenAI.ChatCompletionMessageParam[],
       max_tokens: config.max_tokens,
       temperature: 0.0,
     })
@@ -53,7 +156,77 @@ export async function callModel(
     const msg = err instanceof Error ? err.message : String(err)
     if (attempt < 2) {
       await new Promise(r => setTimeout(r, 1000 * (attempt + 1)))
-      return callModel(config, prompt, attempt + 1)
+      return callModelMultiTurn(config, messages, attempt + 1)
+    }
+    return {
+      model_id: config.id, text: '', input_tokens: 0,
+      output_tokens: 0, latency_ms: Date.now() - start, error: msg
+    }
+  }
+}
+
+export async function callModelWithTools(
+  config: ModelConfig,
+  prompt: string,
+  tools: ToolDef[],
+  attempt = 0
+): Promise<ModelResponse> {
+  const baseURL = config.base_url
+  if (!baseURL) throw new Error(`Model '${config.id}' has no base_url`)
+
+  const client = new OpenAI({
+    baseURL,
+    apiKey: config.api_key === 'none' ? 'no-key-required' : config.api_key,
+    timeout: config.timeout_ms,
+    defaultHeaders: {
+      'HTTP-Referer': 'https://github.com/hnshah/verdict',
+      'X-Title': 'verdict',
+    },
+  })
+
+  const start = Date.now()
+
+  const openaiTools: OpenAI.ChatCompletionTool[] = tools.map(t => ({
+    type: 'function' as const,
+    function: {
+      name: t.name,
+      description: t.description,
+      parameters: t.parameters as Record<string, unknown>,
+    },
+  }))
+
+  try {
+    const response = await client.chat.completions.create({
+      model: config.model,
+      messages: [{ role: 'user', content: prompt }],
+      tools: openaiTools,
+      tool_choice: 'auto',
+      max_tokens: config.max_tokens,
+      temperature: 0.0,
+    })
+
+    const latency_ms = Date.now() - start
+    const message = response.choices[0]?.message
+    const text = message?.content ?? ''
+    const input_tokens = response.usage?.prompt_tokens ?? 0
+    const output_tokens = response.usage?.completion_tokens ?? 0
+    const cost_usd = config.cost_per_1m_input && config.cost_per_1m_output
+      ? (input_tokens / 1_000_000) * config.cost_per_1m_input
+        + (output_tokens / 1_000_000) * config.cost_per_1m_output
+      : 0
+
+    const tool_calls = message?.tool_calls?.map(tc => ({
+      name: tc.function.name,
+      arguments: JSON.parse(tc.function.arguments) as Record<string, unknown>,
+    }))
+
+    return { model_id: config.id, text, input_tokens, output_tokens, latency_ms, cost_usd, tool_calls }
+
+  } catch (err: unknown) {
+    const msg = err instanceof Error ? err.message : String(err)
+    if (attempt < 2) {
+      await new Promise(r => setTimeout(r, 1000 * (attempt + 1)))
+      return callModelWithTools(config, prompt, tools, attempt + 1)
     }
     return {
       model_id: config.id, text: '', input_tokens: 0,

--- a/src/types/index.ts
+++ b/src/types/index.ts
@@ -53,17 +53,41 @@ export const ConfigSchema = z.object({
 })
 export type Config = z.infer<typeof ConfigSchema>
 
+// ─── Tool definitions ────────────────────────────────────────────────────────
+
+export const ToolDefSchema = z.object({
+  name: z.string(),
+  description: z.string(),
+  parameters: z.record(z.unknown()),
+})
+export type ToolDef = z.infer<typeof ToolDefSchema>
+
+export interface ToolCallResult {
+  name: string
+  arguments: Record<string, unknown>
+}
+
 // ─── Eval packs ──────────────────────────────────────────────────────────────
 
 export const EvalCaseSchema = z.object({
   id: z.string(),
-  prompt: z.string(),
+  prompt: z.string().default(''),
   criteria: z.string(),
   expected: z.string().optional(),
   tags: z.array(z.string()).default([]),
   // scorer: 'llm' uses LLM judge (default), 'json' parses output as JSON (pass/fail),
-  // 'exact' checks exact string match, 'contains' checks substring presence
-  scorer: z.enum(['llm', 'json', 'exact', 'contains']).default('llm'),
+  // 'exact' checks exact string match, 'contains' checks substring presence,
+  // 'jsonschema' validates JSON output against a schema, 'tool_call' scores tool usage
+  scorer: z.enum(['llm', 'json', 'exact', 'contains', 'jsonschema', 'tool_call']).default('llm'),
+  schema: z.record(z.unknown()).optional(),
+  turns: z.array(z.object({
+    role: z.enum(['user', 'assistant']),
+    content: z.string(),
+  })).optional(),
+  image: z.string().optional(),
+  tools: z.array(ToolDefSchema).optional(),
+  expected_tool: z.string().optional(),
+  expected_args: z.record(z.unknown()).optional(),
   judge_type: z.enum(['llm', 'reference', 'keyword']).default('llm'),
   max_tokens: z.number().optional(),
 })
@@ -87,6 +111,7 @@ export interface ModelResponse {
   latency_ms: number
   cost_usd?: number
   error?: string
+  tool_calls?: ToolCallResult[]
 }
 
 export interface JudgeScore {


### PR DESCRIPTION
Implements all four feature requests from production user feedback. 14/14 acceptance criteria pass. No breaking changes.

---

## #8 — jsonschema scorer

New `scorer: jsonschema` + `schema:` field validates output shape, not just JSON.parse.

```yaml
- id: extract-001
  prompt: "Extract name and price from: Blue widget, $12.99"
  scorer: jsonschema
  schema:
    type: object
    required: [name, price]
    properties:
      name: { type: string }
      price: { type: number }
  criteria: "Output must match schema"
```

Scoring: -2pts per missing required field, -1pt per wrong type. Partial credit built in. No external dependencies.

---

## #9 — Multi-turn conversations

New `turns` array on cases. Use `__model__` as placeholder — runner replaces with actual model responses, scores the final output.

```yaml
- id: context-001
  turns:
    - role: user
      content: "My name is Alex, building SaaS for lawyers."
    - role: assistant
      content: "__model__"
    - role: user
      content: "What was my name and what am I building?"
  criteria: "Recalls Alex and SaaS for lawyers"
  scorer: contains
  expected: "Alex"
```

Works with all existing scorers (contains, json, exact, llm judge).

---

## #6 — Vision support

New `image` field accepts local path (relative to pack file) or URL. Encoded as base64, sent as multipart content.

```yaml
- id: design-001
  prompt: "Score this homepage for CRO. Top 3 friction points?"
  image: ./screenshots/homepage-v1.png
  criteria: "Identifies CTA, above-fold, trust signals"
```

Graceful fallback: if model doesn't support vision, logs warning and retries text-only.

---

## #7 — Tool calling eval

New `tools` array + `scorer: tool_call`. Runner passes tool definitions to the OpenAI tools API, captures `tool_calls`, scores on name + args.

```yaml
- id: tool-001
  prompt: "Get weather in San Francisco"
  tools:
    - name: get_weather
      description: "Get weather for a city"
      parameters:
        type: object
        required: [city]
        properties:
          city: { type: string }
  scorer: tool_call
  expected_tool: get_weather
  expected_args:
    city: "San Francisco"
```

Scoring: no tool=0/10, wrong tool=2/10, correct tool+format=6/10, +2pts per correct arg (capped at 10/10).

Closes #6, #7, #8, #9