### PR TITLE
feat: add verdict validate command (closes #15)

### DIFF
--- a/src/cli/commands/__tests__/validate.test.ts
+++ b/src/cli/commands/__tests__/validate.test.ts
@@ -1,0 +1,144 @@
+import { describe, it, expect, beforeEach, afterEach } from 'vitest'
+import fs from 'fs'
+import path from 'path'
+import os from 'os'
+import { validateConfig } from '../validate.js'
+
+describe('validate command', () => {
+  let tmpDir: string
+
+  beforeEach(() => {
+    tmpDir = fs.mkdtempSync(path.join(os.tmpdir(), 'verdict-validate-'))
+  })
+
+  afterEach(() => {
+    fs.rmSync(tmpDir, { recursive: true, force: true })
+  })
+
+  function writeConfig(name: string, content: string): string {
+    const p = path.join(tmpDir, name)
+    fs.writeFileSync(p, content)
+    return p
+  }
+
+  it('returns error for missing config file', () => {
+    const result = validateConfig('/nonexistent/verdict.yaml')
+    expect(result.valid).toBe(false)
+    expect(result.errors[0]).toContain('not found')
+  })
+
+  it('returns error for invalid YAML syntax', () => {
+    const p = writeConfig('bad.yaml', '{ invalid yaml: [')
+    const result = validateConfig(p)
+    expect(result.valid).toBe(false)
+    expect(result.errors[0]).toContain('YAML syntax error')
+  })
+
+  it('returns schema errors for missing required fields', () => {
+    const p = writeConfig('empty.yaml', 'name: test\n')
+    const result = validateConfig(p)
+    expect(result.valid).toBe(false)
+    expect(result.errors.some(e => e.includes('models'))).toBe(true)
+  })
+
+  it('validates a correct config', () => {
+    const packPath = writeConfig('pack.yaml', `
+name: Test Pack
+cases:
+  - id: case1
+    prompt: Hello
+    criteria: Be helpful
+    scorer: exact
+    expected: Hi
+`)
+    const relPack = path.relative(tmpDir, packPath)
+    const configPath = writeConfig('verdict.yaml', `
+name: Test
+models:
+  - id: test-model
+    model: test-model
+    provider: ollama
+judge:
+  model: test-model
+packs:
+  - ./${relPack}
+`)
+    const result = validateConfig(configPath)
+    expect(result.valid).toBe(true)
+    expect(result.errors).toHaveLength(0)
+    expect(result.summary.models).toBe(1)
+    expect(result.summary.packs).toBe(1)
+    expect(result.summary.scorers.has('exact')).toBe(true)
+  })
+
+  it('reports error when model has no provider or base_url', () => {
+    const configPath = writeConfig('verdict.yaml', `
+name: Test
+models:
+  - id: bare-model
+    model: bare-model
+judge:
+  model: bare-model
+packs: []
+`)
+    const result = validateConfig(configPath)
+    expect(result.valid).toBe(false)
+    expect(result.errors.some(e => e.includes('base_url'))).toBe(true)
+  })
+
+  it('reports error when judge model is not in models list', () => {
+    const configPath = writeConfig('verdict.yaml', `
+name: Test
+models:
+  - id: model-a
+    model: model-a
+    provider: ollama
+judge:
+  model: nonexistent-judge
+packs: []
+`)
+    const result = validateConfig(configPath)
+    expect(result.valid).toBe(false)
+    expect(result.errors.some(e => e.includes('nonexistent-judge'))).toBe(true)
+  })
+
+  it('reports error for missing eval pack file', () => {
+    const configPath = writeConfig('verdict.yaml', `
+name: Test
+models:
+  - id: m1
+    model: m1
+    provider: ollama
+judge:
+  model: m1
+packs:
+  - ./does-not-exist.yaml
+`)
+    const result = validateConfig(configPath)
+    expect(result.valid).toBe(false)
+    expect(result.errors.some(e => e.includes('not found'))).toBe(true)
+  })
+
+  it('reports error for invalid eval pack schema', () => {
+    const packPath = writeConfig('bad-pack.yaml', `
+name: Bad Pack
+cases:
+  - id: case1
+`)
+    const relPack = path.relative(tmpDir, packPath)
+    const configPath = writeConfig('verdict.yaml', `
+name: Test
+models:
+  - id: m1
+    model: m1
+    provider: ollama
+judge:
+  model: m1
+packs:
+  - ./${relPack}
+`)
+    const result = validateConfig(configPath)
+    expect(result.valid).toBe(false)
+    expect(result.errors.some(e => e.includes('Pack'))).toBe(true)
+  })
+})

--- a/src/cli/commands/validate.ts
+++ b/src/cli/commands/validate.ts
@@ -1,0 +1,140 @@
+import fs from 'fs'
+import path from 'path'
+import yaml from 'js-yaml'
+import chalk from 'chalk'
+import { ConfigSchema } from '../../types/index.js'
+import { EvalPackSchema } from '../../types/index.js'
+
+function resolveEnvVars(value: unknown): unknown {
+  if (typeof value === 'string') {
+    return value.replace(/\$\{([^}:]+)(?::-(.*?))?\}/g, (_, name, fallback) => {
+      return process.env[name] ?? fallback ?? ''
+    })
+  }
+  if (Array.isArray(value)) return value.map(resolveEnvVars)
+  if (value && typeof value === 'object') {
+    return Object.fromEntries(
+      Object.entries(value as Record<string, unknown>).map(([k, v]) => [k, resolveEnvVars(v)])
+    )
+  }
+  return value
+}
+
+interface ValidateOptions {
+  config: string
+}
+
+export interface ValidationResult {
+  valid: boolean
+  errors: string[]
+  summary: {
+    models: number
+    packs: number
+    scorers: Set<string>
+  }
+}
+
+export function validateConfig(configPath: string): ValidationResult {
+  const errors: string[] = []
+  const summary = { models: 0, packs: 0, scorers: new Set<string>() }
+
+  // 1. Check file exists
+  const fullPath = path.resolve(configPath)
+  if (!fs.existsSync(fullPath)) {
+    errors.push(`Config file not found: ${fullPath}`)
+    return { valid: false, errors, summary }
+  }
+
+  // 2. Parse YAML
+  let raw: unknown
+  try {
+    raw = yaml.load(fs.readFileSync(fullPath, 'utf8'))
+  } catch (e) {
+    const yamlErr = e as yaml.YAMLException
+    const line = yamlErr.mark?.line != null ? ` (line ${yamlErr.mark.line + 1})` : ''
+    errors.push(`YAML syntax error${line}: ${yamlErr.reason || yamlErr.message}`)
+    return { valid: false, errors, summary }
+  }
+
+  // 3. Resolve env vars and validate against Zod schema
+  const resolved = resolveEnvVars(raw)
+  const result = ConfigSchema.safeParse(resolved)
+  if (!result.success) {
+    for (const issue of result.error.issues) {
+      const pathStr = issue.path.join('.')
+      errors.push(`Schema error at ${pathStr}: ${issue.message}`)
+    }
+    return { valid: false, errors, summary }
+  }
+
+  const config = result.data
+  summary.models = config.models.length
+  summary.packs = config.packs.length
+
+  // 4. Check model providers
+  for (const model of config.models) {
+    if (!model.provider && !model.base_url) {
+      errors.push(`Model "${model.id}": needs either 'provider' (ollama/mlx) or 'base_url'`)
+    }
+  }
+
+  // 5. Check judge model references a configured model
+  const modelIds = new Set(config.models.map(m => m.id))
+  if (!modelIds.has(config.judge.model)) {
+    errors.push(`Judge model "${config.judge.model}" is not in the models list`)
+  }
+
+  // 6. Validate referenced eval packs exist and parse correctly
+  const configDir = path.dirname(fullPath)
+  for (const packPath of config.packs) {
+    const packFullPath = path.isAbsolute(packPath)
+      ? packPath
+      : path.resolve(configDir, packPath)
+
+    if (!fs.existsSync(packFullPath)) {
+      errors.push(`Eval pack not found: ${packPath}`)
+      continue
+    }
+
+    try {
+      const packRaw = yaml.load(fs.readFileSync(packFullPath, 'utf8'))
+      const packResult = EvalPackSchema.safeParse(packRaw)
+      if (!packResult.success) {
+        for (const issue of packResult.error.issues) {
+          errors.push(`Pack "${packPath}" → ${issue.path.join('.')}: ${issue.message}`)
+        }
+      } else {
+        for (const c of packResult.data.cases) {
+          summary.scorers.add(c.scorer)
+        }
+      }
+    } catch (e) {
+      const yamlErr = e as yaml.YAMLException
+      errors.push(`Pack "${packPath}": YAML parse error — ${yamlErr.reason || yamlErr.message}`)
+    }
+  }
+
+  return { valid: errors.length === 0, errors, summary }
+}
+
+export async function validateCommand(opts: ValidateOptions): Promise<void> {
+  console.log(chalk.bold('\n  verdict') + chalk.dim(' validate\n'))
+
+  const { valid, errors, summary } = validateConfig(opts.config)
+
+  if (valid) {
+    console.log(chalk.green('  ✅ Config valid') + chalk.dim(` — ${opts.config}\n`))
+    console.log(chalk.dim('  Summary:'))
+    console.log(chalk.dim(`    Models:  ${summary.models}`))
+    console.log(chalk.dim(`    Packs:   ${summary.packs}`))
+    console.log(chalk.dim(`    Scorers: ${[...summary.scorers].join(', ') || 'none (no packs loaded)'}`))
+    console.log()
+  } else {
+    console.log(chalk.red(`  ❌ Config invalid`) + chalk.dim(` — ${opts.config}\n`))
+    for (const err of errors) {
+      console.log(chalk.red(`  • ${err}`))
+    }
+    console.log()
+    process.exit(1)
+  }
+}

--- a/src/cli/index.ts
+++ b/src/cli/index.ts
@@ -10,6 +10,7 @@ import { routeCommand } from './commands/route.js'
 import { serveCommand } from './commands/serve.js'
 import { daemonStartCommand, daemonStopCommand, daemonStatusCommand, daemonLogsCommand, daemonWorkerCommand } from './commands/daemon.js'
 import { watchCommand } from './commands/watch.js'
+import { validateCommand } from './commands/validate.js'
 
 const program = new Command()
 
@@ -139,5 +140,12 @@ program
   .option('--interval <seconds>', 'Poll interval in seconds', '60')
   .option('--no-auto-eval', 'Detect but do not auto-queue evals')
   .action(watchCommand)
+
+program
+  .command('validate [config]')
+  .description('Check a verdict.yaml config for errors without running evals')
+  .action((config: string | undefined, _opts: unknown) => {
+    return validateCommand({ config: config ?? './verdict.yaml' })
+  })
 
 program.parse()


### PR DESCRIPTION
Closes #15

Adds `verdict validate [config]` command.

- Validates YAML syntax
- Validates against Zod VerdictConfig schema
- Checks model providers, scorer types, eval pack references
- Exit 0 if valid, exit 1 with errors listed

Typecheck ✅ | 119 tests ✅ (+8 new)