### PR TITLE
feat: verdict v2 — persistence, history, router, serve + 86 tests

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,14 +1,15 @@
 {
   "name": "verdict",
-  "version": "0.1.0",
+  "version": "0.2.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "verdict",
-      "version": "0.1.0",
+      "version": "0.2.0",
       "license": "MIT",
       "dependencies": {
+        "better-sqlite3": "^12.8.0",
         "chalk": "^5.3.0",
         "commander": "^12.0.0",
         "js-yaml": "^4.1.0",
@@ -20,14 +21,111 @@
         "verdict": "dist/cli/index.js"
       },
       "devDependencies": {
+        "@types/better-sqlite3": "^7.6.13",
         "@types/js-yaml": "^4.0.9",
         "@types/node": "^20.0.0",
+        "@vitest/coverage-v8": "^4.1.1",
         "tsup": "^8.0.0",
         "tsx": "^4.7.0",
-        "typescript": "^5.4.0"
+        "typescript": "^5.4.0",
+        "vitest": "^4.1.1"
       },
       "engines": {
         "node": ">=18"
+      }
+    },
+    "node_modules/@babel/helper-string-parser": {
+      "version": "7.27.1",
+      "resolved": "https://registry.npmjs.org/@babel/helper-string-parser/-/helper-string-parser-7.27.1.tgz",
+      "integrity": "sha512-qMlSxKbpRlAridDExk92nSobyDdpPijUq2DW6oDnUqd0iOGxmQjyqhMIihI9+zv4LPyZdRje2cavWPbCbWm3eA==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=6.9.0"
+      }
+    },
+    "node_modules/@babel/helper-validator-identifier": {
+      "version": "7.28.5",
+      "resolved": "https://registry.npmjs.org/@babel/helper-validator-identifier/-/helper-validator-identifier-7.28.5.tgz",
+      "integrity": "sha512-qSs4ifwzKJSV39ucNjsvc6WVHs6b7S03sOh2OcHF9UHfVPqWWALUsNUVzhSBiItjRZoLHx7nIarVjqKVusUZ1Q==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=6.9.0"
+      }
+    },
+    "node_modules/@babel/parser": {
+      "version": "7.29.2",
+      "resolved": "https://registry.npmjs.org/@babel/parser/-/parser-7.29.2.tgz",
+      "integrity": "sha512-4GgRzy/+fsBa72/RZVJmGKPmZu9Byn8o4MoLpmNe1m8ZfYnz5emHLQz3U4gLud6Zwl0RZIcgiLD7Uq7ySFuDLA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@babel/types": "^7.29.0"
+      },
+      "bin": {
+        "parser": "bin/babel-parser.js"
+      },
+      "engines": {
+        "node": ">=6.0.0"
+      }
+    },
+    "node_modules/@babel/types": {
+      "version": "7.29.0",
+      "resolved": "https://registry.npmjs.org/@babel/types/-/types-7.29.0.tgz",
+      "integrity": "sha512-LwdZHpScM4Qz8Xw2iKSzS+cfglZzJGvofQICy7W7v4caru4EaAmyUuO6BGrbyQ2mYV11W0U8j5mBhd14dd3B0A==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@babel/helper-string-parser": "^7.27.1",
+        "@babel/helper-validator-identifier": "^7.28.5"
+      },
+      "engines": {
+        "node": ">=6.9.0"
+      }
+    },
+    "node_modules/@bcoe/v8-coverage": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/@bcoe/v8-coverage/-/v8-coverage-1.0.2.tgz",
+      "integrity": "sha512-6zABk/ECA/QYSCQ1NGiVwwbQerUCZ+TQbp64Q3AgmfNvurHH0j8TtXa1qbShXA6qqkpAj4V5W8pP6mLe1mcMqA==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@emnapi/core": {
+      "version": "1.9.1",
+      "resolved": "https://registry.npmjs.org/@emnapi/core/-/core-1.9.1.tgz",
+      "integrity": "sha512-mukuNALVsoix/w1BJwFzwXBN/dHeejQtuVzcDsfOEsdpCumXb/E9j8w11h5S54tT1xhifGfbbSm/ICrObRb3KA==",
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "dependencies": {
+        "@emnapi/wasi-threads": "1.2.0",
+        "tslib": "^2.4.0"
+      }
+    },
+    "node_modules/@emnapi/runtime": {
+      "version": "1.9.1",
+      "resolved": "https://registry.npmjs.org/@emnapi/runtime/-/runtime-1.9.1.tgz",
+      "integrity": "sha512-VYi5+ZVLhpgK4hQ0TAjiQiZ6ol0oe4mBx7mVv7IflsiEp0OWoVsp/+f9Vc1hOhE0TtkORVrI1GvzyreqpgWtkA==",
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "dependencies": {
+        "tslib": "^2.4.0"
+      }
+    },
+    "node_modules/@emnapi/wasi-threads": {
+      "version": "1.2.0",
+      "resolved": "https://registry.npmjs.org/@emnapi/wasi-threads/-/wasi-threads-1.2.0.tgz",
+      "integrity": "sha512-N10dEJNSsUx41Z6pZsXU8FjPjpBEplgH24sfkmITrBED1/U2Esum9F3lfLrMjKHHjmi557zQn7kR9R+XWXu5Rg==",
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "dependencies": {
+        "tslib": "^2.4.0"
       }
     },
     "node_modules/@esbuild/aix-ppc64": {
@@ -511,6 +609,295 @@
         "@jridgewell/sourcemap-codec": "^1.4.14"
       }
     },
+    "node_modules/@napi-rs/wasm-runtime": {
+      "version": "1.1.1",
+      "resolved": "https://registry.npmjs.org/@napi-rs/wasm-runtime/-/wasm-runtime-1.1.1.tgz",
+      "integrity": "sha512-p64ah1M1ld8xjWv3qbvFwHiFVWrq1yFvV4f7w+mzaqiR4IlSgkqhcRdHwsGgomwzBH51sRY4NEowLxnaBjcW/A==",
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "dependencies": {
+        "@emnapi/core": "^1.7.1",
+        "@emnapi/runtime": "^1.7.1",
+        "@tybys/wasm-util": "^0.10.1"
+      },
+      "funding": {
+        "type": "github",
+        "url": "https://github.com/sponsors/Brooooooklyn"
+      }
+    },
+    "node_modules/@oxc-project/types": {
+      "version": "0.122.0",
+      "resolved": "https://registry.npmjs.org/@oxc-project/types/-/types-0.122.0.tgz",
+      "integrity": "sha512-oLAl5kBpV4w69UtFZ9xqcmTi+GENWOcPF7FCrczTiBbmC0ibXxCwyvZGbO39rCVEuLGAZM84DH0pUIyyv/YJzA==",
+      "dev": true,
+      "license": "MIT",
+      "funding": {
+        "url": "https://github.com/sponsors/Boshen"
+      }
+    },
+    "node_modules/@rolldown/binding-android-arm64": {
+      "version": "1.0.0-rc.11",
+      "resolved": "https://registry.npmjs.org/@rolldown/binding-android-arm64/-/binding-android-arm64-1.0.0-rc.11.tgz",
+      "integrity": "sha512-SJ+/g+xNnOh6NqYxD0V3uVN4W3VfnrGsC9/hoglicgTNfABFG9JjISvkkU0dNY84MNHLWyOgxP9v9Y9pX4S7+A==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "android"
+      ],
+      "engines": {
+        "node": "^20.19.0 || >=22.12.0"
+      }
+    },
+    "node_modules/@rolldown/binding-darwin-arm64": {
+      "version": "1.0.0-rc.11",
+      "resolved": "https://registry.npmjs.org/@rolldown/binding-darwin-arm64/-/binding-darwin-arm64-1.0.0-rc.11.tgz",
+      "integrity": "sha512-7WQgR8SfOPwmDZGFkThUvsmd/nwAWv91oCO4I5LS7RKrssPZmOt7jONN0cW17ydGC1n/+puol1IpoieKqQidmg==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "darwin"
+      ],
+      "engines": {
+        "node": "^20.19.0 || >=22.12.0"
+      }
+    },
+    "node_modules/@rolldown/binding-darwin-x64": {
+      "version": "1.0.0-rc.11",
+      "resolved": "https://registry.npmjs.org/@rolldown/binding-darwin-x64/-/binding-darwin-x64-1.0.0-rc.11.tgz",
+      "integrity": "sha512-39Ks6UvIHq4rEogIfQBoBRusj0Q0nPVWIvqmwBLaT6aqQGIakHdESBVOPRRLacy4WwUPIx4ZKzfZ9PMW+IeyUQ==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "darwin"
+      ],
+      "engines": {
+        "node": "^20.19.0 || >=22.12.0"
+      }
+    },
+    "node_modules/@rolldown/binding-freebsd-x64": {
+      "version": "1.0.0-rc.11",
+      "resolved": "https://registry.npmjs.org/@rolldown/binding-freebsd-x64/-/binding-freebsd-x64-1.0.0-rc.11.tgz",
+      "integrity": "sha512-jfsm0ZHfhiqrvWjJAmzsqiIFPz5e7mAoCOPBNTcNgkiid/LaFKiq92+0ojH+nmJmKYkre4t71BWXUZDNp7vsag==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "freebsd"
+      ],
+      "engines": {
+        "node": "^20.19.0 || >=22.12.0"
+      }
+    },
+    "node_modules/@rolldown/binding-linux-arm-gnueabihf": {
+      "version": "1.0.0-rc.11",
+      "resolved": "https://registry.npmjs.org/@rolldown/binding-linux-arm-gnueabihf/-/binding-linux-arm-gnueabihf-1.0.0-rc.11.tgz",
+      "integrity": "sha512-zjQaUtSyq1nVe3nxmlSCuR96T1LPlpvmJ0SZy0WJFEsV4kFbXcq2u68L4E6O0XeFj4aex9bEauqjW8UQBeAvfQ==",
+      "cpu": [
+        "arm"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": "^20.19.0 || >=22.12.0"
+      }
+    },
+    "node_modules/@rolldown/binding-linux-arm64-gnu": {
+      "version": "1.0.0-rc.11",
+      "resolved": "https://registry.npmjs.org/@rolldown/binding-linux-arm64-gnu/-/binding-linux-arm64-gnu-1.0.0-rc.11.tgz",
+      "integrity": "sha512-WMW1yE6IOnehTcFE9eipFkm3XN63zypWlrJQ2iF7NrQ9b2LDRjumFoOGJE8RJJTJCTBAdmLMnJ8uVitACUUo1Q==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": "^20.19.0 || >=22.12.0"
+      }
+    },
+    "node_modules/@rolldown/binding-linux-arm64-musl": {
+      "version": "1.0.0-rc.11",
+      "resolved": "https://registry.npmjs.org/@rolldown/binding-linux-arm64-musl/-/binding-linux-arm64-musl-1.0.0-rc.11.tgz",
+      "integrity": "sha512-jfndI9tsfm4APzjNt6QdBkYwre5lRPUgHeDHoI7ydKUuJvz3lZeCfMsI56BZj+7BYqiKsJm7cfd/6KYV7ubrBg==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": "^20.19.0 || >=22.12.0"
+      }
+    },
+    "node_modules/@rolldown/binding-linux-ppc64-gnu": {
+      "version": "1.0.0-rc.11",
+      "resolved": "https://registry.npmjs.org/@rolldown/binding-linux-ppc64-gnu/-/binding-linux-ppc64-gnu-1.0.0-rc.11.tgz",
+      "integrity": "sha512-ZlFgw46NOAGMgcdvdYwAGu2Q+SLFA9LzbJLW+iyMOJyhj5wk6P3KEE9Gct4xWwSzFoPI7JCdYmYMzVtlgQ+zfw==",
+      "cpu": [
+        "ppc64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": "^20.19.0 || >=22.12.0"
+      }
+    },
+    "node_modules/@rolldown/binding-linux-s390x-gnu": {
+      "version": "1.0.0-rc.11",
+      "resolved": "https://registry.npmjs.org/@rolldown/binding-linux-s390x-gnu/-/binding-linux-s390x-gnu-1.0.0-rc.11.tgz",
+      "integrity": "sha512-hIOYmuT6ofM4K04XAZd3OzMySEO4K0/nc9+jmNcxNAxRi6c5UWpqfw3KMFV4MVFWL+jQsSh+bGw2VqmaPMTLyw==",
+      "cpu": [
+        "s390x"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": "^20.19.0 || >=22.12.0"
+      }
+    },
+    "node_modules/@rolldown/binding-linux-x64-gnu": {
+      "version": "1.0.0-rc.11",
+      "resolved": "https://registry.npmjs.org/@rolldown/binding-linux-x64-gnu/-/binding-linux-x64-gnu-1.0.0-rc.11.tgz",
+      "integrity": "sha512-qXBQQO9OvkjjQPLdUVr7Nr2t3QTZI7s4KZtfw7HzBgjbmAPSFwSv4rmET9lLSgq3rH/ndA3ngv3Qb8l2njoPNA==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": "^20.19.0 || >=22.12.0"
+      }
+    },
+    "node_modules/@rolldown/binding-linux-x64-musl": {
+      "version": "1.0.0-rc.11",
+      "resolved": "https://registry.npmjs.org/@rolldown/binding-linux-x64-musl/-/binding-linux-x64-musl-1.0.0-rc.11.tgz",
+      "integrity": "sha512-/tpFfoSTzUkH9LPY+cYbqZBDyyX62w5fICq9qzsHLL8uTI6BHip3Q9Uzft0wylk/i8OOwKik8OxW+QAhDmzwmg==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": "^20.19.0 || >=22.12.0"
+      }
+    },
+    "node_modules/@rolldown/binding-openharmony-arm64": {
+      "version": "1.0.0-rc.11",
+      "resolved": "https://registry.npmjs.org/@rolldown/binding-openharmony-arm64/-/binding-openharmony-arm64-1.0.0-rc.11.tgz",
+      "integrity": "sha512-mcp3Rio2w72IvdZG0oQ4bM2c2oumtwHfUfKncUM6zGgz0KgPz4YmDPQfnXEiY5t3+KD/i8HG2rOB/LxdmieK2g==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "openharmony"
+      ],
+      "engines": {
+        "node": "^20.19.0 || >=22.12.0"
+      }
+    },
+    "node_modules/@rolldown/binding-wasm32-wasi": {
+      "version": "1.0.0-rc.11",
+      "resolved": "https://registry.npmjs.org/@rolldown/binding-wasm32-wasi/-/binding-wasm32-wasi-1.0.0-rc.11.tgz",
+      "integrity": "sha512-LXk5Hii1Ph9asuGRjBuz8TUxdc1lWzB7nyfdoRgI0WGPZKmCxvlKk8KfYysqtr4MfGElu/f/pEQRh8fcEgkrWw==",
+      "cpu": [
+        "wasm32"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "dependencies": {
+        "@napi-rs/wasm-runtime": "^1.1.1"
+      },
+      "engines": {
+        "node": ">=14.0.0"
+      }
+    },
+    "node_modules/@rolldown/binding-win32-arm64-msvc": {
+      "version": "1.0.0-rc.11",
+      "resolved": "https://registry.npmjs.org/@rolldown/binding-win32-arm64-msvc/-/binding-win32-arm64-msvc-1.0.0-rc.11.tgz",
+      "integrity": "sha512-dDwf5otnx0XgRY1yqxOC4ITizcdzS/8cQ3goOWv3jFAo4F+xQYni+hnMuO6+LssHHdJW7+OCVL3CoU4ycnh35Q==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "win32"
+      ],
+      "engines": {
+        "node": "^20.19.0 || >=22.12.0"
+      }
+    },
+    "node_modules/@rolldown/binding-win32-x64-msvc": {
+      "version": "1.0.0-rc.11",
+      "resolved": "https://registry.npmjs.org/@rolldown/binding-win32-x64-msvc/-/binding-win32-x64-msvc-1.0.0-rc.11.tgz",
+      "integrity": "sha512-LN4/skhSggybX71ews7dAj6r2geaMJfm3kMbK2KhFMg9B10AZXnKoLCVVgzhMHL0S+aKtr4p8QbAW8k+w95bAA==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "win32"
+      ],
+      "engines": {
+        "node": "^20.19.0 || >=22.12.0"
+      }
+    },
+    "node_modules/@rolldown/pluginutils": {
+      "version": "1.0.0-rc.11",
+      "resolved": "https://registry.npmjs.org/@rolldown/pluginutils/-/pluginutils-1.0.0-rc.11.tgz",
+      "integrity": "sha512-xQO9vbwBecJRv9EUcQ/y0dzSTJgA7Q6UVN7xp6B81+tBGSLVAK03yJ9NkJaUA7JFD91kbjxRSC/mDnmvXzbHoQ==",
+      "dev": true,
+      "license": "MIT"
+    },
     "node_modules/@rollup/rollup-android-arm-eabi": {
       "version": "4.60.0",
       "resolved": "https://registry.npmjs.org/@rollup/rollup-android-arm-eabi/-/rollup-android-arm-eabi-4.60.0.tgz",
@@ -861,6 +1248,52 @@
         "win32"
       ]
     },
+    "node_modules/@standard-schema/spec": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/@standard-schema/spec/-/spec-1.1.0.tgz",
+      "integrity": "sha512-l2aFy5jALhniG5HgqrD6jXLi/rUWrKvqN/qJx6yoJsgKhblVd+iqqU4RCXavm/jPityDo5TCvKMnpjKnOriy0w==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/@tybys/wasm-util": {
+      "version": "0.10.1",
+      "resolved": "https://registry.npmjs.org/@tybys/wasm-util/-/wasm-util-0.10.1.tgz",
+      "integrity": "sha512-9tTaPJLSiejZKx+Bmog4uSubteqTvFrVrURwkmHixBo0G4seD0zUxp98E1DzUBJxLQ3NPwXrGKDiVjwx/DpPsg==",
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "dependencies": {
+        "tslib": "^2.4.0"
+      }
+    },
+    "node_modules/@types/better-sqlite3": {
+      "version": "7.6.13",
+      "resolved": "https://registry.npmjs.org/@types/better-sqlite3/-/better-sqlite3-7.6.13.tgz",
+      "integrity": "sha512-NMv9ASNARoKksWtsq/SHakpYAYnhBrQgGD8zkLYk/jaK8jUGn08CfEdTRgYhMypUQAfzSP8W6gNLe0q19/t4VA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@types/node": "*"
+      }
+    },
+    "node_modules/@types/chai": {
+      "version": "5.2.3",
+      "resolved": "https://registry.npmjs.org/@types/chai/-/chai-5.2.3.tgz",
+      "integrity": "sha512-Mw558oeA9fFbv65/y4mHtXDs9bPnFMZAL/jxdPFUpOHHIXX91mcgEHbS5Lahr+pwZFR8A7GQleRWeI6cGFC2UA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@types/deep-eql": "*",
+        "assertion-error": "^2.0.1"
+      }
+    },
+    "node_modules/@types/deep-eql": {
+      "version": "4.0.2",
+      "resolved": "https://registry.npmjs.org/@types/deep-eql/-/deep-eql-4.0.2.tgz",
+      "integrity": "sha512-c9h9dVVMigMPc4bwTvC5dxqtqJZwQPePsWjPlpSOnojbor6pGqdk541lfA7AqFQr5pB1BRdq0juY9db81BwyFw==",
+      "dev": true,
+      "license": "MIT"
+    },
     "node_modules/@types/estree": {
       "version": "1.0.8",
       "resolved": "https://registry.npmjs.org/@types/estree/-/estree-1.0.8.tgz",
@@ -892,6 +1325,150 @@
       "dependencies": {
         "@types/node": "*",
         "form-data": "^4.0.4"
+      }
+    },
+    "node_modules/@vitest/coverage-v8": {
+      "version": "4.1.1",
+      "resolved": "https://registry.npmjs.org/@vitest/coverage-v8/-/coverage-v8-4.1.1.tgz",
+      "integrity": "sha512-nZ4RWwGCoGOQRMmU/Q9wlUY540RVRxJZ9lxFsFfy0QV7Zmo5VVBhB6Sl9Xa0KIp2iIs3zWfPlo9LcY1iqbpzCw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@bcoe/v8-coverage": "^1.0.2",
+        "@vitest/utils": "4.1.1",
+        "ast-v8-to-istanbul": "^1.0.0",
+        "istanbul-lib-coverage": "^3.2.2",
+        "istanbul-lib-report": "^3.0.1",
+        "istanbul-reports": "^3.2.0",
+        "magicast": "^0.5.2",
+        "obug": "^2.1.1",
+        "std-env": "^4.0.0-rc.1",
+        "tinyrainbow": "^3.0.3"
+      },
+      "funding": {
+        "url": "https://opencollective.com/vitest"
+      },
+      "peerDependencies": {
+        "@vitest/browser": "4.1.1",
+        "vitest": "4.1.1"
+      },
+      "peerDependenciesMeta": {
+        "@vitest/browser": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@vitest/expect": {
+      "version": "4.1.1",
+      "resolved": "https://registry.npmjs.org/@vitest/expect/-/expect-4.1.1.tgz",
+      "integrity": "sha512-xAV0fqBTk44Rn6SjJReEQkHP3RrqbJo6JQ4zZ7/uVOiJZRarBtblzrOfFIZeYUrukp2YD6snZG6IBqhOoHTm+A==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@standard-schema/spec": "^1.1.0",
+        "@types/chai": "^5.2.2",
+        "@vitest/spy": "4.1.1",
+        "@vitest/utils": "4.1.1",
+        "chai": "^6.2.2",
+        "tinyrainbow": "^3.0.3"
+      },
+      "funding": {
+        "url": "https://opencollective.com/vitest"
+      }
+    },
+    "node_modules/@vitest/mocker": {
+      "version": "4.1.1",
+      "resolved": "https://registry.npmjs.org/@vitest/mocker/-/mocker-4.1.1.tgz",
+      "integrity": "sha512-h3BOylsfsCLPeceuCPAAJ+BvNwSENgJa4hXoXu4im0bs9Lyp4URc4JYK4pWLZ4pG/UQn7AT92K6IByi6rE6g3A==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@vitest/spy": "4.1.1",
+        "estree-walker": "^3.0.3",
+        "magic-string": "^0.30.21"
+      },
+      "funding": {
+        "url": "https://opencollective.com/vitest"
+      },
+      "peerDependencies": {
+        "msw": "^2.4.9",
+        "vite": "^6.0.0 || ^7.0.0 || ^8.0.0"
+      },
+      "peerDependenciesMeta": {
+        "msw": {
+          "optional": true
+        },
+        "vite": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@vitest/pretty-format": {
+      "version": "4.1.1",
+      "resolved": "https://registry.npmjs.org/@vitest/pretty-format/-/pretty-format-4.1.1.tgz",
+      "integrity": "sha512-GM+TEQN5WhOygr1lp7skeVjdLPqqWMHsfzXrcHAqZJi/lIVh63H0kaRCY8MDhNWikx19zBUK8ceaLB7X5AH9NQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "tinyrainbow": "^3.0.3"
+      },
+      "funding": {
+        "url": "https://opencollective.com/vitest"
+      }
+    },
+    "node_modules/@vitest/runner": {
+      "version": "4.1.1",
+      "resolved": "https://registry.npmjs.org/@vitest/runner/-/runner-4.1.1.tgz",
+      "integrity": "sha512-f7+FPy75vN91QGWsITueq0gedwUZy1fLtHOCMeQpjs8jTekAHeKP80zfDEnhrleviLHzVSDXIWuCIOFn3D3f8A==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@vitest/utils": "4.1.1",
+        "pathe": "^2.0.3"
+      },
+      "funding": {
+        "url": "https://opencollective.com/vitest"
+      }
+    },
+    "node_modules/@vitest/snapshot": {
+      "version": "4.1.1",
+      "resolved": "https://registry.npmjs.org/@vitest/snapshot/-/snapshot-4.1.1.tgz",
+      "integrity": "sha512-kMVSgcegWV2FibXEx9p9WIKgje58lcTbXgnJixfcg15iK8nzCXhmalL0ZLtTWLW9PH1+1NEDShiFFedB3tEgWg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@vitest/pretty-format": "4.1.1",
+        "@vitest/utils": "4.1.1",
+        "magic-string": "^0.30.21",
+        "pathe": "^2.0.3"
+      },
+      "funding": {
+        "url": "https://opencollective.com/vitest"
+      }
+    },
+    "node_modules/@vitest/spy": {
+      "version": "4.1.1",
+      "resolved": "https://registry.npmjs.org/@vitest/spy/-/spy-4.1.1.tgz",
+      "integrity": "sha512-6Ti/KT5OVaiupdIZEuZN7l3CZcR0cxnxt70Z0//3CtwgObwA6jZhmVBA3yrXSVN3gmwjgd7oDNLlsXz526gpRA==",
+      "dev": true,
+      "license": "MIT",
+      "funding": {
+        "url": "https://opencollective.com/vitest"
+      }
+    },
+    "node_modules/@vitest/utils": {
+      "version": "4.1.1",
+      "resolved": "https://registry.npmjs.org/@vitest/utils/-/utils-4.1.1.tgz",
+      "integrity": "sha512-cNxAlaB3sHoCdL6pj6yyUXv9Gry1NHNg0kFTXdvSIZXLHsqKH7chiWOkwJ5s5+d/oMwcoG9T0bKU38JZWKusrQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@vitest/pretty-format": "4.1.1",
+        "convert-source-map": "^2.0.0",
+        "tinyrainbow": "^3.0.3"
+      },
+      "funding": {
+        "url": "https://opencollective.com/vitest"
       }
     },
     "node_modules/abort-controller": {
@@ -956,11 +1533,111 @@
       "integrity": "sha512-8+9WqebbFzpX9OR+Wa6O29asIogeRMzcGtAINdpMHHyAg10f05aSFVBbcEqGf/PXw1EjAZ+q2/bEBg3DvurK3Q==",
       "license": "Python-2.0"
     },
+    "node_modules/assertion-error": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/assertion-error/-/assertion-error-2.0.1.tgz",
+      "integrity": "sha512-Izi8RQcffqCeNVgFigKli1ssklIbpHnCYc6AknXGYoB6grJqyeby7jv12JUQgmTAnIDnbck1uxksT4dzN3PWBA==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/ast-v8-to-istanbul": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/ast-v8-to-istanbul/-/ast-v8-to-istanbul-1.0.0.tgz",
+      "integrity": "sha512-1fSfIwuDICFA4LKkCzRPO7F0hzFf0B7+Xqrl27ynQaa+Rh0e1Es0v6kWHPott3lU10AyAr7oKHa65OppjLn3Rg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@jridgewell/trace-mapping": "^0.3.31",
+        "estree-walker": "^3.0.3",
+        "js-tokens": "^10.0.0"
+      }
+    },
     "node_modules/asynckit": {
       "version": "0.4.0",
       "resolved": "https://registry.npmjs.org/asynckit/-/asynckit-0.4.0.tgz",
       "integrity": "sha512-Oei9OH4tRh0YqU3GxhX79dM/mwVgvbZJaSNaRk+bshkj0S5cfHcgYakreBjrHwatXKbz+IoIdYLxrKim2MjW0Q==",
       "license": "MIT"
+    },
+    "node_modules/base64-js": {
+      "version": "1.5.1",
+      "resolved": "https://registry.npmjs.org/base64-js/-/base64-js-1.5.1.tgz",
+      "integrity": "sha512-AKpaYlHn8t4SVbOHCy+b5+KKgvR4vrsD8vbvrbiQJps7fKDTkjkDry6ji0rUJjC0kzbNePLwzxq8iypo41qeWA==",
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/feross"
+        },
+        {
+          "type": "patreon",
+          "url": "https://www.patreon.com/feross"
+        },
+        {
+          "type": "consulting",
+          "url": "https://feross.org/support"
+        }
+      ],
+      "license": "MIT"
+    },
+    "node_modules/better-sqlite3": {
+      "version": "12.8.0",
+      "resolved": "https://registry.npmjs.org/better-sqlite3/-/better-sqlite3-12.8.0.tgz",
+      "integrity": "sha512-RxD2Vd96sQDjQr20kdP+F+dK/1OUNiVOl200vKBZY8u0vTwysfolF6Hq+3ZK2+h8My9YvZhHsF+RSGZW2VYrPQ==",
+      "hasInstallScript": true,
+      "license": "MIT",
+      "dependencies": {
+        "bindings": "^1.5.0",
+        "prebuild-install": "^7.1.1"
+      },
+      "engines": {
+        "node": "20.x || 22.x || 23.x || 24.x || 25.x"
+      }
+    },
+    "node_modules/bindings": {
+      "version": "1.5.0",
+      "resolved": "https://registry.npmjs.org/bindings/-/bindings-1.5.0.tgz",
+      "integrity": "sha512-p2q/t/mhvuOj/UeLlV6566GD/guowlr0hHxClI0W9m7MWYkL1F0hLo+0Aexs9HSPCtR1SXQ0TD3MMKrXZajbiQ==",
+      "license": "MIT",
+      "dependencies": {
+        "file-uri-to-path": "1.0.0"
+      }
+    },
+    "node_modules/bl": {
+      "version": "4.1.0",
+      "resolved": "https://registry.npmjs.org/bl/-/bl-4.1.0.tgz",
+      "integrity": "sha512-1W07cM9gS6DcLperZfFSj+bWLtaPGSOHWhPiGzXmvVJbRLdG82sH/Kn8EtW1VqWVA54AKf2h5k5BbnIbwF3h6w==",
+      "license": "MIT",
+      "dependencies": {
+        "buffer": "^5.5.0",
+        "inherits": "^2.0.4",
+        "readable-stream": "^3.4.0"
+      }
+    },
+    "node_modules/buffer": {
+      "version": "5.7.1",
+      "resolved": "https://registry.npmjs.org/buffer/-/buffer-5.7.1.tgz",
+      "integrity": "sha512-EHcyIPBQ4BSGlvjB16k5KgAJ27CIsHY/2JBmCRReo48y9rQ3MaUzWX3KVlBa4U7MyX02HdVj0K7C3WaB3ju7FQ==",
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/feross"
+        },
+        {
+          "type": "patreon",
+          "url": "https://www.patreon.com/feross"
+        },
+        {
+          "type": "consulting",
+          "url": "https://feross.org/support"
+        }
+      ],
+      "license": "MIT",
+      "dependencies": {
+        "base64-js": "^1.3.1",
+        "ieee754": "^1.1.13"
+      }
     },
     "node_modules/bundle-require": {
       "version": "5.1.0",
@@ -1001,6 +1678,16 @@
         "node": ">= 0.4"
       }
     },
+    "node_modules/chai": {
+      "version": "6.2.2",
+      "resolved": "https://registry.npmjs.org/chai/-/chai-6.2.2.tgz",
+      "integrity": "sha512-NUPRluOfOiTKBKvWPtSD4PhFvWCqOi0BGStNWs57X9js7XGTprSmFoz5F0tWhR4WPjNeR9jXqdC7/UpSJTnlRg==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=18"
+      }
+    },
     "node_modules/chalk": {
       "version": "5.6.2",
       "resolved": "https://registry.npmjs.org/chalk/-/chalk-5.6.2.tgz",
@@ -1028,6 +1715,12 @@
       "funding": {
         "url": "https://paulmillr.com/funding/"
       }
+    },
+    "node_modules/chownr": {
+      "version": "1.1.4",
+      "resolved": "https://registry.npmjs.org/chownr/-/chownr-1.1.4.tgz",
+      "integrity": "sha512-jJ0bqzaylmJtVnNgzTeSOs8DPavpbYgEr/b0YL8/2GO3xJEhInFmhKMUnEJQjZumK7KXGFhUy89PrsJWlakBVg==",
+      "license": "ISC"
     },
     "node_modules/cli-cursor": {
       "version": "5.0.0",
@@ -1094,6 +1787,13 @@
         "node": "^14.18.0 || >=16.10.0"
       }
     },
+    "node_modules/convert-source-map": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/convert-source-map/-/convert-source-map-2.0.0.tgz",
+      "integrity": "sha512-Kvp459HrV2FEJ1CAsi1Ku+MY3kasH19TFykTz2xWmMeq6bk2NU3XXvfJ+Q61m0xktWwt+1HSYf3JZsTms3aRJg==",
+      "dev": true,
+      "license": "MIT"
+    },
     "node_modules/debug": {
       "version": "4.4.3",
       "resolved": "https://registry.npmjs.org/debug/-/debug-4.4.3.tgz",
@@ -1112,6 +1812,30 @@
         }
       }
     },
+    "node_modules/decompress-response": {
+      "version": "6.0.0",
+      "resolved": "https://registry.npmjs.org/decompress-response/-/decompress-response-6.0.0.tgz",
+      "integrity": "sha512-aW35yZM6Bb/4oJlZncMH2LCoZtJXTRxES17vE3hoRiowU2kWHaJKFkSBDnDR+cm9J+9QhXmREyIfv0pji9ejCQ==",
+      "license": "MIT",
+      "dependencies": {
+        "mimic-response": "^3.1.0"
+      },
+      "engines": {
+        "node": ">=10"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/deep-extend": {
+      "version": "0.6.0",
+      "resolved": "https://registry.npmjs.org/deep-extend/-/deep-extend-0.6.0.tgz",
+      "integrity": "sha512-LOHxIOaPYdHlJRtCQfDIVZtfw/ufM8+rVj649RIHzcm/vGwQRXFt6OPqIFWsm2XEMrNIEtWR64sY1LEKD2vAOA==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=4.0.0"
+      }
+    },
     "node_modules/delayed-stream": {
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/delayed-stream/-/delayed-stream-1.0.0.tgz",
@@ -1119,6 +1843,15 @@
       "license": "MIT",
       "engines": {
         "node": ">=0.4.0"
+      }
+    },
+    "node_modules/detect-libc": {
+      "version": "2.1.2",
+      "resolved": "https://registry.npmjs.org/detect-libc/-/detect-libc-2.1.2.tgz",
+      "integrity": "sha512-Btj2BOOO83o3WyH59e8MgXsxEQVcarkUOpEYrubB0urwnN10yQ364rsiByU11nZlqWYZm05i/of7io4mzihBtQ==",
+      "license": "Apache-2.0",
+      "engines": {
+        "node": ">=8"
       }
     },
     "node_modules/dunder-proto": {
@@ -1141,6 +1874,15 @@
       "integrity": "sha512-toUI84YS5YmxW219erniWD0CIVOo46xGKColeNQRgOzDorgBi1v4D71/OFzgD9GO2UGKIv1C3Sp8DAn0+j5w7A==",
       "license": "MIT"
     },
+    "node_modules/end-of-stream": {
+      "version": "1.4.5",
+      "resolved": "https://registry.npmjs.org/end-of-stream/-/end-of-stream-1.4.5.tgz",
+      "integrity": "sha512-ooEGc6HP26xXq/N+GCGOT0JKCLDGrq2bQUZrQ7gyrJiZANJ/8YDTxTpQBXGMn+WbIQXNVpyWymm7KYVICQnyOg==",
+      "license": "MIT",
+      "dependencies": {
+        "once": "^1.4.0"
+      }
+    },
     "node_modules/es-define-property": {
       "version": "1.0.1",
       "resolved": "https://registry.npmjs.org/es-define-property/-/es-define-property-1.0.1.tgz",
@@ -1158,6 +1900,13 @@
       "engines": {
         "node": ">= 0.4"
       }
+    },
+    "node_modules/es-module-lexer": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/es-module-lexer/-/es-module-lexer-2.0.0.tgz",
+      "integrity": "sha512-5POEcUuZybH7IdmGsD8wlf0AI55wMecM9rVBTI/qEAy2c1kTOm3DjFYjrBdI2K3BaJjJYfYFeRtM0t9ssnRuxw==",
+      "dev": true,
+      "license": "MIT"
     },
     "node_modules/es-object-atoms": {
       "version": "1.1.1",
@@ -1228,6 +1977,16 @@
         "@esbuild/win32-x64": "0.27.4"
       }
     },
+    "node_modules/estree-walker": {
+      "version": "3.0.3",
+      "resolved": "https://registry.npmjs.org/estree-walker/-/estree-walker-3.0.3.tgz",
+      "integrity": "sha512-7RUKfXgSMMkzt6ZuXmqapOurLGPPfgj6l9uRZ7lRGolvk0y2yocc35LdcxKC5PQZdn2DMqioAQ2NoWcrTKmm6g==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@types/estree": "^1.0.0"
+      }
+    },
     "node_modules/event-target-shim": {
       "version": "5.0.1",
       "resolved": "https://registry.npmjs.org/event-target-shim/-/event-target-shim-5.0.1.tgz",
@@ -1235,6 +1994,25 @@
       "license": "MIT",
       "engines": {
         "node": ">=6"
+      }
+    },
+    "node_modules/expand-template": {
+      "version": "2.0.3",
+      "resolved": "https://registry.npmjs.org/expand-template/-/expand-template-2.0.3.tgz",
+      "integrity": "sha512-XYfuKMvj4O35f/pOXLObndIRvyQ+/+6AhODh+OKWj9S9498pHHn/IMszH+gt0fBCRWMNfk1ZSp5x3AifmnI2vg==",
+      "license": "(MIT OR WTFPL)",
+      "engines": {
+        "node": ">=6"
+      }
+    },
+    "node_modules/expect-type": {
+      "version": "1.3.0",
+      "resolved": "https://registry.npmjs.org/expect-type/-/expect-type-1.3.0.tgz",
+      "integrity": "sha512-knvyeauYhqjOYvQ66MznSMs83wmHrCycNEN6Ao+2AeYEfxUIkuiVxdEa1qlGEPK+We3n0THiDciYSsCcgW/DoA==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "engines": {
+        "node": ">=12.0.0"
       }
     },
     "node_modules/fdir": {
@@ -1254,6 +2032,12 @@
           "optional": true
         }
       }
+    },
+    "node_modules/file-uri-to-path": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/file-uri-to-path/-/file-uri-to-path-1.0.0.tgz",
+      "integrity": "sha512-0Zt+s3L7Vf1biwWZ29aARiVYLx7iMGnEUl9x33fbB/j3jR81u/O2LbqK+Bm1CDSNDKVtJ/YjwY7TUd5SkeLQLw==",
+      "license": "MIT"
     },
     "node_modules/fix-dts-default-cjs-exports": {
       "version": "1.0.1",
@@ -1301,6 +2085,12 @@
       "engines": {
         "node": ">= 12.20"
       }
+    },
+    "node_modules/fs-constants": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/fs-constants/-/fs-constants-1.0.0.tgz",
+      "integrity": "sha512-y6OAwoSIf7FyjMIv94u+b5rdheZEjzR63GTyZJm5qh4Bi+2YgwLCcI/fPFZkL5PSixOt6ZNKm+w+Hfp/Bciwow==",
+      "license": "MIT"
     },
     "node_modules/fsevents": {
       "version": "2.3.3",
@@ -1388,6 +2178,12 @@
         "url": "https://github.com/privatenumber/get-tsconfig?sponsor=1"
       }
     },
+    "node_modules/github-from-package": {
+      "version": "0.0.0",
+      "resolved": "https://registry.npmjs.org/github-from-package/-/github-from-package-0.0.0.tgz",
+      "integrity": "sha512-SyHy3T1v2NUXn29OsWdxmK6RwHD+vkj3v8en8AOBZ1wBQ/hCAQ5bAQTD02kW4W9tUp/3Qh6J8r9EvntiyCmOOw==",
+      "license": "MIT"
+    },
     "node_modules/gopd": {
       "version": "1.2.0",
       "resolved": "https://registry.npmjs.org/gopd/-/gopd-1.2.0.tgz",
@@ -1398,6 +2194,16 @@
       },
       "funding": {
         "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/has-flag": {
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/has-flag/-/has-flag-4.0.0.tgz",
+      "integrity": "sha512-EykJT/Q1KjTWctppgIAgfSO0tKVuZUjhgMr17kqTumMl6Afv3EISleU7qZUzoXDFTAHTDC4NOoG/ZxU3EvlMPQ==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=8"
       }
     },
     "node_modules/has-symbols": {
@@ -1439,6 +2245,13 @@
         "node": ">= 0.4"
       }
     },
+    "node_modules/html-escaper": {
+      "version": "2.0.2",
+      "resolved": "https://registry.npmjs.org/html-escaper/-/html-escaper-2.0.2.tgz",
+      "integrity": "sha512-H2iMtd0I4Mt5eYiapRdIDjp+XzelXQ0tFE4JS7YFwFevXXMmOp9myNrUvCg0D6ws8iqkRPBfKHgbwig1SmlLfg==",
+      "dev": true,
+      "license": "MIT"
+    },
     "node_modules/humanize-ms": {
       "version": "1.2.1",
       "resolved": "https://registry.npmjs.org/humanize-ms/-/humanize-ms-1.2.1.tgz",
@@ -1447,6 +2260,38 @@
       "dependencies": {
         "ms": "^2.0.0"
       }
+    },
+    "node_modules/ieee754": {
+      "version": "1.2.1",
+      "resolved": "https://registry.npmjs.org/ieee754/-/ieee754-1.2.1.tgz",
+      "integrity": "sha512-dcyqhDvX1C46lXZcVqCpK+FtMRQVdIMN6/Df5js2zouUsqG7I6sFxitIC+7KYK29KdXOLHdu9zL4sFnoVQnqaA==",
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/feross"
+        },
+        {
+          "type": "patreon",
+          "url": "https://www.patreon.com/feross"
+        },
+        {
+          "type": "consulting",
+          "url": "https://feross.org/support"
+        }
+      ],
+      "license": "BSD-3-Clause"
+    },
+    "node_modules/inherits": {
+      "version": "2.0.4",
+      "resolved": "https://registry.npmjs.org/inherits/-/inherits-2.0.4.tgz",
+      "integrity": "sha512-k/vGaX4/Yla3WzyMCvTQOXYeIHvqOKtnqBduzTHpzpQZzAskKMhZ2K+EnBiSM9zGSoIFeMpXKxa4dYeZIQqewQ==",
+      "license": "ISC"
+    },
+    "node_modules/ini": {
+      "version": "1.3.8",
+      "resolved": "https://registry.npmjs.org/ini/-/ini-1.3.8.tgz",
+      "integrity": "sha512-JV/yugV2uzW5iMRSiZAyDtQd+nxtUnjeLt0acNdw98kKLrvuRVyB80tsREOE7yvGVgalhZ6RNXCmEHkUKBKxew==",
+      "license": "ISC"
     },
     "node_modules/is-interactive": {
       "version": "2.0.0",
@@ -1472,6 +2317,45 @@
         "url": "https://github.com/sponsors/sindresorhus"
       }
     },
+    "node_modules/istanbul-lib-coverage": {
+      "version": "3.2.2",
+      "resolved": "https://registry.npmjs.org/istanbul-lib-coverage/-/istanbul-lib-coverage-3.2.2.tgz",
+      "integrity": "sha512-O8dpsF+r0WV/8MNRKfnmrtCWhuKjxrq2w+jpzBL5UZKTi2LeVWnWOmWRxFlesJONmc+wLAGvKQZEOanko0LFTg==",
+      "dev": true,
+      "license": "BSD-3-Clause",
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/istanbul-lib-report": {
+      "version": "3.0.1",
+      "resolved": "https://registry.npmjs.org/istanbul-lib-report/-/istanbul-lib-report-3.0.1.tgz",
+      "integrity": "sha512-GCfE1mtsHGOELCU8e/Z7YWzpmybrx/+dSTfLrvY8qRmaY6zXTKWn6WQIjaAFw069icm6GVMNkgu0NzI4iPZUNw==",
+      "dev": true,
+      "license": "BSD-3-Clause",
+      "dependencies": {
+        "istanbul-lib-coverage": "^3.0.0",
+        "make-dir": "^4.0.0",
+        "supports-color": "^7.1.0"
+      },
+      "engines": {
+        "node": ">=10"
+      }
+    },
+    "node_modules/istanbul-reports": {
+      "version": "3.2.0",
+      "resolved": "https://registry.npmjs.org/istanbul-reports/-/istanbul-reports-3.2.0.tgz",
+      "integrity": "sha512-HGYWWS/ehqTV3xN10i23tkPkpH46MLCIMFNCaaKNavAXTF1RkqxawEPtnjnGZ6XKSInBKkiOA5BKS+aZiY3AvA==",
+      "dev": true,
+      "license": "BSD-3-Clause",
+      "dependencies": {
+        "html-escaper": "^2.0.0",
+        "istanbul-lib-report": "^3.0.0"
+      },
+      "engines": {
+        "node": ">=8"
+      }
+    },
     "node_modules/joycon": {
       "version": "3.1.1",
       "resolved": "https://registry.npmjs.org/joycon/-/joycon-3.1.1.tgz",
@@ -1481,6 +2365,13 @@
       "engines": {
         "node": ">=10"
       }
+    },
+    "node_modules/js-tokens": {
+      "version": "10.0.0",
+      "resolved": "https://registry.npmjs.org/js-tokens/-/js-tokens-10.0.0.tgz",
+      "integrity": "sha512-lM/UBzQmfJRo9ABXbPWemivdCW8V2G8FHaHdypQaIy523snUjog0W71ayWXTjiR+ixeMyVHN2XcpnTd/liPg/Q==",
+      "dev": true,
+      "license": "MIT"
     },
     "node_modules/js-yaml": {
       "version": "4.1.1",
@@ -1492,6 +2383,267 @@
       },
       "bin": {
         "js-yaml": "bin/js-yaml.js"
+      }
+    },
+    "node_modules/lightningcss": {
+      "version": "1.32.0",
+      "resolved": "https://registry.npmjs.org/lightningcss/-/lightningcss-1.32.0.tgz",
+      "integrity": "sha512-NXYBzinNrblfraPGyrbPoD19C1h9lfI/1mzgWYvXUTe414Gz/X1FD2XBZSZM7rRTrMA8JL3OtAaGifrIKhQ5yQ==",
+      "dev": true,
+      "license": "MPL-2.0",
+      "dependencies": {
+        "detect-libc": "^2.0.3"
+      },
+      "engines": {
+        "node": ">= 12.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/parcel"
+      },
+      "optionalDependencies": {
+        "lightningcss-android-arm64": "1.32.0",
+        "lightningcss-darwin-arm64": "1.32.0",
+        "lightningcss-darwin-x64": "1.32.0",
+        "lightningcss-freebsd-x64": "1.32.0",
+        "lightningcss-linux-arm-gnueabihf": "1.32.0",
+        "lightningcss-linux-arm64-gnu": "1.32.0",
+        "lightningcss-linux-arm64-musl": "1.32.0",
+        "lightningcss-linux-x64-gnu": "1.32.0",
+        "lightningcss-linux-x64-musl": "1.32.0",
+        "lightningcss-win32-arm64-msvc": "1.32.0",
+        "lightningcss-win32-x64-msvc": "1.32.0"
+      }
+    },
+    "node_modules/lightningcss-android-arm64": {
+      "version": "1.32.0",
+      "resolved": "https://registry.npmjs.org/lightningcss-android-arm64/-/lightningcss-android-arm64-1.32.0.tgz",
+      "integrity": "sha512-YK7/ClTt4kAK0vo6w3X+Pnm0D2cf2vPHbhOXdoNti1Ga0al1P4TBZhwjATvjNwLEBCnKvjJc2jQgHXH0NEwlAg==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MPL-2.0",
+      "optional": true,
+      "os": [
+        "android"
+      ],
+      "engines": {
+        "node": ">= 12.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/parcel"
+      }
+    },
+    "node_modules/lightningcss-darwin-arm64": {
+      "version": "1.32.0",
+      "resolved": "https://registry.npmjs.org/lightningcss-darwin-arm64/-/lightningcss-darwin-arm64-1.32.0.tgz",
+      "integrity": "sha512-RzeG9Ju5bag2Bv1/lwlVJvBE3q6TtXskdZLLCyfg5pt+HLz9BqlICO7LZM7VHNTTn/5PRhHFBSjk5lc4cmscPQ==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MPL-2.0",
+      "optional": true,
+      "os": [
+        "darwin"
+      ],
+      "engines": {
+        "node": ">= 12.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/parcel"
+      }
+    },
+    "node_modules/lightningcss-darwin-x64": {
+      "version": "1.32.0",
+      "resolved": "https://registry.npmjs.org/lightningcss-darwin-x64/-/lightningcss-darwin-x64-1.32.0.tgz",
+      "integrity": "sha512-U+QsBp2m/s2wqpUYT/6wnlagdZbtZdndSmut/NJqlCcMLTWp5muCrID+K5UJ6jqD2BFshejCYXniPDbNh73V8w==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MPL-2.0",
+      "optional": true,
+      "os": [
+        "darwin"
+      ],
+      "engines": {
+        "node": ">= 12.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/parcel"
+      }
+    },
+    "node_modules/lightningcss-freebsd-x64": {
+      "version": "1.32.0",
+      "resolved": "https://registry.npmjs.org/lightningcss-freebsd-x64/-/lightningcss-freebsd-x64-1.32.0.tgz",
+      "integrity": "sha512-JCTigedEksZk3tHTTthnMdVfGf61Fky8Ji2E4YjUTEQX14xiy/lTzXnu1vwiZe3bYe0q+SpsSH/CTeDXK6WHig==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MPL-2.0",
+      "optional": true,
+      "os": [
+        "freebsd"
+      ],
+      "engines": {
+        "node": ">= 12.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/parcel"
+      }
+    },
+    "node_modules/lightningcss-linux-arm-gnueabihf": {
+      "version": "1.32.0",
+      "resolved": "https://registry.npmjs.org/lightningcss-linux-arm-gnueabihf/-/lightningcss-linux-arm-gnueabihf-1.32.0.tgz",
+      "integrity": "sha512-x6rnnpRa2GL0zQOkt6rts3YDPzduLpWvwAF6EMhXFVZXD4tPrBkEFqzGowzCsIWsPjqSK+tyNEODUBXeeVHSkw==",
+      "cpu": [
+        "arm"
+      ],
+      "dev": true,
+      "license": "MPL-2.0",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">= 12.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/parcel"
+      }
+    },
+    "node_modules/lightningcss-linux-arm64-gnu": {
+      "version": "1.32.0",
+      "resolved": "https://registry.npmjs.org/lightningcss-linux-arm64-gnu/-/lightningcss-linux-arm64-gnu-1.32.0.tgz",
+      "integrity": "sha512-0nnMyoyOLRJXfbMOilaSRcLH3Jw5z9HDNGfT/gwCPgaDjnx0i8w7vBzFLFR1f6CMLKF8gVbebmkUN3fa/kQJpQ==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MPL-2.0",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">= 12.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/parcel"
+      }
+    },
+    "node_modules/lightningcss-linux-arm64-musl": {
+      "version": "1.32.0",
+      "resolved": "https://registry.npmjs.org/lightningcss-linux-arm64-musl/-/lightningcss-linux-arm64-musl-1.32.0.tgz",
+      "integrity": "sha512-UpQkoenr4UJEzgVIYpI80lDFvRmPVg6oqboNHfoH4CQIfNA+HOrZ7Mo7KZP02dC6LjghPQJeBsvXhJod/wnIBg==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MPL-2.0",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">= 12.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/parcel"
+      }
+    },
+    "node_modules/lightningcss-linux-x64-gnu": {
+      "version": "1.32.0",
+      "resolved": "https://registry.npmjs.org/lightningcss-linux-x64-gnu/-/lightningcss-linux-x64-gnu-1.32.0.tgz",
+      "integrity": "sha512-V7Qr52IhZmdKPVr+Vtw8o+WLsQJYCTd8loIfpDaMRWGUZfBOYEJeyJIkqGIDMZPwPx24pUMfwSxxI8phr/MbOA==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MPL-2.0",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">= 12.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/parcel"
+      }
+    },
+    "node_modules/lightningcss-linux-x64-musl": {
+      "version": "1.32.0",
+      "resolved": "https://registry.npmjs.org/lightningcss-linux-x64-musl/-/lightningcss-linux-x64-musl-1.32.0.tgz",
+      "integrity": "sha512-bYcLp+Vb0awsiXg/80uCRezCYHNg1/l3mt0gzHnWV9XP1W5sKa5/TCdGWaR/zBM2PeF/HbsQv/j2URNOiVuxWg==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MPL-2.0",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">= 12.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/parcel"
+      }
+    },
+    "node_modules/lightningcss-win32-arm64-msvc": {
+      "version": "1.32.0",
+      "resolved": "https://registry.npmjs.org/lightningcss-win32-arm64-msvc/-/lightningcss-win32-arm64-msvc-1.32.0.tgz",
+      "integrity": "sha512-8SbC8BR40pS6baCM8sbtYDSwEVQd4JlFTOlaD3gWGHfThTcABnNDBda6eTZeqbofalIJhFx0qKzgHJmcPTnGdw==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MPL-2.0",
+      "optional": true,
+      "os": [
+        "win32"
+      ],
+      "engines": {
+        "node": ">= 12.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/parcel"
+      }
+    },
+    "node_modules/lightningcss-win32-x64-msvc": {
+      "version": "1.32.0",
+      "resolved": "https://registry.npmjs.org/lightningcss-win32-x64-msvc/-/lightningcss-win32-x64-msvc-1.32.0.tgz",
+      "integrity": "sha512-Amq9B/SoZYdDi1kFrojnoqPLxYhQ4Wo5XiL8EVJrVsB8ARoC1PWW6VGtT0WKCemjy8aC+louJnjS7U18x3b06Q==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MPL-2.0",
+      "optional": true,
+      "os": [
+        "win32"
+      ],
+      "engines": {
+        "node": ">= 12.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/parcel"
       }
     },
     "node_modules/lilconfig": {
@@ -1562,6 +2714,34 @@
         "@jridgewell/sourcemap-codec": "^1.5.5"
       }
     },
+    "node_modules/magicast": {
+      "version": "0.5.2",
+      "resolved": "https://registry.npmjs.org/magicast/-/magicast-0.5.2.tgz",
+      "integrity": "sha512-E3ZJh4J3S9KfwdjZhe2afj6R9lGIN5Pher1pF39UGrXRqq/VDaGVIGN13BjHd2u8B61hArAGOnso7nBOouW3TQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@babel/parser": "^7.29.0",
+        "@babel/types": "^7.29.0",
+        "source-map-js": "^1.2.1"
+      }
+    },
+    "node_modules/make-dir": {
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/make-dir/-/make-dir-4.0.0.tgz",
+      "integrity": "sha512-hXdUTZYIVOt1Ex//jAQi+wTZZpUpwBj/0QsOzqegb3rGMMeJiSEu5xLHnYfBrRV4RH2+OCSOO95Is/7x1WJ4bw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "semver": "^7.5.3"
+      },
+      "engines": {
+        "node": ">=10"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
     "node_modules/math-intrinsics": {
       "version": "1.1.0",
       "resolved": "https://registry.npmjs.org/math-intrinsics/-/math-intrinsics-1.1.0.tgz",
@@ -1604,6 +2784,33 @@
         "url": "https://github.com/sponsors/sindresorhus"
       }
     },
+    "node_modules/mimic-response": {
+      "version": "3.1.0",
+      "resolved": "https://registry.npmjs.org/mimic-response/-/mimic-response-3.1.0.tgz",
+      "integrity": "sha512-z0yWI+4FDrrweS8Zmt4Ej5HdJmky15+L2e6Wgn3+iK5fWzb6T3fhNFq2+MeTRb064c6Wr4N/wv0DzQTjNzHNGQ==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=10"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/minimist": {
+      "version": "1.2.8",
+      "resolved": "https://registry.npmjs.org/minimist/-/minimist-1.2.8.tgz",
+      "integrity": "sha512-2yyAR8qBkN3YuheJanUpWC5U3bb5osDywNB8RzDVlDwDHbocAJveqqj1u8+SVD7jkWT4yvsHCpWqqWqAxb0zCA==",
+      "license": "MIT",
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/mkdirp-classic": {
+      "version": "0.5.3",
+      "resolved": "https://registry.npmjs.org/mkdirp-classic/-/mkdirp-classic-0.5.3.tgz",
+      "integrity": "sha512-gKLcREMhtuZRwRAfqP3RFW+TK4JqApVBtOIftVgjuABpAtpxhPGaDcfvbhNvD0B8iD1oUr/txX35NjcaY6Ns/A==",
+      "license": "MIT"
+    },
     "node_modules/mlly": {
       "version": "1.8.2",
       "resolved": "https://registry.npmjs.org/mlly/-/mlly-1.8.2.tgz",
@@ -1633,6 +2840,43 @@
         "any-promise": "^1.0.0",
         "object-assign": "^4.0.1",
         "thenify-all": "^1.0.0"
+      }
+    },
+    "node_modules/nanoid": {
+      "version": "3.3.11",
+      "resolved": "https://registry.npmjs.org/nanoid/-/nanoid-3.3.11.tgz",
+      "integrity": "sha512-N8SpfPUnUp1bK+PMYW8qSWdl9U+wwNWI4QKxOYDy9JAro3WMX7p2OeVRF9v+347pnakNevPmiHhNmZ2HbFA76w==",
+      "dev": true,
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/ai"
+        }
+      ],
+      "license": "MIT",
+      "bin": {
+        "nanoid": "bin/nanoid.cjs"
+      },
+      "engines": {
+        "node": "^10 || ^12 || ^13.7 || ^14 || >=15.0.1"
+      }
+    },
+    "node_modules/napi-build-utils": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/napi-build-utils/-/napi-build-utils-2.0.0.tgz",
+      "integrity": "sha512-GEbrYkbfF7MoNaoh2iGG84Mnf/WZfB0GdGEsM8wz7Expx/LlWf5U8t9nvJKXSp3qr5IsEbK04cBGhol/KwOsWA==",
+      "license": "MIT"
+    },
+    "node_modules/node-abi": {
+      "version": "3.89.0",
+      "resolved": "https://registry.npmjs.org/node-abi/-/node-abi-3.89.0.tgz",
+      "integrity": "sha512-6u9UwL0HlAl21+agMN3YAMXcKByMqwGx+pq+P76vii5f7hTPtKDp08/H9py6DY+cfDw7kQNTGEj/rly3IgbNQA==",
+      "license": "MIT",
+      "dependencies": {
+        "semver": "^7.3.5"
+      },
+      "engines": {
+        "node": ">=10"
       }
     },
     "node_modules/node-domexception": {
@@ -1683,6 +2927,26 @@
       "license": "MIT",
       "engines": {
         "node": ">=0.10.0"
+      }
+    },
+    "node_modules/obug": {
+      "version": "2.1.1",
+      "resolved": "https://registry.npmjs.org/obug/-/obug-2.1.1.tgz",
+      "integrity": "sha512-uTqF9MuPraAQ+IsnPf366RG4cP9RtUi7MLO1N3KEc+wb0a6yKpeL0lmk2IB1jY5KHPAlTc6T/JRdC/YqxHNwkQ==",
+      "dev": true,
+      "funding": [
+        "https://github.com/sponsors/sxzz",
+        "https://opencollective.com/debug"
+      ],
+      "license": "MIT"
+    },
+    "node_modules/once": {
+      "version": "1.4.0",
+      "resolved": "https://registry.npmjs.org/once/-/once-1.4.0.tgz",
+      "integrity": "sha512-lNaJgI+2Q5URQBkccEKHTQOPaXdUxnZZElQTZY0MFUAuaEqe1E+Nyvgdz/aIyNi6Z9MzO5dv1H8n58/GELp3+w==",
+      "license": "ISC",
+      "dependencies": {
+        "wrappy": "1"
       }
     },
     "node_modules/onetime": {
@@ -1817,6 +3081,35 @@
         "pathe": "^2.0.1"
       }
     },
+    "node_modules/postcss": {
+      "version": "8.5.8",
+      "resolved": "https://registry.npmjs.org/postcss/-/postcss-8.5.8.tgz",
+      "integrity": "sha512-OW/rX8O/jXnm82Ey1k44pObPtdblfiuWnrd8X7GJ7emImCOstunGbXUpp7HdBrFQX6rJzn3sPT397Wp5aCwCHg==",
+      "dev": true,
+      "funding": [
+        {
+          "type": "opencollective",
+          "url": "https://opencollective.com/postcss/"
+        },
+        {
+          "type": "tidelift",
+          "url": "https://tidelift.com/funding/github/npm/postcss"
+        },
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/ai"
+        }
+      ],
+      "license": "MIT",
+      "dependencies": {
+        "nanoid": "^3.3.11",
+        "picocolors": "^1.1.1",
+        "source-map-js": "^1.2.1"
+      },
+      "engines": {
+        "node": "^10 || ^12 || >=14"
+      }
+    },
     "node_modules/postcss-load-config": {
       "version": "6.0.1",
       "resolved": "https://registry.npmjs.org/postcss-load-config/-/postcss-load-config-6.0.1.tgz",
@@ -1858,6 +3151,72 @@
         "yaml": {
           "optional": true
         }
+      }
+    },
+    "node_modules/prebuild-install": {
+      "version": "7.1.3",
+      "resolved": "https://registry.npmjs.org/prebuild-install/-/prebuild-install-7.1.3.tgz",
+      "integrity": "sha512-8Mf2cbV7x1cXPUILADGI3wuhfqWvtiLA1iclTDbFRZkgRQS0NqsPZphna9V+HyTEadheuPmjaJMsbzKQFOzLug==",
+      "deprecated": "No longer maintained. Please contact the author of the relevant native addon; alternatives are available.",
+      "license": "MIT",
+      "dependencies": {
+        "detect-libc": "^2.0.0",
+        "expand-template": "^2.0.3",
+        "github-from-package": "0.0.0",
+        "minimist": "^1.2.3",
+        "mkdirp-classic": "^0.5.3",
+        "napi-build-utils": "^2.0.0",
+        "node-abi": "^3.3.0",
+        "pump": "^3.0.0",
+        "rc": "^1.2.7",
+        "simple-get": "^4.0.0",
+        "tar-fs": "^2.0.0",
+        "tunnel-agent": "^0.6.0"
+      },
+      "bin": {
+        "prebuild-install": "bin.js"
+      },
+      "engines": {
+        "node": ">=10"
+      }
+    },
+    "node_modules/pump": {
+      "version": "3.0.4",
+      "resolved": "https://registry.npmjs.org/pump/-/pump-3.0.4.tgz",
+      "integrity": "sha512-VS7sjc6KR7e1ukRFhQSY5LM2uBWAUPiOPa/A3mkKmiMwSmRFUITt0xuj+/lesgnCv+dPIEYlkzrcyXgquIHMcA==",
+      "license": "MIT",
+      "dependencies": {
+        "end-of-stream": "^1.1.0",
+        "once": "^1.3.1"
+      }
+    },
+    "node_modules/rc": {
+      "version": "1.2.8",
+      "resolved": "https://registry.npmjs.org/rc/-/rc-1.2.8.tgz",
+      "integrity": "sha512-y3bGgqKj3QBdxLbLkomlohkvsA8gdAiUQlSBJnBhfn+BPxg4bc62d8TcBW15wavDfgexCgccckhcZvywyQYPOw==",
+      "license": "(BSD-2-Clause OR MIT OR Apache-2.0)",
+      "dependencies": {
+        "deep-extend": "^0.6.0",
+        "ini": "~1.3.0",
+        "minimist": "^1.2.0",
+        "strip-json-comments": "~2.0.1"
+      },
+      "bin": {
+        "rc": "cli.js"
+      }
+    },
+    "node_modules/readable-stream": {
+      "version": "3.6.2",
+      "resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-3.6.2.tgz",
+      "integrity": "sha512-9u/sniCrY3D5WdsERHzHE4G2YCXqoG5FTHUiCC4SIbr6XcLZBY05ya9EKjYek9O5xOAwjGq+1JdGBAS7Q9ScoA==",
+      "license": "MIT",
+      "dependencies": {
+        "inherits": "^2.0.3",
+        "string_decoder": "^1.1.1",
+        "util-deprecate": "^1.0.1"
+      },
+      "engines": {
+        "node": ">= 6"
       }
     },
     "node_modules/readdirp": {
@@ -1910,6 +3269,40 @@
         "url": "https://github.com/sponsors/sindresorhus"
       }
     },
+    "node_modules/rolldown": {
+      "version": "1.0.0-rc.11",
+      "resolved": "https://registry.npmjs.org/rolldown/-/rolldown-1.0.0-rc.11.tgz",
+      "integrity": "sha512-NRjoKMusSjfRbSYiH3VSumlkgFe7kYAa3pzVOsVYVFY3zb5d7nS+a3KGQ7hJKXuYWbzJKPVQ9Wxq2UvyK+ENpw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@oxc-project/types": "=0.122.0",
+        "@rolldown/pluginutils": "1.0.0-rc.11"
+      },
+      "bin": {
+        "rolldown": "bin/cli.mjs"
+      },
+      "engines": {
+        "node": "^20.19.0 || >=22.12.0"
+      },
+      "optionalDependencies": {
+        "@rolldown/binding-android-arm64": "1.0.0-rc.11",
+        "@rolldown/binding-darwin-arm64": "1.0.0-rc.11",
+        "@rolldown/binding-darwin-x64": "1.0.0-rc.11",
+        "@rolldown/binding-freebsd-x64": "1.0.0-rc.11",
+        "@rolldown/binding-linux-arm-gnueabihf": "1.0.0-rc.11",
+        "@rolldown/binding-linux-arm64-gnu": "1.0.0-rc.11",
+        "@rolldown/binding-linux-arm64-musl": "1.0.0-rc.11",
+        "@rolldown/binding-linux-ppc64-gnu": "1.0.0-rc.11",
+        "@rolldown/binding-linux-s390x-gnu": "1.0.0-rc.11",
+        "@rolldown/binding-linux-x64-gnu": "1.0.0-rc.11",
+        "@rolldown/binding-linux-x64-musl": "1.0.0-rc.11",
+        "@rolldown/binding-openharmony-arm64": "1.0.0-rc.11",
+        "@rolldown/binding-wasm32-wasi": "1.0.0-rc.11",
+        "@rolldown/binding-win32-arm64-msvc": "1.0.0-rc.11",
+        "@rolldown/binding-win32-x64-msvc": "1.0.0-rc.11"
+      }
+    },
     "node_modules/rollup": {
       "version": "4.60.0",
       "resolved": "https://registry.npmjs.org/rollup/-/rollup-4.60.0.tgz",
@@ -1955,6 +3348,45 @@
         "fsevents": "~2.3.2"
       }
     },
+    "node_modules/safe-buffer": {
+      "version": "5.2.1",
+      "resolved": "https://registry.npmjs.org/safe-buffer/-/safe-buffer-5.2.1.tgz",
+      "integrity": "sha512-rp3So07KcdmmKbGvgaNxQSJr7bGVSVk5S9Eq1F+ppbRo70+YeaDxkw5Dd8NPN+GD6bjnYm2VuPuCXmpuYvmCXQ==",
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/feross"
+        },
+        {
+          "type": "patreon",
+          "url": "https://www.patreon.com/feross"
+        },
+        {
+          "type": "consulting",
+          "url": "https://feross.org/support"
+        }
+      ],
+      "license": "MIT"
+    },
+    "node_modules/semver": {
+      "version": "7.7.4",
+      "resolved": "https://registry.npmjs.org/semver/-/semver-7.7.4.tgz",
+      "integrity": "sha512-vFKC2IEtQnVhpT78h1Yp8wzwrf8CM+MzKMHGJZfBtzhZNycRFnXsHk6E5TxIkkMsgNS7mdX3AGB7x2QM2di4lA==",
+      "license": "ISC",
+      "bin": {
+        "semver": "bin/semver.js"
+      },
+      "engines": {
+        "node": ">=10"
+      }
+    },
+    "node_modules/siginfo": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/siginfo/-/siginfo-2.0.0.tgz",
+      "integrity": "sha512-ybx0WO1/8bSBLEWXZvEd7gMW3Sn3JFlW3TvX1nREbDLRNQNaeNN8WK0meBwPdAaOI7TtRRRJn/Es1zhrrCHu7g==",
+      "dev": true,
+      "license": "ISC"
+    },
     "node_modules/signal-exit": {
       "version": "4.1.0",
       "resolved": "https://registry.npmjs.org/signal-exit/-/signal-exit-4.1.0.tgz",
@@ -1967,6 +3399,51 @@
         "url": "https://github.com/sponsors/isaacs"
       }
     },
+    "node_modules/simple-concat": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/simple-concat/-/simple-concat-1.0.1.tgz",
+      "integrity": "sha512-cSFtAPtRhljv69IK0hTVZQ+OfE9nePi/rtJmw5UjHeVyVroEqJXP1sFztKUy1qU+xvz3u/sfYJLa947b7nAN2Q==",
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/feross"
+        },
+        {
+          "type": "patreon",
+          "url": "https://www.patreon.com/feross"
+        },
+        {
+          "type": "consulting",
+          "url": "https://feross.org/support"
+        }
+      ],
+      "license": "MIT"
+    },
+    "node_modules/simple-get": {
+      "version": "4.0.1",
+      "resolved": "https://registry.npmjs.org/simple-get/-/simple-get-4.0.1.tgz",
+      "integrity": "sha512-brv7p5WgH0jmQJr1ZDDfKDOSeWWg+OVypG99A/5vYGPqJ6pxiaHLy8nxtFjBA7oMa01ebA9gfh1uMCFqOuXxvA==",
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/feross"
+        },
+        {
+          "type": "patreon",
+          "url": "https://www.patreon.com/feross"
+        },
+        {
+          "type": "consulting",
+          "url": "https://feross.org/support"
+        }
+      ],
+      "license": "MIT",
+      "dependencies": {
+        "decompress-response": "^6.0.0",
+        "once": "^1.3.1",
+        "simple-concat": "^1.0.0"
+      }
+    },
     "node_modules/source-map": {
       "version": "0.7.6",
       "resolved": "https://registry.npmjs.org/source-map/-/source-map-0.7.6.tgz",
@@ -1976,6 +3453,30 @@
       "engines": {
         "node": ">= 12"
       }
+    },
+    "node_modules/source-map-js": {
+      "version": "1.2.1",
+      "resolved": "https://registry.npmjs.org/source-map-js/-/source-map-js-1.2.1.tgz",
+      "integrity": "sha512-UXWMKhLOwVKb728IUtQPXxfYU+usdybtUrK/8uGE8CQMvrhOpwvzDBwj0QhSL7MQc7vIsISBG8VQ8+IDQxpfQA==",
+      "dev": true,
+      "license": "BSD-3-Clause",
+      "engines": {
+        "node": ">=0.10.0"
+      }
+    },
+    "node_modules/stackback": {
+      "version": "0.0.2",
+      "resolved": "https://registry.npmjs.org/stackback/-/stackback-0.0.2.tgz",
+      "integrity": "sha512-1XMJE5fQo1jGH6Y/7ebnwPOBEkIEnT4QF32d5R1+VXdXveM0IBMJt8zfaxX1P3QhVwrYe+576+jkANtSS2mBbw==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/std-env": {
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/std-env/-/std-env-4.0.0.tgz",
+      "integrity": "sha512-zUMPtQ/HBY3/50VbpkupYHbRroTRZJPRLvreamgErJVys0ceuzMkD44J/QjqhHjOzK42GQ3QZIeFG1OYfOtKqQ==",
+      "dev": true,
+      "license": "MIT"
     },
     "node_modules/stdin-discarder": {
       "version": "0.2.2",
@@ -1987,6 +3488,15 @@
       },
       "funding": {
         "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/string_decoder": {
+      "version": "1.3.0",
+      "resolved": "https://registry.npmjs.org/string_decoder/-/string_decoder-1.3.0.tgz",
+      "integrity": "sha512-hkRX8U1WjJFd8LsDJ2yQ/wWWxaopEsABU1XfkM8A+j0+85JAGppt16cr1Whg6KIbb4okU6Mql6BOj+uup/wKeA==",
+      "license": "MIT",
+      "dependencies": {
+        "safe-buffer": "~5.2.0"
       }
     },
     "node_modules/string-width": {
@@ -2019,6 +3529,15 @@
       },
       "funding": {
         "url": "https://github.com/chalk/strip-ansi?sponsor=1"
+      }
+    },
+    "node_modules/strip-json-comments": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/strip-json-comments/-/strip-json-comments-2.0.1.tgz",
+      "integrity": "sha512-4gB8na07fecVVkOI6Rs4e7T6NOTki5EmL7TUduTs6bu3EdnSycntVJ4re8kgZA+wx9IueI2Y11bfbgwtzuE0KQ==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=0.10.0"
       }
     },
     "node_modules/sucrase": {
@@ -2054,6 +3573,47 @@
         "node": ">= 6"
       }
     },
+    "node_modules/supports-color": {
+      "version": "7.2.0",
+      "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-7.2.0.tgz",
+      "integrity": "sha512-qpCAvRl9stuOHveKsn7HncJRvv501qIacKzQlO/+Lwxc9+0q2wLyv4Dfvt80/DPn2pqOBsJdDiogXGR9+OvwRw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "has-flag": "^4.0.0"
+      },
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/tar-fs": {
+      "version": "2.1.4",
+      "resolved": "https://registry.npmjs.org/tar-fs/-/tar-fs-2.1.4.tgz",
+      "integrity": "sha512-mDAjwmZdh7LTT6pNleZ05Yt65HC3E+NiQzl672vQG38jIrehtJk/J3mNwIg+vShQPcLF/LV7CMnDW6vjj6sfYQ==",
+      "license": "MIT",
+      "dependencies": {
+        "chownr": "^1.1.1",
+        "mkdirp-classic": "^0.5.2",
+        "pump": "^3.0.0",
+        "tar-stream": "^2.1.4"
+      }
+    },
+    "node_modules/tar-stream": {
+      "version": "2.2.0",
+      "resolved": "https://registry.npmjs.org/tar-stream/-/tar-stream-2.2.0.tgz",
+      "integrity": "sha512-ujeqbceABgwMZxEJnk2HDY2DlnUZ+9oEcb1KzTVfYHio0UE6dG71n60d8D2I4qNvleWrrXpmjpt7vZeF1LnMZQ==",
+      "license": "MIT",
+      "dependencies": {
+        "bl": "^4.0.3",
+        "end-of-stream": "^1.4.1",
+        "fs-constants": "^1.0.0",
+        "inherits": "^2.0.3",
+        "readable-stream": "^3.1.1"
+      },
+      "engines": {
+        "node": ">=6"
+      }
+    },
     "node_modules/thenify": {
       "version": "3.3.1",
       "resolved": "https://registry.npmjs.org/thenify/-/thenify-3.3.1.tgz",
@@ -2076,6 +3636,13 @@
       "engines": {
         "node": ">=0.8"
       }
+    },
+    "node_modules/tinybench": {
+      "version": "2.9.0",
+      "resolved": "https://registry.npmjs.org/tinybench/-/tinybench-2.9.0.tgz",
+      "integrity": "sha512-0+DUvqWMValLmha6lr4kD8iAMK1HzV0/aKnCtWb9v9641TnP/MFb7Pc2bxoxQjTXAErryXVgUOfv2YqNllqGeg==",
+      "dev": true,
+      "license": "MIT"
     },
     "node_modules/tinyexec": {
       "version": "0.3.2",
@@ -2101,6 +3668,16 @@
         "url": "https://github.com/sponsors/SuperchupuDev"
       }
     },
+    "node_modules/tinyrainbow": {
+      "version": "3.1.0",
+      "resolved": "https://registry.npmjs.org/tinyrainbow/-/tinyrainbow-3.1.0.tgz",
+      "integrity": "sha512-Bf+ILmBgretUrdJxzXM0SgXLZ3XfiaUuOj/IKQHuTXip+05Xn+uyEYdVg0kYDipTBcLrCVyUzAPz7QmArb0mmw==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=14.0.0"
+      }
+    },
     "node_modules/tr46": {
       "version": "0.0.3",
       "resolved": "https://registry.npmjs.org/tr46/-/tr46-0.0.3.tgz",
@@ -2123,6 +3700,14 @@
       "integrity": "sha512-Y/arvbn+rrz3JCKl9C4kVNfTfSm2/mEp5FSz5EsZSANGPSlQrpRI5M4PKF+mJnE52jOO90PnPSc3Ur3bTQw0gA==",
       "dev": true,
       "license": "Apache-2.0"
+    },
+    "node_modules/tslib": {
+      "version": "2.8.1",
+      "resolved": "https://registry.npmjs.org/tslib/-/tslib-2.8.1.tgz",
+      "integrity": "sha512-oJFu94HQb+KVduSUQL7wnpmqnfmLsOA/nAh6b6EH0wCEoK0/mPeXU6c3wKDV83MkOuHPRHtSXKKU99IBazS/2w==",
+      "dev": true,
+      "license": "0BSD",
+      "optional": true
     },
     "node_modules/tsup": {
       "version": "8.5.1",
@@ -2197,6 +3782,18 @@
         "fsevents": "~2.3.3"
       }
     },
+    "node_modules/tunnel-agent": {
+      "version": "0.6.0",
+      "resolved": "https://registry.npmjs.org/tunnel-agent/-/tunnel-agent-0.6.0.tgz",
+      "integrity": "sha512-McnNiV1l8RYeY8tBgEpuodCC1mLUdbSN+CYBL7kJsJNInOP8UjDDEwdk6Mw60vdLLrr5NHKZhMAOSrR2NZuQ+w==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "safe-buffer": "^5.0.1"
+      },
+      "engines": {
+        "node": "*"
+      }
+    },
     "node_modules/typescript": {
       "version": "5.9.3",
       "resolved": "https://registry.npmjs.org/typescript/-/typescript-5.9.3.tgz",
@@ -2224,6 +3821,182 @@
       "integrity": "sha512-iwDZqg0QAGrg9Rav5H4n0M64c3mkR59cJ6wQp+7C4nI0gsmExaedaYLNO44eT4AtBBwjbTiGPMlt2Md0T9H9JQ==",
       "license": "MIT"
     },
+    "node_modules/util-deprecate": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/util-deprecate/-/util-deprecate-1.0.2.tgz",
+      "integrity": "sha512-EPD5q1uXyFxJpCrLnCc1nHnq3gOa6DZBocAIiI2TaSCA7VCJ1UJDMagCzIkXNsUYfD1daK//LTEQ8xiIbrHtcw==",
+      "license": "MIT"
+    },
+    "node_modules/vite": {
+      "version": "8.0.2",
+      "resolved": "https://registry.npmjs.org/vite/-/vite-8.0.2.tgz",
+      "integrity": "sha512-1gFhNi+bHhRE/qKZOJXACm6tX4bA3Isy9KuKF15AgSRuRazNBOJfdDemPBU16/mpMxApDPrWvZ08DcLPEoRnuA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "lightningcss": "^1.32.0",
+        "picomatch": "^4.0.3",
+        "postcss": "^8.5.8",
+        "rolldown": "1.0.0-rc.11",
+        "tinyglobby": "^0.2.15"
+      },
+      "bin": {
+        "vite": "bin/vite.js"
+      },
+      "engines": {
+        "node": "^20.19.0 || >=22.12.0"
+      },
+      "funding": {
+        "url": "https://github.com/vitejs/vite?sponsor=1"
+      },
+      "optionalDependencies": {
+        "fsevents": "~2.3.3"
+      },
+      "peerDependencies": {
+        "@types/node": "^20.19.0 || >=22.12.0",
+        "@vitejs/devtools": "^0.1.0",
+        "esbuild": "^0.27.0",
+        "jiti": ">=1.21.0",
+        "less": "^4.0.0",
+        "sass": "^1.70.0",
+        "sass-embedded": "^1.70.0",
+        "stylus": ">=0.54.8",
+        "sugarss": "^5.0.0",
+        "terser": "^5.16.0",
+        "tsx": "^4.8.1",
+        "yaml": "^2.4.2"
+      },
+      "peerDependenciesMeta": {
+        "@types/node": {
+          "optional": true
+        },
+        "@vitejs/devtools": {
+          "optional": true
+        },
+        "esbuild": {
+          "optional": true
+        },
+        "jiti": {
+          "optional": true
+        },
+        "less": {
+          "optional": true
+        },
+        "sass": {
+          "optional": true
+        },
+        "sass-embedded": {
+          "optional": true
+        },
+        "stylus": {
+          "optional": true
+        },
+        "sugarss": {
+          "optional": true
+        },
+        "terser": {
+          "optional": true
+        },
+        "tsx": {
+          "optional": true
+        },
+        "yaml": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/vitest": {
+      "version": "4.1.1",
+      "resolved": "https://registry.npmjs.org/vitest/-/vitest-4.1.1.tgz",
+      "integrity": "sha512-yF+o4POL41rpAzj5KVILUxm1GCjKnELvaqmU9TLLUbMfDzuN0UpUR9uaDs+mCtjPe+uYPksXDRLQGGPvj1cTmA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@vitest/expect": "4.1.1",
+        "@vitest/mocker": "4.1.1",
+        "@vitest/pretty-format": "4.1.1",
+        "@vitest/runner": "4.1.1",
+        "@vitest/snapshot": "4.1.1",
+        "@vitest/spy": "4.1.1",
+        "@vitest/utils": "4.1.1",
+        "es-module-lexer": "^2.0.0",
+        "expect-type": "^1.3.0",
+        "magic-string": "^0.30.21",
+        "obug": "^2.1.1",
+        "pathe": "^2.0.3",
+        "picomatch": "^4.0.3",
+        "std-env": "^4.0.0-rc.1",
+        "tinybench": "^2.9.0",
+        "tinyexec": "^1.0.2",
+        "tinyglobby": "^0.2.15",
+        "tinyrainbow": "^3.0.3",
+        "vite": "^6.0.0 || ^7.0.0 || ^8.0.0",
+        "why-is-node-running": "^2.3.0"
+      },
+      "bin": {
+        "vitest": "vitest.mjs"
+      },
+      "engines": {
+        "node": "^20.0.0 || ^22.0.0 || >=24.0.0"
+      },
+      "funding": {
+        "url": "https://opencollective.com/vitest"
+      },
+      "peerDependencies": {
+        "@edge-runtime/vm": "*",
+        "@opentelemetry/api": "^1.9.0",
+        "@types/node": "^20.0.0 || ^22.0.0 || >=24.0.0",
+        "@vitest/browser-playwright": "4.1.1",
+        "@vitest/browser-preview": "4.1.1",
+        "@vitest/browser-webdriverio": "4.1.1",
+        "@vitest/ui": "4.1.1",
+        "happy-dom": "*",
+        "jsdom": "*",
+        "vite": "^6.0.0 || ^7.0.0 || ^8.0.0"
+      },
+      "peerDependenciesMeta": {
+        "@edge-runtime/vm": {
+          "optional": true
+        },
+        "@opentelemetry/api": {
+          "optional": true
+        },
+        "@types/node": {
+          "optional": true
+        },
+        "@vitest/browser-playwright": {
+          "optional": true
+        },
+        "@vitest/browser-preview": {
+          "optional": true
+        },
+        "@vitest/browser-webdriverio": {
+          "optional": true
+        },
+        "@vitest/ui": {
+          "optional": true
+        },
+        "happy-dom": {
+          "optional": true
+        },
+        "jsdom": {
+          "optional": true
+        },
+        "vite": {
+          "optional": false
+        }
+      }
+    },
+    "node_modules/vitest/node_modules/tinyexec": {
+      "version": "1.0.4",
+      "resolved": "https://registry.npmjs.org/tinyexec/-/tinyexec-1.0.4.tgz",
+      "integrity": "sha512-u9r3uZC0bdpGOXtlxUIdwf9pkmvhqJdrVCH9fapQtgy/OeTTMZ1nqH7agtvEfmGui6e1XxjcdrlxvxJvc3sMqw==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=18"
+      }
+    },
     "node_modules/web-streams-polyfill": {
       "version": "4.0.0-beta.3",
       "resolved": "https://registry.npmjs.org/web-streams-polyfill/-/web-streams-polyfill-4.0.0-beta.3.tgz",
@@ -2248,6 +4021,29 @@
         "tr46": "~0.0.3",
         "webidl-conversions": "^3.0.0"
       }
+    },
+    "node_modules/why-is-node-running": {
+      "version": "2.3.0",
+      "resolved": "https://registry.npmjs.org/why-is-node-running/-/why-is-node-running-2.3.0.tgz",
+      "integrity": "sha512-hUrmaWBdVDcxvYqnyh09zunKzROWjbZTiNy8dBEjkS7ehEDQibXJ7XvlmtbwuTclUiIyN+CyXQD4Vmko8fNm8w==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "siginfo": "^2.0.0",
+        "stackback": "0.0.2"
+      },
+      "bin": {
+        "why-is-node-running": "cli.js"
+      },
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/wrappy": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/wrappy/-/wrappy-1.0.2.tgz",
+      "integrity": "sha512-l4Sp/DRseor9wL6EvV2+TuQn63dMkPjZ/sp9XkghTEbV9KlPS1xUsZ3u7/IQO4wxtcFB4bgpQPRcR3QCvezPcQ==",
+      "license": "ISC"
     },
     "node_modules/zod": {
       "version": "3.25.76",

--- a/package.json
+++ b/package.json
@@ -20,9 +20,13 @@
     "build": "tsup",
     "prepublishOnly": "npm run build && npm run typecheck",
     "dev": "npx tsx src/cli/index.ts",
-    "typecheck": "tsc --noEmit"
+    "typecheck": "tsc --noEmit",
+    "test": "vitest run",
+    "test:watch": "vitest",
+    "test:coverage": "vitest run --coverage"
   },
   "dependencies": {
+    "better-sqlite3": "^12.8.0",
     "chalk": "^5.3.0",
     "commander": "^12.0.0",
     "js-yaml": "^4.1.0",
@@ -31,11 +35,14 @@
     "zod": "^3.22.0"
   },
   "devDependencies": {
+    "@types/better-sqlite3": "^7.6.13",
     "@types/js-yaml": "^4.0.9",
     "@types/node": "^20.0.0",
+    "@vitest/coverage-v8": "^4.1.1",
     "tsup": "^8.0.0",
     "tsx": "^4.7.0",
-    "typescript": "^5.4.0"
+    "typescript": "^5.4.0",
+    "vitest": "^4.1.1"
   },
   "keywords": [
     "llm",

--- a/src/cli/commands/__tests__/history.test.ts
+++ b/src/cli/commands/__tests__/history.test.ts
@@ -1,0 +1,103 @@
+import { describe, it, expect } from 'vitest'
+import { sparkline } from '../history.js'
+import { parseSince } from '../../../db/client.js'
+
+describe('history command', () => {
+  describe('sparkline', () => {
+    it('generates sparkline from scores', () => {
+      const result = sparkline([1, 5, 10])
+      expect(result.length).toBe(3)
+      // First char should be lowest, last should be highest
+      expect(result[0]).toBe('▁')
+      expect(result[2]).toBe('█')
+    })
+
+    it('handles empty array', () => {
+      expect(sparkline([])).toBe('')
+    })
+
+    it('handles all same values', () => {
+      const result = sparkline([5, 5, 5])
+      expect(result.length).toBe(3)
+      // All same values should produce same character
+      expect(result[0]).toBe(result[1])
+      expect(result[1]).toBe(result[2])
+    })
+
+    it('handles single value', () => {
+      const result = sparkline([7])
+      expect(result.length).toBe(1)
+    })
+
+    it('uses correct unicode block characters', () => {
+      const chars = '▁▂▃▄▅▆▇█'
+      const result = sparkline([0, 1, 2, 3, 4, 5, 6, 7, 8])
+      // Should use full range of characters
+      for (const char of result) {
+        expect(chars).toContain(char)
+      }
+    })
+
+    it('correctly orders ascending scores', () => {
+      const result = sparkline([2, 4, 6, 8, 10])
+      // Each subsequent character should be >= previous in the block char ordering
+      const chars = '▁▂▃▄▅▆▇█'
+      for (let i = 1; i < result.length; i++) {
+        expect(chars.indexOf(result[i])).toBeGreaterThanOrEqual(chars.indexOf(result[i - 1]))
+      }
+    })
+
+    it('correctly orders descending scores', () => {
+      const result = sparkline([10, 8, 6, 4, 2])
+      const chars = '▁▂▃▄▅▆▇█'
+      for (let i = 1; i < result.length; i++) {
+        expect(chars.indexOf(result[i])).toBeLessThanOrEqual(chars.indexOf(result[i - 1]))
+      }
+    })
+  })
+
+  describe('parseSince', () => {
+    it('parses "7d" into approximately 7 days ago', () => {
+      const result = parseSince('7d')
+      expect(result).not.toBeNull()
+      const now = new Date()
+      const diffDays = (now.getTime() - result!.getTime()) / (1000 * 60 * 60 * 24)
+      expect(diffDays).toBeGreaterThan(6.9)
+      expect(diffDays).toBeLessThan(7.1)
+    })
+
+    it('parses "24h" into approximately 24 hours ago', () => {
+      const result = parseSince('24h')
+      expect(result).not.toBeNull()
+      const now = new Date()
+      const diffHours = (now.getTime() - result!.getTime()) / (1000 * 60 * 60)
+      expect(diffHours).toBeGreaterThan(23.9)
+      expect(diffHours).toBeLessThan(24.1)
+    })
+
+    it('parses "1w" into approximately 7 days ago', () => {
+      const result = parseSince('1w')
+      expect(result).not.toBeNull()
+      const now = new Date()
+      const diffDays = (now.getTime() - result!.getTime()) / (1000 * 60 * 60 * 24)
+      expect(diffDays).toBeGreaterThan(6.9)
+      expect(diffDays).toBeLessThan(7.1)
+    })
+
+    it('parses "30d" into approximately 30 days ago', () => {
+      const result = parseSince('30d')
+      expect(result).not.toBeNull()
+      const now = new Date()
+      const diffDays = (now.getTime() - result!.getTime()) / (1000 * 60 * 60 * 24)
+      expect(diffDays).toBeGreaterThan(29.9)
+      expect(diffDays).toBeLessThan(30.1)
+    })
+
+    it('returns null for invalid formats', () => {
+      expect(parseSince('abc')).toBeNull()
+      expect(parseSince('7m')).toBeNull()
+      expect(parseSince('')).toBeNull()
+      expect(parseSince('d7')).toBeNull()
+    })
+  })
+})

--- a/src/cli/commands/history.ts
+++ b/src/cli/commands/history.ts
@@ -1,0 +1,138 @@
+/**
+ * `verdict history` command — query and display eval history from SQLite.
+ */
+
+import chalk from 'chalk'
+import { getDb, initSchema, queryHistory, parseSince } from '../../db/client.js'
+import type { EvalHistoryRow, HistoryOpts } from '../../db/client.js'
+
+interface HistoryCommandOpts {
+  model?: string
+  pack?: string
+  since?: string
+  limit?: string
+  sort?: string
+  trend?: boolean
+}
+
+/** Unicode sparkline characters ordered by magnitude. */
+const SPARK_CHARS = '▁▂▃▄▅▆▇█'
+
+/** Generate a sparkline string from an array of scores (0-10 scale). */
+export function sparkline(scores: number[]): string {
+  if (scores.length === 0) return ''
+  const min = Math.min(...scores)
+  const max = Math.max(...scores)
+  const range = max - min || 1
+  return scores.map(s => {
+    const idx = Math.round(((s - min) / range) * (SPARK_CHARS.length - 1))
+    return SPARK_CHARS[idx]
+  }).join('')
+}
+
+/** Pad/truncate a string to fixed width. */
+function col(s: string, w: number): string {
+  return s.slice(0, w).padEnd(w)
+}
+
+/** Format a date string for display. */
+function formatDate(dateStr: string): string {
+  return dateStr.slice(0, 10)
+}
+
+/** Format latency in ms as a human-readable string. */
+function formatLatency(ms: number | null): string {
+  if (ms === null || ms === undefined) return '-'
+  return `${Math.round(ms)}ms`
+}
+
+/** Format cost as a dollar string. */
+function formatCost(cost: number | null): string {
+  if (cost === null || cost === undefined || cost === 0) return '$0.00'
+  return `$${cost.toFixed(2)}`
+}
+
+export async function historyCommand(opts: HistoryCommandOpts): Promise<void> {
+  let db
+  try {
+    db = getDb()
+    initSchema(db)
+  } catch (err) {
+    console.error(chalk.red(`  Failed to open database: ${err instanceof Error ? err.message : err}`))
+    process.exit(1)
+  }
+
+  const historyOpts: HistoryOpts = {
+    modelId: opts.model,
+    pack: opts.pack,
+    since: opts.since,
+    limit: opts.limit ? parseInt(opts.limit, 10) : 20,
+    orderBy: opts.sort === 'score' ? 'score' : 'date',
+  }
+
+  let rows: EvalHistoryRow[]
+  try {
+    rows = queryHistory(db, historyOpts)
+  } catch (err) {
+    console.error(chalk.red(`  Query failed: ${err instanceof Error ? err.message : err}`))
+    process.exit(1)
+  } finally {
+    db.close()
+  }
+
+  if (rows.length === 0) {
+    console.log()
+    console.log(chalk.dim('  No eval history found. Run `verdict run` first.'))
+    console.log()
+    return
+  }
+
+  console.log()
+  console.log(chalk.bold('  verdict history') + chalk.dim(` — last ${rows.length} runs`))
+  console.log()
+
+  // Header
+  const header = `  ${col('MODEL', 25)}${col('PACK', 12)}${col('SCORE', 10)}${col('LATENCY', 10)}${col('COST', 10)}${'DATE'}`
+  console.log(chalk.dim(header))
+  console.log(chalk.dim('  ' + '─'.repeat(77)))
+
+  // If --trend, group by model and compute sparklines
+  if (opts.trend) {
+    const modelScores: Record<string, number[]> = {}
+    for (const row of rows) {
+      if (!modelScores[row.model_id]) modelScores[row.model_id] = []
+      modelScores[row.model_id].push(row.score)
+    }
+
+    for (const row of rows) {
+      const providerSuffix = row.provider ? ` (${row.provider})` : ''
+      const modelStr = `${row.model_id}${providerSuffix}`
+      const scoreStr = `${row.score.toFixed(1)}/10`
+      const latencyStr = formatLatency(row.avg_latency_ms)
+      const costStr = formatCost(row.total_cost_usd)
+      const dateStr = formatDate(row.run_at)
+      const spark = sparkline(modelScores[row.model_id])
+
+      console.log(
+        `  ${col(modelStr, 25)}${col(row.pack, 12)}${col(scoreStr, 10)}${col(latencyStr, 10)}${col(costStr, 10)}${dateStr}  ${chalk.cyan(spark)}`
+      )
+    }
+  } else {
+    for (const row of rows) {
+      const providerSuffix = row.provider ? ` (${row.provider})` : ''
+      const modelStr = `${row.model_id}${providerSuffix}`
+      const scoreStr = `${row.score.toFixed(1)}/10`
+      const latencyStr = formatLatency(row.avg_latency_ms)
+      const costStr = formatCost(row.total_cost_usd)
+      const dateStr = formatDate(row.run_at)
+
+      console.log(
+        `  ${col(modelStr, 25)}${col(row.pack, 12)}${col(scoreStr, 10)}${col(latencyStr, 10)}${col(costStr, 10)}${dateStr}`
+      )
+    }
+  }
+
+  console.log()
+  console.log(chalk.dim(`  ${rows.length} results`))
+  console.log()
+}

--- a/src/cli/commands/route.ts
+++ b/src/cli/commands/route.ts
@@ -1,0 +1,136 @@
+/**
+ * `verdict route` command — select and query the best model using eval history.
+ */
+
+import chalk from 'chalk'
+import { getDb, initSchema } from '../../db/client.js'
+import { selectModel } from '../../router/selector.js'
+import { callModel } from '../../providers/compat.js'
+import type { ModelConfig } from '../../types/index.js'
+
+interface RouteCommandOpts {
+  type?: string
+  prefer?: string
+  minScore?: string
+  dryRun?: boolean
+  model?: string
+}
+
+export async function routeCommand(prompt: string, opts: RouteCommandOpts): Promise<void> {
+  let db
+  try {
+    db = getDb()
+    initSchema(db)
+  } catch (err) {
+    console.error(chalk.red(`  Failed to open database: ${err instanceof Error ? err.message : err}`))
+    process.exit(1)
+  }
+
+  let selectedModelId: string
+  let selectedProvider: string
+  let selectedScore: number | null = null
+  let reason: string
+
+  if (opts.model) {
+    // Force a specific model
+    selectedModelId = opts.model
+    selectedProvider = 'manual'
+    reason = 'Manually specified'
+  } else {
+    // Use router to select best model
+    const selected = selectModel(db, {
+      taskType: opts.type,
+      preferLocal: opts.prefer === 'local',
+      minScore: opts.minScore ? parseFloat(opts.minScore) : undefined,
+    })
+
+    if (!selected) {
+      console.error(chalk.red('  No model found matching criteria. Run `verdict run` first to build eval history.'))
+      db.close()
+      process.exit(1)
+    }
+
+    selectedModelId = selected.modelId
+    selectedProvider = selected.provider
+    selectedScore = selected.score
+    reason = selected.reason
+  }
+
+  db.close()
+
+  const scoreInfo = selectedScore !== null ? ` (${selectedScore.toFixed(1)}/10)` : ''
+  console.log(chalk.cyan(`  → routing to ${selectedModelId}${scoreInfo}`))
+  console.log(chalk.dim(`    ${reason}`))
+  console.log()
+
+  if (opts.dryRun) {
+    console.log(chalk.dim('  dry-run: no inference performed'))
+    console.log()
+    return
+  }
+
+  // Build a minimal ModelConfig from what we know
+  const modelConfig = buildModelConfig(selectedModelId, selectedProvider)
+
+  try {
+    const response = await callModel(modelConfig, prompt)
+
+    if (response.error) {
+      console.error(chalk.red(`  Error: ${response.error}`))
+      process.exit(1)
+    }
+
+    console.log(response.text)
+    console.log()
+    console.log(chalk.dim(`  ${response.input_tokens + response.output_tokens} tokens | ${response.latency_ms}ms`))
+    if (response.cost_usd && response.cost_usd > 0) {
+      console.log(chalk.dim(`  $${response.cost_usd.toFixed(4)}`))
+    }
+    console.log()
+  } catch (err) {
+    console.error(chalk.red(`  Inference failed: ${err instanceof Error ? err.message : err}`))
+    process.exit(1)
+  }
+}
+
+/** Build a minimal ModelConfig from model ID and provider. */
+function buildModelConfig(modelId: string, provider: string): ModelConfig {
+  const config: ModelConfig = {
+    id: modelId,
+    model: modelId,
+    api_key: 'none',
+    tags: [],
+    port: 8080,
+    timeout_ms: 120_000,
+    max_tokens: 2048,
+  }
+
+  switch (provider) {
+    case 'ollama': {
+      const host = process.env.OLLAMA_HOST ?? 'http://localhost:11434'
+      config.base_url = host.endsWith('/v1') ? host : `${host}/v1`
+      break
+    }
+    case 'mlx': {
+      const port = process.env.MLX_PORT ?? '8080'
+      config.base_url = `http://localhost:${port}/v1`
+      break
+    }
+    case 'openrouter':
+      config.base_url = 'https://openrouter.ai/api/v1'
+      config.api_key = process.env.OPENROUTER_API_KEY ?? 'none'
+      break
+    case 'openai':
+      config.base_url = 'https://api.openai.com/v1'
+      config.api_key = process.env.OPENAI_API_KEY ?? 'none'
+      break
+    default: {
+      // Try ollama as default for local models
+      const host = process.env.OLLAMA_HOST ?? 'http://localhost:11434'
+      config.base_url = host.endsWith('/v1') ? host : `${host}/v1`
+      break
+    }
+  }
+
+  return config
+}

--- a/src/cli/commands/run.ts
+++ b/src/cli/commands/run.ts
@@ -17,6 +17,7 @@ interface RunOptions {
   dryRun?: boolean
   resume?: boolean
   question?: string
+  noStore?: boolean
 }
 
 export async function runCommand(opts: RunOptions): Promise<void> {
@@ -122,6 +123,24 @@ export async function runCommand(opts: RunOptions): Promise<void> {
   const base = path.join(config.output.dir, `${ts}-${result.run_id}`)
 
   fs.writeFileSync(`${base}.json`, JSON.stringify(result, null, 2))
+
+  // Persist to SQLite unless --no-store
+  if (!opts.noStore) {
+    try {
+      const { getDb, initSchema, saveRunResult } = await import('../../db/client.js')
+      const db = getDb()
+      initSchema(db)
+      const packName = opts.pack ?? config.packs[0] ?? 'unknown'
+      // Extract pack basename without path/extension
+      const packLabel = packName.replace(/^.*\//, '').replace(/\.ya?ml$/, '')
+      saveRunResult(db, result, packLabel)
+      db.close()
+      console.log(chalk.dim(`  stored: ~/.verdict/results.db`))
+    } catch (err) {
+      console.warn(chalk.yellow(`  warning: failed to store results in DB: ${err instanceof Error ? err.message : err}`))
+    }
+  }
+
   if (config.output.formats.includes('markdown')) {
     fs.writeFileSync(`${base}.md`, generateMarkdownReport(result))
     console.log(chalk.dim(`  report: ${base}.md`))

--- a/src/cli/commands/serve.ts
+++ b/src/cli/commands/serve.ts
@@ -1,0 +1,270 @@
+/**
+ * `verdict serve` command — OpenAI-compatible HTTP proxy with smart routing.
+ */
+
+import http from 'http'
+import chalk from 'chalk'
+import { getDb, initSchema } from '../../db/client.js'
+import { selectModel } from '../../router/selector.js'
+import { callModel, callModelMultiTurn } from '../../providers/compat.js'
+import type { ModelConfig } from '../../types/index.js'
+import type Database from 'better-sqlite3'
+
+interface ServeCommandOpts {
+  port?: string
+}
+
+/** Parse the "model" field from the request to determine routing. */
+function parseAutoModel(model: string): { isAuto: boolean; taskType?: string } {
+  if (model === 'auto') return { isAuto: true }
+  if (model.startsWith('auto:')) return { isAuto: true, taskType: model.slice(5) }
+  return { isAuto: false }
+}
+
+/** Build a minimal ModelConfig for a selected model. */
+function buildModelConfig(modelId: string, provider: string): ModelConfig {
+  const config: ModelConfig = {
+    id: modelId,
+    model: modelId,
+    api_key: 'none',
+    tags: [],
+    port: 8080,
+    timeout_ms: 120_000,
+    max_tokens: 4096,
+  }
+
+  switch (provider) {
+    case 'ollama': {
+      const host = process.env.OLLAMA_HOST ?? 'http://localhost:11434'
+      config.base_url = host.endsWith('/v1') ? host : `${host}/v1`
+      break
+    }
+    case 'mlx': {
+      const port = process.env.MLX_PORT ?? '8080'
+      config.base_url = `http://localhost:${port}/v1`
+      break
+    }
+    case 'openrouter':
+      config.base_url = 'https://openrouter.ai/api/v1'
+      config.api_key = process.env.OPENROUTER_API_KEY ?? 'none'
+      break
+    case 'openai':
+      config.base_url = 'https://api.openai.com/v1'
+      config.api_key = process.env.OPENAI_API_KEY ?? 'none'
+      break
+    default: {
+      const host = process.env.OLLAMA_HOST ?? 'http://localhost:11434'
+      config.base_url = host.endsWith('/v1') ? host : `${host}/v1`
+      break
+    }
+  }
+
+  return config
+}
+
+/** Read the full request body as a string. */
+function readBody(req: http.IncomingMessage): Promise<string> {
+  return new Promise((resolve, reject) => {
+    const chunks: Buffer[] = []
+    req.on('data', (chunk: Buffer) => chunks.push(chunk))
+    req.on('end', () => resolve(Buffer.concat(chunks).toString('utf-8')))
+    req.on('error', reject)
+  })
+}
+
+/** Send a JSON response. */
+function sendJson(res: http.ServerResponse, status: number, body: unknown): void {
+  const json = JSON.stringify(body)
+  res.writeHead(status, {
+    'Content-Type': 'application/json',
+    'Access-Control-Allow-Origin': '*',
+  })
+  res.end(json)
+}
+
+/** Handle POST /v1/chat/completions */
+async function handleChatCompletions(
+  req: http.IncomingMessage,
+  res: http.ServerResponse,
+  db: Database.Database
+): Promise<void> {
+  const bodyStr = await readBody(req)
+  let body: Record<string, unknown>
+  try {
+    body = JSON.parse(bodyStr)
+  } catch {
+    sendJson(res, 400, { error: { message: 'Invalid JSON body', type: 'invalid_request_error' } })
+    return
+  }
+
+  const requestedModel = (body.model as string) ?? 'auto'
+  const messages = (body.messages as Array<{ role: string; content: string }>) ?? []
+
+  if (messages.length === 0) {
+    sendJson(res, 400, { error: { message: 'messages array is required', type: 'invalid_request_error' } })
+    return
+  }
+
+  const { isAuto, taskType } = parseAutoModel(requestedModel)
+
+  let modelConfig: ModelConfig
+
+  if (isAuto) {
+    const selected = selectModel(db, {
+      taskType,
+      preferLocal: true,
+    })
+
+    if (!selected) {
+      sendJson(res, 503, { error: { message: 'No models available. Run `verdict run` first.', type: 'server_error' } })
+      return
+    }
+
+    modelConfig = buildModelConfig(selected.modelId, selected.provider)
+  } else {
+    // Look up model in registry to get provider info
+    const row = db.prepare('SELECT provider FROM models_registry WHERE model_id = ?').get(requestedModel) as { provider: string } | undefined
+    const provider = row?.provider ?? 'ollama'
+    modelConfig = buildModelConfig(requestedModel, provider)
+  }
+
+  // Apply max_tokens from request if specified
+  if (typeof body.max_tokens === 'number') {
+    modelConfig.max_tokens = body.max_tokens
+  }
+
+  try {
+    let response
+    if (messages.length === 1 && messages[0].role === 'user') {
+      response = await callModel(modelConfig, messages[0].content)
+    } else {
+      response = await callModelMultiTurn(modelConfig, messages)
+    }
+
+    if (response.error) {
+      sendJson(res, 502, { error: { message: response.error, type: 'upstream_error' } })
+      return
+    }
+
+    // Return OpenAI-compatible response
+    const responseBody = {
+      id: `chatcmpl-${Date.now()}`,
+      object: 'chat.completion',
+      created: Math.floor(Date.now() / 1000),
+      model: modelConfig.id,
+      choices: [{
+        index: 0,
+        message: {
+          role: 'assistant',
+          content: response.text,
+        },
+        finish_reason: 'stop',
+      }],
+      usage: {
+        prompt_tokens: response.input_tokens,
+        completion_tokens: response.output_tokens,
+        total_tokens: response.input_tokens + response.output_tokens,
+      },
+    }
+
+    sendJson(res, 200, responseBody)
+  } catch (err) {
+    sendJson(res, 500, { error: { message: err instanceof Error ? err.message : String(err), type: 'server_error' } })
+  }
+}
+
+/** Handle GET /v1/models */
+function handleListModels(res: http.ServerResponse, db: Database.Database): void {
+  const rows = db.prepare('SELECT model_id, provider, first_seen FROM models_registry ORDER BY model_id').all() as Array<{ model_id: string; provider: string; first_seen: string }>
+
+  const models = rows.map(row => ({
+    id: row.model_id,
+    object: 'model',
+    created: Math.floor(new Date(row.first_seen).getTime() / 1000),
+    owned_by: row.provider ?? 'unknown',
+  }))
+
+  sendJson(res, 200, {
+    object: 'list',
+    data: models,
+  })
+}
+
+export async function serveCommand(opts: ServeCommandOpts): Promise<void> {
+  const port = parseInt(opts.port ?? '4000', 10)
+
+  let db: Database.Database
+  try {
+    db = getDb()
+    initSchema(db)
+  } catch (err) {
+    console.error(chalk.red(`  Failed to open database: ${err instanceof Error ? err.message : err}`))
+    process.exit(1)
+  }
+
+  // Count models by provider
+  const modelRows = db.prepare('SELECT model_id, provider FROM models_registry').all() as Array<{ model_id: string; provider: string | null }>
+  const providerCounts: Record<string, number> = {}
+  for (const row of modelRows) {
+    const p = row.provider ?? 'unknown'
+    providerCounts[p] = (providerCounts[p] ?? 0) + 1
+  }
+
+  const localCount = (providerCounts['ollama'] ?? 0) + (providerCounts['mlx'] ?? 0)
+  const providerBreakdown = Object.entries(providerCounts)
+    .filter(([p]) => p === 'ollama' || p === 'mlx')
+    .map(([p, c]) => `${c} ${p}`)
+    .join(', ')
+
+  const server = http.createServer(async (req, res) => {
+    // Handle CORS preflight
+    if (req.method === 'OPTIONS') {
+      res.writeHead(204, {
+        'Access-Control-Allow-Origin': '*',
+        'Access-Control-Allow-Methods': 'GET, POST, OPTIONS',
+        'Access-Control-Allow-Headers': 'Content-Type, Authorization',
+      })
+      res.end()
+      return
+    }
+
+    const url = new URL(req.url ?? '/', `http://localhost:${port}`)
+
+    try {
+      if (req.method === 'POST' && url.pathname === '/v1/chat/completions') {
+        await handleChatCompletions(req, res, db)
+      } else if (req.method === 'GET' && url.pathname === '/v1/models') {
+        handleListModels(res, db)
+      } else {
+        sendJson(res, 404, { error: { message: 'Not found', type: 'invalid_request_error' } })
+      }
+    } catch (err) {
+      sendJson(res, 500, { error: { message: 'Internal server error', type: 'server_error' } })
+    }
+  })
+
+  server.listen(port, () => {
+    console.log()
+    console.log(chalk.bold(`  verdict serve`) + chalk.dim(` running on http://localhost:${port}`))
+    if (localCount > 0) {
+      console.log(chalk.dim(`  → ${localCount} local models available (${providerBreakdown})`))
+    }
+    console.log(chalk.dim(`  → ${modelRows.length} total models in registry`))
+    console.log(chalk.dim(`  → routing: prefer local, fallback cloud`))
+    console.log(chalk.dim(`  → /v1/chat/completions  (OpenAI-compatible)`))
+    console.log(chalk.dim(`  → /v1/models`))
+    console.log()
+  })
+
+  // Graceful shutdown
+  process.on('SIGINT', () => {
+    server.close()
+    db.close()
+    process.exit(0)
+  })
+  process.on('SIGTERM', () => {
+    server.close()
+    db.close()
+    process.exit(0)
+  })
+}

--- a/src/cli/index.ts
+++ b/src/cli/index.ts
@@ -5,6 +5,9 @@ import { modelsCommand, discoverCommand } from './commands/models.js'
 import { initCommand } from './commands/init.js'
 import { compareCommand } from './commands/compare.js'
 import { baselineSaveCommand, baselineListCommand, baselineCompareCommand } from './commands/baseline.js'
+import { historyCommand } from './commands/history.js'
+import { routeCommand } from './commands/route.js'
+import { serveCommand } from './commands/serve.js'
 
 const program = new Command()
 
@@ -28,6 +31,7 @@ program
   .option('--dry-run', 'Preview without calling any APIs')
   .option('--resume', 'Resume from last checkpoint')
   .option('--question <text>', 'Question for synthesis agent to answer after eval')
+  .option('--no-store', 'Skip persisting results to SQLite database')
   .action(runCommand)
 
 const models = program
@@ -67,5 +71,32 @@ baseline
   .description('Compare most recent run against a named baseline')
   .option('-c, --config <path>', 'Config file', './verdict.yaml')
   .action(baselineCompareCommand)
+
+program
+  .command('history')
+  .description('View eval history from local database')
+  .option('--model <id>', 'Filter by model ID')
+  .option('--pack <name>', 'Filter by eval pack')
+  .option('--since <time>', 'Filter by time (e.g., 7d, 24h, 30d, 1w)')
+  .option('--limit <n>', 'Number of rows to show', '20')
+  .option('--sort <field>', 'Sort by: date (default), score')
+  .option('--trend', 'Show sparkline score trends per model')
+  .action(historyCommand)
+
+program
+  .command('route <prompt>')
+  .description('Route a prompt to the best model based on eval history')
+  .option('--type <type>', 'Task type hint (reasoning, coding, summarize, fast)')
+  .option('--prefer <pref>', 'Prefer model type (local)')
+  .option('--min-score <n>', 'Minimum acceptable score')
+  .option('--dry-run', 'Show selected model without running inference')
+  .option('--model <id>', 'Force a specific model')
+  .action(routeCommand)
+
+program
+  .command('serve')
+  .description('Start OpenAI-compatible HTTP proxy with smart routing')
+  .option('--port <n>', 'Port to listen on', '4000')
+  .action(serveCommand)
 
 program.parse()

--- a/src/db/__tests__/client.test.ts
+++ b/src/db/__tests__/client.test.ts
@@ -1,0 +1,295 @@
+import { describe, it, expect, beforeEach } from 'vitest'
+import Database from 'better-sqlite3'
+import { initSchema, saveRunResult, queryHistory, parseSince } from '../client.js'
+import type { RunResult } from '../../types/index.js'
+
+function createTestDb(): Database.Database {
+  const db = new Database(':memory:')
+  db.pragma('foreign_keys = ON')
+  initSchema(db)
+  return db
+}
+
+function makeRunResult(overrides: Partial<RunResult> = {}): RunResult {
+  return {
+    run_id: 'test-run-1',
+    name: 'Test Run',
+    timestamp: '2026-03-25T12:00:00Z',
+    models: ['qwen2.5:32b', 'llama4:8b'],
+    cases: [
+      {
+        case_id: 'case-1',
+        prompt: 'What is 2+2?',
+        criteria: 'Correct answer',
+        responses: {
+          'qwen2.5:32b': {
+            model_id: 'qwen2.5:32b',
+            text: '4',
+            input_tokens: 10,
+            output_tokens: 5,
+            latency_ms: 1200,
+            cost_usd: 0,
+          },
+          'llama4:8b': {
+            model_id: 'llama4:8b',
+            text: '4',
+            input_tokens: 10,
+            output_tokens: 5,
+            latency_ms: 800,
+            cost_usd: 0,
+          },
+        },
+        scores: {
+          'qwen2.5:32b': { accuracy: 10, completeness: 10, conciseness: 10, total: 9.2, reasoning: 'Correct' },
+          'llama4:8b': { accuracy: 8, completeness: 9, conciseness: 9, total: 8.7, reasoning: 'Correct' },
+        },
+        winner: 'qwen2.5:32b',
+      },
+    ],
+    summary: {
+      'qwen2.5:32b': {
+        model_id: 'qwen2.5:32b',
+        avg_total: 9.2,
+        avg_accuracy: 10,
+        avg_completeness: 10,
+        avg_conciseness: 10,
+        avg_latency_ms: 1200,
+        total_cost_usd: 0,
+        win_rate: 100,
+        wins: 1,
+        cases_run: 1,
+      },
+      'llama4:8b': {
+        model_id: 'llama4:8b',
+        avg_total: 8.7,
+        avg_accuracy: 8,
+        avg_completeness: 9,
+        avg_conciseness: 9,
+        avg_latency_ms: 800,
+        total_cost_usd: 0,
+        win_rate: 0,
+        wins: 0,
+        cases_run: 1,
+      },
+    },
+    ...overrides,
+  }
+}
+
+describe('client', () => {
+  let db: Database.Database
+
+  beforeEach(() => {
+    db = createTestDb()
+  })
+
+  describe('initSchema', () => {
+    it('creates tables without errors', () => {
+      const tables = db.prepare(
+        "SELECT name FROM sqlite_master WHERE type='table' AND name NOT LIKE 'sqlite_%'"
+      ).all() as Array<{ name: string }>
+      expect(tables.length).toBeGreaterThanOrEqual(3)
+    })
+  })
+
+  describe('saveRunResult', () => {
+    it('inserts eval_results rows for each model', () => {
+      const result = makeRunResult()
+      saveRunResult(db, result, 'general')
+
+      const rows = db.prepare('SELECT * FROM eval_results ORDER BY model_id').all() as Array<Record<string, unknown>>
+      expect(rows.length).toBe(2)
+      expect(rows[0].model_id).toBe('llama4:8b')
+      expect(rows[1].model_id).toBe('qwen2.5:32b')
+      expect(rows[1].score).toBe(9.2)
+      expect(rows[1].pack).toBe('general')
+    })
+
+    it('inserts question_results for each case per model', () => {
+      const result = makeRunResult()
+      saveRunResult(db, result, 'general')
+
+      const rows = db.prepare('SELECT * FROM question_results ORDER BY model_id').all() as Array<Record<string, unknown>>
+      expect(rows.length).toBe(2) // 1 case * 2 models
+      expect(rows[0].case_id).toBe('case-1')
+    })
+
+    it('upserts models_registry entries', () => {
+      const result = makeRunResult()
+      saveRunResult(db, result, 'general')
+
+      const rows = db.prepare('SELECT * FROM models_registry ORDER BY model_id').all() as Array<Record<string, unknown>>
+      expect(rows.length).toBe(2)
+
+      const qwen = rows.find(r => r.model_id === 'qwen2.5:32b')
+      expect(qwen).toBeDefined()
+      expect(qwen!.total_runs).toBe(1)
+      expect(qwen!.best_score).toBe(9.2)
+    })
+
+    it('increments total_runs on subsequent saves', () => {
+      const result1 = makeRunResult()
+      saveRunResult(db, result1, 'general')
+
+      const result2 = makeRunResult({ run_id: 'test-run-2' })
+      saveRunResult(db, result2, 'general')
+
+      const row = db.prepare("SELECT * FROM models_registry WHERE model_id = 'qwen2.5:32b'").get() as Record<string, unknown>
+      expect(row.total_runs).toBe(2)
+    })
+
+    it('updates best_score when a higher score is achieved', () => {
+      const result1 = makeRunResult()
+      saveRunResult(db, result1, 'general')
+
+      const result2 = makeRunResult({
+        run_id: 'test-run-2',
+        summary: {
+          'qwen2.5:32b': {
+            model_id: 'qwen2.5:32b',
+            avg_total: 9.8,
+            avg_accuracy: 10,
+            avg_completeness: 10,
+            avg_conciseness: 10,
+            avg_latency_ms: 1100,
+            total_cost_usd: 0,
+            win_rate: 100,
+            wins: 1,
+            cases_run: 1,
+          },
+          'llama4:8b': {
+            model_id: 'llama4:8b',
+            avg_total: 8.7,
+            avg_accuracy: 8,
+            avg_completeness: 9,
+            avg_conciseness: 9,
+            avg_latency_ms: 800,
+            total_cost_usd: 0,
+            win_rate: 0,
+            wins: 0,
+            cases_run: 1,
+          },
+        },
+      })
+      saveRunResult(db, result2, 'general')
+
+      const row = db.prepare("SELECT * FROM models_registry WHERE model_id = 'qwen2.5:32b'").get() as Record<string, unknown>
+      expect(row.best_score).toBe(9.8)
+    })
+
+    it('handles multiple models correctly', () => {
+      const result = makeRunResult()
+      saveRunResult(db, result, 'general')
+
+      const evalCount = (db.prepare('SELECT COUNT(*) as count FROM eval_results').get() as { count: number }).count
+      const questionCount = (db.prepare('SELECT COUNT(*) as count FROM question_results').get() as { count: number }).count
+      const registryCount = (db.prepare('SELECT COUNT(*) as count FROM models_registry').get() as { count: number }).count
+
+      expect(evalCount).toBe(2)
+      expect(questionCount).toBe(2)
+      expect(registryCount).toBe(2)
+    })
+  })
+
+  describe('queryHistory', () => {
+    beforeEach(() => {
+      saveRunResult(db, makeRunResult(), 'general')
+      saveRunResult(db, makeRunResult({
+        run_id: 'test-run-2',
+        timestamp: '2026-03-24T12:00:00Z',
+      }), 'reasoning')
+    })
+
+    it('returns all rows with default options', () => {
+      const rows = queryHistory(db, {})
+      expect(rows.length).toBe(4) // 2 models * 2 runs
+    })
+
+    it('filters by model', () => {
+      const rows = queryHistory(db, { modelId: 'qwen2.5:32b' })
+      expect(rows.length).toBe(2)
+      expect(rows.every(r => r.model_id === 'qwen2.5:32b')).toBe(true)
+    })
+
+    it('filters by pack', () => {
+      const rows = queryHistory(db, { pack: 'reasoning' })
+      expect(rows.length).toBe(2)
+      expect(rows.every(r => r.pack === 'reasoning')).toBe(true)
+    })
+
+    it('respects limit', () => {
+      const rows = queryHistory(db, { limit: 2 })
+      expect(rows.length).toBe(2)
+    })
+
+    it('sorts by score descending', () => {
+      const rows = queryHistory(db, { orderBy: 'score' })
+      for (let i = 1; i < rows.length; i++) {
+        expect(rows[i - 1].score).toBeGreaterThanOrEqual(rows[i].score)
+      }
+    })
+
+    it('sorts by date descending by default', () => {
+      const rows = queryHistory(db, {})
+      for (let i = 1; i < rows.length; i++) {
+        expect(rows[i - 1].run_at >= rows[i].run_at).toBe(true)
+      }
+    })
+
+    it('filters by since (time-based)', () => {
+      // Save a very old result
+      saveRunResult(db, makeRunResult({
+        run_id: 'old-run',
+        timestamp: '2020-01-01T00:00:00Z',
+      }), 'general')
+
+      const rows = queryHistory(db, { since: '7d' })
+      // Should exclude the old run
+      expect(rows.every(r => r.run_at > '2020-01-01')).toBe(true)
+    })
+  })
+
+  describe('parseSince', () => {
+    it('parses hours', () => {
+      const result = parseSince('24h')
+      expect(result).toBeInstanceOf(Date)
+      const now = new Date()
+      const diff = now.getTime() - result!.getTime()
+      // Should be approximately 24 hours (allow 1 minute tolerance)
+      expect(diff).toBeGreaterThan(23 * 60 * 60 * 1000)
+      expect(diff).toBeLessThan(25 * 60 * 60 * 1000)
+    })
+
+    it('parses days', () => {
+      const result = parseSince('7d')
+      expect(result).toBeInstanceOf(Date)
+      const now = new Date()
+      const diff = now.getTime() - result!.getTime()
+      expect(diff).toBeGreaterThan(6 * 24 * 60 * 60 * 1000)
+      expect(diff).toBeLessThan(8 * 24 * 60 * 60 * 1000)
+    })
+
+    it('parses weeks', () => {
+      const result = parseSince('1w')
+      expect(result).toBeInstanceOf(Date)
+      const now = new Date()
+      const diff = now.getTime() - result!.getTime()
+      expect(diff).toBeGreaterThan(6 * 24 * 60 * 60 * 1000)
+      expect(diff).toBeLessThan(8 * 24 * 60 * 60 * 1000)
+    })
+
+    it('returns null for invalid format', () => {
+      expect(parseSince('abc')).toBeNull()
+      expect(parseSince('7m')).toBeNull()
+      expect(parseSince('')).toBeNull()
+    })
+
+    it('handles 30d correctly', () => {
+      const result = parseSince('30d')
+      expect(result).toBeInstanceOf(Date)
+      const now = new Date()
+      const diff = now.getTime() - result!.getTime()
+      expect(diff).toBeGreaterThan(29 * 24 * 60 * 60 * 1000)
+    })
+  })
+})

--- a/src/db/__tests__/schema.test.ts
+++ b/src/db/__tests__/schema.test.ts
@@ -1,0 +1,90 @@
+import { describe, it, expect, beforeEach } from 'vitest'
+import Database from 'better-sqlite3'
+import { initSchema } from '../client.js'
+
+describe('schema', () => {
+  let db: Database.Database
+
+  beforeEach(() => {
+    db = new Database(':memory:')
+    db.pragma('foreign_keys = ON')
+    initSchema(db)
+  })
+
+  it('creates all three tables', () => {
+    const tables = db.prepare(
+      "SELECT name FROM sqlite_master WHERE type='table' AND name NOT LIKE 'sqlite_%' ORDER BY name"
+    ).all() as Array<{ name: string }>
+
+    const names = tables.map(t => t.name)
+    expect(names).toContain('eval_results')
+    expect(names).toContain('question_results')
+    expect(names).toContain('models_registry')
+  })
+
+  it('eval_results has correct columns', () => {
+    const cols = db.prepare('PRAGMA table_info(eval_results)').all() as Array<{ name: string; type: string }>
+    const colNames = cols.map(c => c.name)
+    expect(colNames).toEqual(expect.arrayContaining([
+      'id', 'run_id', 'name', 'model_id', 'provider', 'pack',
+      'score', 'max_score', 'cases_run', 'wins', 'avg_latency_ms',
+      'total_cost_usd', 'tokens_per_sec', 'run_at',
+    ]))
+  })
+
+  it('question_results has correct columns', () => {
+    const cols = db.prepare('PRAGMA table_info(question_results)').all() as Array<{ name: string }>
+    const colNames = cols.map(c => c.name)
+    expect(colNames).toEqual(expect.arrayContaining([
+      'id', 'eval_result_id', 'case_id', 'prompt', 'model_id',
+      'score', 'latency_ms', 'response', 'input_tokens', 'output_tokens',
+    ]))
+  })
+
+  it('models_registry has correct columns', () => {
+    const cols = db.prepare('PRAGMA table_info(models_registry)').all() as Array<{ name: string }>
+    const colNames = cols.map(c => c.name)
+    expect(colNames).toEqual(expect.arrayContaining([
+      'id', 'model_id', 'provider', 'first_seen', 'last_eval_at',
+      'best_score', 'best_pack', 'avg_tokens_per_sec', 'total_runs',
+    ]))
+  })
+
+  it('enforces UNIQUE constraint on models_registry.model_id', () => {
+    db.prepare("INSERT INTO models_registry (model_id, provider) VALUES ('test-model', 'ollama')").run()
+    expect(() => {
+      db.prepare("INSERT INTO models_registry (model_id, provider) VALUES ('test-model', 'mlx')").run()
+    }).toThrow(/UNIQUE constraint/)
+  })
+
+  it('enforces foreign key constraint: question_results → eval_results', () => {
+    expect(() => {
+      db.prepare(
+        "INSERT INTO question_results (eval_result_id, case_id, model_id, score) VALUES (9999, 'case-1', 'model-1', 8.5)"
+      ).run()
+    }).toThrow(/FOREIGN KEY/)
+  })
+
+  it('cascade deletes question_results when eval_results row is deleted', () => {
+    const info = db.prepare(
+      "INSERT INTO eval_results (run_id, model_id, pack, score, cases_run, run_at) VALUES ('run-1', 'model-1', 'general', 9.0, 1, '2026-03-25T12:00:00Z')"
+    ).run()
+    const evalId = info.lastInsertRowid
+
+    db.prepare(
+      "INSERT INTO question_results (eval_result_id, case_id, model_id, score) VALUES (?, 'case-1', 'model-1', 9.0)"
+    ).run(evalId)
+
+    const before = db.prepare('SELECT COUNT(*) as count FROM question_results').get() as { count: number }
+    expect(before.count).toBe(1)
+
+    db.prepare('DELETE FROM eval_results WHERE id = ?').run(evalId)
+
+    const after = db.prepare('SELECT COUNT(*) as count FROM question_results').get() as { count: number }
+    expect(after.count).toBe(0)
+  })
+
+  it('is idempotent — running initSchema twice does not error', () => {
+    expect(() => initSchema(db)).not.toThrow()
+  })
+})

--- a/src/db/client.ts
+++ b/src/db/client.ts
@@ -1,0 +1,235 @@
+/**
+ * SQLite database connection and helper methods for verdict persistence.
+ * Uses better-sqlite3 synchronous API for simplicity.
+ */
+
+import Database from 'better-sqlite3'
+import path from 'path'
+import fs from 'fs'
+import os from 'os'
+import { ALL_SCHEMAS } from './schema.js'
+import type { RunResult } from '../types/index.js'
+
+/** Options for querying eval history. */
+export interface HistoryOpts {
+  modelId?: string
+  pack?: string
+  since?: string
+  limit?: number
+  orderBy?: 'score' | 'date'
+}
+
+/** A row returned from the eval history query. */
+export interface EvalHistoryRow {
+  run_id: string
+  name: string | null
+  model_id: string
+  provider: string | null
+  pack: string
+  score: number
+  max_score: number
+  cases_run: number
+  wins: number
+  avg_latency_ms: number | null
+  total_cost_usd: number | null
+  tokens_per_sec: number | null
+  run_at: string
+}
+
+/**
+ * Opens or creates the verdict SQLite database.
+ * Database location: ~/.verdict/results.db
+ */
+export function getDb(dbPath?: string): Database.Database {
+  const resolvedPath = dbPath ?? path.join(os.homedir(), '.verdict', 'results.db')
+  const dir = path.dirname(resolvedPath)
+  if (!fs.existsSync(dir)) {
+    fs.mkdirSync(dir, { recursive: true })
+  }
+  const db = new Database(resolvedPath)
+  db.pragma('journal_mode = WAL')
+  db.pragma('foreign_keys = ON')
+  return db
+}
+
+/** Runs all CREATE TABLE IF NOT EXISTS statements. */
+export function initSchema(db: Database.Database): void {
+  for (const sql of ALL_SCHEMAS) {
+    db.exec(sql)
+  }
+}
+
+/**
+ * Persists a full RunResult to the database.
+ * Inserts into eval_results, question_results, and upserts models_registry.
+ */
+export function saveRunResult(db: Database.Database, result: RunResult, pack: string): void {
+  const insertEvalResult = db.prepare(`
+    INSERT INTO eval_results (run_id, name, model_id, provider, pack, score, max_score, cases_run, wins, avg_latency_ms, total_cost_usd, tokens_per_sec, run_at)
+    VALUES (@run_id, @name, @model_id, @provider, @pack, @score, @max_score, @cases_run, @wins, @avg_latency_ms, @total_cost_usd, @tokens_per_sec, @run_at)
+  `)
+
+  const insertQuestionResult = db.prepare(`
+    INSERT INTO question_results (eval_result_id, case_id, prompt, model_id, score, latency_ms, response, input_tokens, output_tokens)
+    VALUES (@eval_result_id, @case_id, @prompt, @model_id, @score, @latency_ms, @response, @input_tokens, @output_tokens)
+  `)
+
+  const upsertModel = db.prepare(`
+    INSERT INTO models_registry (model_id, provider, first_seen, last_eval_at, best_score, best_pack, total_runs)
+    VALUES (@model_id, @provider, @last_eval_at, @last_eval_at, @best_score, @best_pack, 1)
+    ON CONFLICT(model_id) DO UPDATE SET
+      provider = COALESCE(@provider, provider),
+      last_eval_at = @last_eval_at,
+      best_score = MAX(COALESCE(best_score, 0), @best_score),
+      best_pack = CASE WHEN @best_score > COALESCE(best_score, 0) THEN @best_pack ELSE best_pack END,
+      total_runs = total_runs + 1
+  `)
+
+  const runAt = result.timestamp
+
+  const saveAll = db.transaction(() => {
+    for (const modelId of result.models) {
+      const summary = result.summary[modelId]
+      if (!summary) continue
+
+      // Detect provider from model_id pattern
+      const provider = detectProvider(modelId)
+
+      // Calculate tokens/sec from case data
+      let totalTokens = 0
+      let totalLatencyS = 0
+      for (const c of result.cases) {
+        const resp = c.responses[modelId]
+        if (resp && !resp.error) {
+          totalTokens += resp.output_tokens
+          totalLatencyS += resp.latency_ms / 1000
+        }
+      }
+      const tokensPerSec = totalLatencyS > 0 ? totalTokens / totalLatencyS : null
+
+      const evalInfo = insertEvalResult.run({
+        run_id: result.run_id,
+        name: result.name,
+        model_id: modelId,
+        provider,
+        pack,
+        score: summary.avg_total,
+        max_score: 10,
+        cases_run: summary.cases_run,
+        wins: summary.wins,
+        avg_latency_ms: summary.avg_latency_ms,
+        total_cost_usd: summary.total_cost_usd,
+        tokens_per_sec: tokensPerSec,
+        run_at: runAt,
+      })
+
+      const evalResultId = evalInfo.lastInsertRowid
+
+      // Insert individual question results
+      for (const c of result.cases) {
+        const resp = c.responses[modelId]
+        const score = c.scores[modelId]
+        if (!resp || !score) continue
+
+        insertQuestionResult.run({
+          eval_result_id: evalResultId,
+          case_id: c.case_id,
+          prompt: c.prompt,
+          model_id: modelId,
+          score: score.total,
+          latency_ms: resp.latency_ms,
+          response: resp.text,
+          input_tokens: resp.input_tokens,
+          output_tokens: resp.output_tokens,
+        })
+      }
+
+      // Upsert models registry
+      upsertModel.run({
+        model_id: modelId,
+        provider,
+        last_eval_at: runAt,
+        best_score: summary.avg_total,
+        best_pack: pack,
+      })
+    }
+  })
+
+  saveAll()
+}
+
+/**
+ * Flexible query builder for eval history.
+ * Supports filtering by model, pack, date range, and sorting.
+ */
+export function queryHistory(db: Database.Database, opts: HistoryOpts): EvalHistoryRow[] {
+  const conditions: string[] = []
+  const params: Record<string, string | number> = {}
+
+  if (opts.modelId) {
+    conditions.push('model_id = @modelId')
+    params.modelId = opts.modelId
+  }
+
+  if (opts.pack) {
+    conditions.push('pack = @pack')
+    params.pack = opts.pack
+  }
+
+  if (opts.since) {
+    const sinceDate = parseSince(opts.since)
+    if (sinceDate) {
+      conditions.push('run_at >= @since')
+      params.since = sinceDate.toISOString()
+    }
+  }
+
+  const where = conditions.length > 0 ? `WHERE ${conditions.join(' AND ')}` : ''
+  const orderBy = opts.orderBy === 'score' ? 'score DESC' : 'run_at DESC'
+  const limit = opts.limit ?? 20
+
+  const sql = `SELECT run_id, name, model_id, provider, pack, score, max_score, cases_run, wins, avg_latency_ms, total_cost_usd, tokens_per_sec, run_at FROM eval_results ${where} ORDER BY ${orderBy} LIMIT @limit`
+  params.limit = limit
+
+  return db.prepare(sql).all(params) as EvalHistoryRow[]
+}
+
+/** Detect provider from model id conventions. */
+function detectProvider(modelId: string): string | null {
+  const lower = modelId.toLowerCase()
+  if (lower.includes('ollama') || lower.includes(':')) return 'ollama'
+  if (lower.includes('mlx')) return 'mlx'
+  if (lower.includes('openrouter')) return 'openrouter'
+  if (lower.includes('gpt') || lower.includes('o1') || lower.includes('o3')) return 'openai'
+  if (lower.includes('claude')) return 'anthropic'
+  if (lower.includes('groq')) return 'groq'
+  if (lower.includes('sonar')) return 'openrouter'
+  return null
+}
+
+/**
+ * Parse a relative time string like "7d", "24h", "30d", "1w" into a Date.
+ * Returns null if the format is not recognized.
+ */
+export function parseSince(since: string): Date | null {
+  const match = since.match(/^(\d+)(h|d|w)$/)
+  if (!match) return null
+
+  const amount = parseInt(match[1], 10)
+  const unit = match[2]
+  const now = new Date()
+
+  switch (unit) {
+    case 'h':
+      now.setHours(now.getHours() - amount)
+      break
+    case 'd':
+      now.setDate(now.getDate() - amount)
+      break
+    case 'w':
+      now.setDate(now.getDate() - amount * 7)
+      break
+  }
+
+  return now
+}

--- a/src/db/schema.ts
+++ b/src/db/schema.ts
@@ -1,0 +1,57 @@
+/**
+ * SQLite schema definitions for verdict persistence layer.
+ * Uses better-sqlite3 synchronous API.
+ */
+
+/** SQL statements to create the verdict database schema. */
+export const CREATE_EVAL_RESULTS = `
+CREATE TABLE IF NOT EXISTS eval_results (
+  id INTEGER PRIMARY KEY AUTOINCREMENT,
+  run_id TEXT NOT NULL,
+  name TEXT,
+  model_id TEXT NOT NULL,
+  provider TEXT,
+  pack TEXT NOT NULL,
+  score REAL NOT NULL,
+  max_score REAL NOT NULL DEFAULT 10,
+  cases_run INTEGER NOT NULL DEFAULT 0,
+  wins INTEGER NOT NULL DEFAULT 0,
+  avg_latency_ms REAL,
+  total_cost_usd REAL DEFAULT 0,
+  tokens_per_sec REAL,
+  run_at TEXT NOT NULL
+)` as const
+
+export const CREATE_QUESTION_RESULTS = `
+CREATE TABLE IF NOT EXISTS question_results (
+  id INTEGER PRIMARY KEY AUTOINCREMENT,
+  eval_result_id INTEGER NOT NULL REFERENCES eval_results(id) ON DELETE CASCADE,
+  case_id TEXT NOT NULL,
+  prompt TEXT,
+  model_id TEXT NOT NULL,
+  score REAL NOT NULL,
+  latency_ms REAL,
+  response TEXT,
+  input_tokens INTEGER,
+  output_tokens INTEGER
+)` as const
+
+export const CREATE_MODELS_REGISTRY = `
+CREATE TABLE IF NOT EXISTS models_registry (
+  id INTEGER PRIMARY KEY AUTOINCREMENT,
+  model_id TEXT UNIQUE NOT NULL,
+  provider TEXT,
+  first_seen TEXT NOT NULL DEFAULT '',
+  last_eval_at TEXT,
+  best_score REAL,
+  best_pack TEXT,
+  avg_tokens_per_sec REAL,
+  total_runs INTEGER DEFAULT 0
+)` as const
+
+/** All schema creation statements in order. */
+export const ALL_SCHEMAS = [
+  CREATE_EVAL_RESULTS,
+  CREATE_QUESTION_RESULTS,
+  CREATE_MODELS_REGISTRY,
+] as const

--- a/src/judge/__tests__/deterministic.test.ts
+++ b/src/judge/__tests__/deterministic.test.ts
@@ -1,0 +1,277 @@
+import { describe, it, expect } from 'vitest'
+import {
+  scoreJson,
+  scoreExact,
+  scoreContains,
+  scoreToolCall,
+  scoreJsonSchema,
+  isDeterministic,
+  scoreDeterministic,
+} from '../deterministic.js'
+
+describe('deterministic scorers', () => {
+  describe('scoreJson', () => {
+    it('scores valid JSON as 10/10', () => {
+      const result = scoreJson('{"key": "value"}')
+      expect(result.total).toBe(10)
+    })
+
+    it('scores valid JSON array as 10/10', () => {
+      const result = scoreJson('[1, 2, 3]')
+      expect(result.total).toBe(10)
+    })
+
+    it('scores JSON with markdown fences as 10/10', () => {
+      const result = scoreJson('```json\n{"key": "value"}\n```')
+      expect(result.total).toBe(10)
+    })
+
+    it('gives partial credit for malformed JSON-like output', () => {
+      const result = scoreJson('{key: value}')
+      expect(result.total).toBe(2)
+    })
+
+    it('scores non-JSON as 0/10', () => {
+      const result = scoreJson('This is plain text')
+      expect(result.total).toBe(0)
+    })
+
+    it('handles empty string', () => {
+      const result = scoreJson('')
+      expect(result.total).toBe(0)
+    })
+
+    it('handles whitespace-only input', () => {
+      const result = scoreJson('   \n\t  ')
+      expect(result.total).toBe(0)
+    })
+  })
+
+  describe('scoreExact', () => {
+    it('scores exact match as 10/10', () => {
+      const result = scoreExact('hello world', 'hello world')
+      expect(result.total).toBe(10)
+    })
+
+    it('is case-insensitive', () => {
+      const result = scoreExact('Hello World', 'hello world')
+      expect(result.total).toBe(10)
+    })
+
+    it('trims whitespace', () => {
+      const result = scoreExact('  hello  ', 'hello')
+      expect(result.total).toBe(10)
+    })
+
+    it('scores mismatch as 0/10', () => {
+      const result = scoreExact('hello', 'goodbye')
+      expect(result.total).toBe(0)
+    })
+
+    it('includes expected vs actual in reasoning on failure', () => {
+      const result = scoreExact('got', 'want')
+      expect(result.reasoning).toContain('want')
+      expect(result.reasoning).toContain('got')
+    })
+  })
+
+  describe('scoreContains', () => {
+    it('scores substring match as 10/10', () => {
+      const result = scoreContains('The answer is 42 and more', '42')
+      expect(result.total).toBe(10)
+    })
+
+    it('is case-insensitive', () => {
+      const result = scoreContains('Hello World', 'hello')
+      expect(result.total).toBe(10)
+    })
+
+    it('scores missing substring as 0/10', () => {
+      const result = scoreContains('Hello World', 'goodbye')
+      expect(result.total).toBe(0)
+    })
+
+    it('handles empty expected', () => {
+      const result = scoreContains('anything', '')
+      expect(result.total).toBe(10)
+    })
+  })
+
+  describe('scoreToolCall', () => {
+    it('scores no tool calls as 0/10', () => {
+      const result = scoreToolCall(undefined, 'get_weather')
+      expect(result.total).toBe(0)
+    })
+
+    it('scores empty tool calls as 0/10', () => {
+      const result = scoreToolCall([], 'get_weather')
+      expect(result.total).toBe(0)
+    })
+
+    it('scores wrong tool as 2/10', () => {
+      const result = scoreToolCall(
+        [{ name: 'wrong_tool', arguments: {} }],
+        'get_weather'
+      )
+      expect(result.total).toBe(2)
+    })
+
+    it('scores correct tool with no expected args as 6/10', () => {
+      const result = scoreToolCall(
+        [{ name: 'get_weather', arguments: { city: 'NYC' } }],
+        'get_weather'
+      )
+      expect(result.total).toBe(6)
+    })
+
+    it('scores correct tool with correct args as 10/10', () => {
+      const result = scoreToolCall(
+        [{ name: 'get_weather', arguments: { city: 'NYC', unit: 'celsius' } }],
+        'get_weather',
+        { city: 'NYC', unit: 'celsius' }
+      )
+      expect(result.total).toBe(10)
+    })
+
+    it('scores correct tool with partial args correctly', () => {
+      const result = scoreToolCall(
+        [{ name: 'get_weather', arguments: { city: 'NYC', unit: 'fahrenheit' } }],
+        'get_weather',
+        { city: 'NYC', unit: 'celsius' }
+      )
+      // 4 (correct tool) + 2 (valid format) + 2 (city correct) = 8
+      expect(result.total).toBe(8)
+    })
+
+    it('caps arg points at 4', () => {
+      const result = scoreToolCall(
+        [{ name: 'fn', arguments: { a: 1, b: 2, c: 3, d: 4 } }],
+        'fn',
+        { a: 1, b: 2, c: 3, d: 4 }
+      )
+      // 4 + 2 + min(4, 8) = 10
+      expect(result.total).toBe(10)
+    })
+  })
+
+  describe('scoreJsonSchema', () => {
+    it('scores valid matching schema as 10/10', () => {
+      const output = '{"name": "John", "age": 30}'
+      const schema = {
+        type: 'object',
+        required: ['name', 'age'],
+        properties: {
+          name: { type: 'string' },
+          age: { type: 'number' },
+        },
+      }
+      const result = scoreJsonSchema(output, schema)
+      expect(result.total).toBe(10)
+    })
+
+    it('deducts 2pts per missing required field', () => {
+      const output = '{"name": "John"}'
+      const schema = {
+        required: ['name', 'age', 'email'],
+        properties: {
+          name: { type: 'string' },
+          age: { type: 'number' },
+          email: { type: 'string' },
+        },
+      }
+      const result = scoreJsonSchema(output, schema)
+      // Missing age and email: 10 - 4 = 6
+      expect(result.total).toBe(6)
+    })
+
+    it('deducts 1pt per wrong type', () => {
+      const output = '{"name": 123, "age": "thirty"}'
+      const schema = {
+        required: ['name', 'age'],
+        properties: {
+          name: { type: 'string' },
+          age: { type: 'number' },
+        },
+      }
+      const result = scoreJsonSchema(output, schema)
+      // 2 wrong types: 10 - 2 = 8
+      expect(result.total).toBe(8)
+    })
+
+    it('scores invalid JSON as 0/10', () => {
+      const result = scoreJsonSchema('not json', {})
+      expect(result.total).toBe(0)
+    })
+
+    it('scores non-object JSON as 0/10', () => {
+      const result = scoreJsonSchema('[1, 2, 3]', {})
+      expect(result.total).toBe(0)
+    })
+
+    it('handles JSON with markdown fences', () => {
+      const output = '```json\n{"name": "John"}\n```'
+      const schema = {
+        required: ['name'],
+        properties: { name: { type: 'string' } },
+      }
+      const result = scoreJsonSchema(output, schema)
+      expect(result.total).toBe(10)
+    })
+
+    it('does not go below 0', () => {
+      const output = '{}'
+      const schema = {
+        required: ['a', 'b', 'c', 'd', 'e', 'f'],
+        properties: {},
+      }
+      const result = scoreJsonSchema(output, schema)
+      expect(result.total).toBe(0)
+    })
+  })
+
+  describe('isDeterministic', () => {
+    it('returns true for deterministic scorers', () => {
+      expect(isDeterministic('json')).toBe(true)
+      expect(isDeterministic('exact')).toBe(true)
+      expect(isDeterministic('contains')).toBe(true)
+      expect(isDeterministic('jsonschema')).toBe(true)
+      expect(isDeterministic('tool_call')).toBe(true)
+    })
+
+    it('returns false for non-deterministic scorers', () => {
+      expect(isDeterministic('llm')).toBe(false)
+      expect(isDeterministic('unknown')).toBe(false)
+    })
+  })
+
+  describe('scoreDeterministic', () => {
+    it('dispatches to scoreJson', () => {
+      const result = scoreDeterministic('json', '{"key": "value"}')
+      expect(result).not.toBeNull()
+      expect(result!.total).toBe(10)
+    })
+
+    it('dispatches to scoreExact', () => {
+      const result = scoreDeterministic('exact', 'hello', 'hello')
+      expect(result).not.toBeNull()
+      expect(result!.total).toBe(10)
+    })
+
+    it('dispatches to scoreContains', () => {
+      const result = scoreDeterministic('contains', 'hello world', 'world')
+      expect(result).not.toBeNull()
+      expect(result!.total).toBe(10)
+    })
+
+    it('dispatches to scoreJsonSchema', () => {
+      const result = scoreDeterministic('jsonschema', '{"a": 1}', undefined, { required: ['a'], properties: { a: { type: 'number' } } })
+      expect(result).not.toBeNull()
+      expect(result!.total).toBe(10)
+    })
+
+    it('returns null for unknown scorer', () => {
+      const result = scoreDeterministic('llm', 'text')
+      expect(result).toBeNull()
+    })
+  })
+})

--- a/src/router/__tests__/selector.test.ts
+++ b/src/router/__tests__/selector.test.ts
@@ -1,0 +1,115 @@
+import { describe, it, expect, beforeEach } from 'vitest'
+import Database from 'better-sqlite3'
+import { initSchema, saveRunResult } from '../../db/client.js'
+import { selectModel } from '../selector.js'
+import type { RunResult } from '../../types/index.js'
+
+function createTestDb(): Database.Database {
+  const db = new Database(':memory:')
+  db.pragma('foreign_keys = ON')
+  initSchema(db)
+  return db
+}
+
+function seedDb(db: Database.Database): void {
+  // Insert eval results directly for more control
+  db.prepare(`
+    INSERT INTO eval_results (run_id, model_id, provider, pack, score, cases_run, wins, avg_latency_ms, total_cost_usd, run_at)
+    VALUES ('run-1', 'qwen2.5:32b', 'ollama', 'general', 9.2, 5, 4, 1200, 0, '2026-03-25T12:00:00Z')
+  `).run()
+
+  db.prepare(`
+    INSERT INTO eval_results (run_id, model_id, provider, pack, score, cases_run, wins, avg_latency_ms, total_cost_usd, run_at)
+    VALUES ('run-1', 'llama4:8b', 'ollama', 'general', 8.7, 5, 1, 800, 0, '2026-03-25T12:00:00Z')
+  `).run()
+
+  db.prepare(`
+    INSERT INTO eval_results (run_id, model_id, provider, pack, score, cases_run, wins, avg_latency_ms, total_cost_usd, run_at)
+    VALUES ('run-1', 'sonar-pro', 'openrouter', 'general', 9.6, 5, 5, 3200, 0.04, '2026-03-25T12:00:00Z')
+  `).run()
+
+  db.prepare(`
+    INSERT INTO eval_results (run_id, model_id, provider, pack, score, cases_run, wins, avg_latency_ms, total_cost_usd, run_at)
+    VALUES ('run-2', 'qwen2.5:32b', 'ollama', 'reasoning', 8.5, 3, 2, 1500, 0, '2026-03-24T12:00:00Z')
+  `).run()
+
+  db.prepare(`
+    INSERT INTO eval_results (run_id, model_id, provider, pack, score, cases_run, wins, avg_latency_ms, total_cost_usd, run_at)
+    VALUES ('run-2', 'mlx-phi3', 'mlx', 'reasoning', 7.2, 3, 0, 600, 0, '2026-03-24T12:00:00Z')
+  `).run()
+}
+
+describe('selectModel', () => {
+  let db: Database.Database
+
+  beforeEach(() => {
+    db = createTestDb()
+    seedDb(db)
+  })
+
+  it('selects the highest scoring model by default', () => {
+    const result = selectModel(db, {})
+    expect(result).not.toBeNull()
+    expect(result!.modelId).toBe('sonar-pro')
+    expect(result!.score).toBe(9.6)
+  })
+
+  it('filters by pack when packHint is given', () => {
+    const result = selectModel(db, { packHint: 'reasoning' })
+    expect(result).not.toBeNull()
+    expect(result!.modelId).toBe('qwen2.5:32b')
+    // avg of 8.5 on reasoning
+    expect(result!.score).toBe(8.5)
+  })
+
+  it('filters to local models when preferLocal is true', () => {
+    const result = selectModel(db, { preferLocal: true })
+    expect(result).not.toBeNull()
+    // sonar-pro is openrouter, should not be returned
+    expect(result!.modelId).not.toBe('sonar-pro')
+    expect(['ollama', 'mlx']).toContain(result!.provider)
+  })
+
+  it('applies minScore threshold', () => {
+    const result = selectModel(db, { minScore: 9.5 })
+    expect(result).not.toBeNull()
+    expect(result!.modelId).toBe('sonar-pro')
+    expect(result!.score).toBeGreaterThanOrEqual(9.5)
+  })
+
+  it('returns null when minScore excludes all models', () => {
+    const result = selectModel(db, { minScore: 99 })
+    expect(result).toBeNull()
+  })
+
+  it('excludes specified models', () => {
+    const result = selectModel(db, { excludeModels: ['sonar-pro'] })
+    expect(result).not.toBeNull()
+    expect(result!.modelId).not.toBe('sonar-pro')
+  })
+
+  it('maps taskType to pack correctly', () => {
+    const result = selectModel(db, { taskType: 'reasoning' })
+    expect(result).not.toBeNull()
+    // Should only look at reasoning pack results
+    expect(result!.modelId).toBe('qwen2.5:32b')
+  })
+
+  it('returns null when no data in DB', () => {
+    const emptyDb = createTestDb()
+    const result = selectModel(emptyDb, {})
+    expect(result).toBeNull()
+  })
+
+  it('includes reason string with score info', () => {
+    const result = selectModel(db, {})
+    expect(result).not.toBeNull()
+    expect(result!.reason).toContain('9.6')
+  })
+
+  it('combines preferLocal + packHint', () => {
+    const result = selectModel(db, { preferLocal: true, packHint: 'reasoning' })
+    expect(result).not.toBeNull()
+    expect(['ollama', 'mlx']).toContain(result!.provider)
+  })
+})

--- a/src/router/selector.ts
+++ b/src/router/selector.ts
@@ -1,0 +1,101 @@
+/**
+ * Model selector — picks the best available model for a task using eval history.
+ */
+
+import type BetterSqlite3 from 'better-sqlite3'
+
+/** Options for model selection. */
+export interface SelectorOpts {
+  taskType?: string
+  packHint?: string
+  preferLocal?: boolean
+  minScore?: number
+  excludeModels?: string[]
+}
+
+/** The selected model result. */
+export interface SelectedModel {
+  modelId: string
+  provider: string
+  score: number
+  reason: string
+}
+
+/** Map task types to eval pack names. */
+function taskTypeToPack(taskType?: string): string | null {
+  if (!taskType) return null
+  const mapping: Record<string, string> = {
+    reasoning: 'reasoning',
+    coding: 'coding',
+    summarize: 'writing-quality',
+    writing: 'writing-quality',
+    general: 'general',
+    fast: 'general',
+    instruction: 'instruction-following',
+  }
+  return mapping[taskType.toLowerCase()] ?? null
+}
+
+/**
+ * Selects the best model for a task based on eval history.
+ * Queries eval_results for best average score, optionally filtering by provider and pack.
+ */
+export function selectModel(db: BetterSqlite3.Database, opts: SelectorOpts): SelectedModel | null {
+  const conditions: string[] = []
+  const params: Record<string, string | number> = {}
+
+  // Filter by pack if we have a hint
+  const pack = opts.packHint ?? taskTypeToPack(opts.taskType)
+  if (pack) {
+    conditions.push('pack = @pack')
+    params.pack = pack
+  }
+
+  // Filter for local models only if preferred
+  if (opts.preferLocal) {
+    conditions.push("(provider = 'ollama' OR provider = 'mlx')")
+  }
+
+  // Exclude specific models
+  const excludes = opts.excludeModels ?? []
+  if (excludes.length > 0) {
+    const placeholders = excludes.map((_, i) => `@exclude${i}`)
+    conditions.push(`model_id NOT IN (${placeholders.join(', ')})`)
+    excludes.forEach((m, i) => { params[`exclude${i}`] = m })
+  }
+
+  const where = conditions.length > 0 ? `WHERE ${conditions.join(' AND ')}` : ''
+
+  // minScore must go in HAVING since it filters on the aggregate
+  const havingClauses: string[] = ['COUNT(*) >= 1']
+  if (opts.minScore !== undefined) {
+    havingClauses.push('AVG(score) >= @minScore')
+    params.minScore = opts.minScore
+  }
+  const having = `HAVING ${havingClauses.join(' AND ')}`
+
+  const sql = `
+    SELECT model_id, provider, AVG(score) as avg_score, COUNT(*) as run_count
+    FROM eval_results
+    ${where}
+    GROUP BY model_id
+    ${having}
+    ORDER BY avg_score DESC
+    LIMIT 1
+  `
+
+  const row = db.prepare(sql).get(params) as { model_id: string; provider: string; avg_score: number; run_count: number } | undefined
+
+  if (!row) return null
+
+  const packInfo = pack ? ` on ${pack}` : ''
+  const localInfo = opts.preferLocal ? ', local preferred' : ''
+  const reason = `Best avg score ${row.avg_score.toFixed(1)}/10${packInfo} (${row.run_count} runs${localInfo})`
+
+  return {
+    modelId: row.model_id,
+    provider: row.provider ?? 'unknown',
+    score: row.avg_score,
+    reason,
+  }
+}

--- a/tsup.config.ts
+++ b/tsup.config.ts
@@ -11,7 +11,7 @@ export default defineConfig({
   shims: false,
   // Mark openai as external so it loads from node_modules at runtime rather
   // than being bundled inline. Bundling the openai SDK breaks its HTTP handling.
-  external: ['openai'],
+  external: ['openai', 'better-sqlite3'],
   banner: {
     js: '#!/usr/bin/env node',
   },

--- a/vitest.config.ts
+++ b/vitest.config.ts
@@ -1,0 +1,8 @@
+import { defineConfig } from 'vitest/config'
+
+export default defineConfig({
+  test: {
+    globals: true,
+    include: ['src/**/__tests__/**/*.test.ts'],
+  },
+})


### PR DESCRIPTION
## What this ships

### SQLite Persistence Layer
- `src/db/schema.ts` — 3 tables: `eval_results`, `question_results`, `models_registry`
- `src/db/client.ts` — `getDb()`, `saveRunResult()`, `queryHistory()`
- Every `verdict run` auto-saves to `~/.verdict/results.db`. Pass `--no-store` to skip.

### `verdict history`
```
verdict history
verdict history --model qwen2.5:32b
verdict history --pack reasoning --since 7d
verdict history --trend   # sparkline view
```

### `verdict route`
Router picks the best model from eval history and runs inference:
```
verdict route "Explain X" --type reasoning
verdict route "Summarize..." --prefer local --dry-run
verdict route "Write a function" --min-score 8.0
```

### `verdict serve`
OpenAI-compatible HTTP proxy — any tool that speaks OpenAI API routes through verdict:
```
verdict serve --port 4000
```
- `POST /v1/chat/completions` with `model: "auto"` or `"auto:reasoning"` etc.
- `GET /v1/models` — lists your full model registry
- CORS support, graceful shutdown

### Tests — 86 passing, 0 failures
| Suite | Coverage |
|---|---|
| `db/schema` | 100% |
| `router/selector` | 100% |
| `judge/deterministic` | 100% |
| `db/client` | 80%+ |

- TypeScript strict throughout, zero `any` types
- `npm run typecheck` — 0 errors
- `npm run build` — clean
- No breaking changes to existing commands

## Foundation for
- `verdict watch` — auto-eval new Ollama/MLX models on detection
- `verdict daemon` — background job queue
- `verdict schedule` — cron workloads
- Full autonomous continuous local LLM infrastructure