### PR TITLE
feat: add regex scorer for pattern matching (closes #18)

### DIFF
--- a/eval-packs/regex-examples.yaml
+++ b/eval-packs/regex-examples.yaml
@@ -1,0 +1,34 @@
+name: Regex Scorer Examples
+description: Demonstrates the regex scorer — checks model output against regular expression patterns
+category: pattern-matching
+
+cases:
+  - id: regex-email-extraction
+    description: "Model output must contain a valid email address"
+    category: pattern-matching
+    prompt: |
+      What is the support email for Acme Corp? Reply with just the email address.
+    scorer: regex
+    expected: "[a-zA-Z0-9._%+-]+@[a-zA-Z0-9.-]+\\.[a-zA-Z]{2,}"
+    criteria: "Output contains a valid email address"
+    tags: [regex, extraction]
+
+  - id: regex-iso-date
+    description: "Model output must contain an ISO 8601 date"
+    category: pattern-matching
+    prompt: |
+      What is today's date? Reply in ISO 8601 format (YYYY-MM-DD).
+    scorer: regex
+    expected: "\\d{4}-\\d{2}-\\d{2}"
+    criteria: "Output contains a date in YYYY-MM-DD format"
+    tags: [regex, date-format]
+
+  - id: regex-hex-color
+    description: "Model output must contain a hex color code"
+    category: pattern-matching
+    prompt: |
+      What is the hex color code for pure red? Reply with just the color code.
+    scorer: regex
+    expected: "/^#([0-9a-f]{6}|[0-9a-f]{3})$/i"
+    criteria: "Output is a valid hex color code like #FF0000"
+    tags: [regex, color-format]

--- a/src/judge/__tests__/deterministic.test.ts
+++ b/src/judge/__tests__/deterministic.test.ts
@@ -5,6 +5,7 @@ import {
   scoreContains,
   scoreToolCall,
   scoreJsonSchema,
+  scoreRegex,
   isDeterministic,
   scoreDeterministic,
 } from '../deterministic.js'
@@ -229,6 +230,40 @@ describe('deterministic scorers', () => {
     })
   })
 
+  describe('scoreRegex', () => {
+    it('scores matching output as 10/10', () => {
+      const result = scoreRegex('The answer is 42.', '\\d+')
+      expect(result.total).toBe(10)
+    })
+
+    it('scores non-matching output as 0/10', () => {
+      const result = scoreRegex('No numbers here', '^\\d+$')
+      expect(result.total).toBe(0)
+      expect(result.reasoning).toContain('does not match')
+    })
+
+    it('handles invalid regex pattern gracefully', () => {
+      const result = scoreRegex('anything', '[invalid')
+      expect(result.total).toBe(0)
+      expect(result.reasoning).toContain('Invalid regex pattern')
+    })
+
+    it('supports /pattern/flags format', () => {
+      const result = scoreRegex('Hello World', '/hello/i')
+      expect(result.total).toBe(10)
+    })
+
+    it('supports global and multiline flags', () => {
+      const result = scoreRegex('line1\nline2', '/^line2$/m')
+      expect(result.total).toBe(10)
+    })
+
+    it('works without slash format', () => {
+      const result = scoreRegex('test@example.com', '[a-z]+@[a-z]+\\.[a-z]+')
+      expect(result.total).toBe(10)
+    })
+  })
+
   describe('isDeterministic', () => {
     it('returns true for deterministic scorers', () => {
       expect(isDeterministic('json')).toBe(true)
@@ -236,6 +271,7 @@ describe('deterministic scorers', () => {
       expect(isDeterministic('contains')).toBe(true)
       expect(isDeterministic('jsonschema')).toBe(true)
       expect(isDeterministic('tool_call')).toBe(true)
+      expect(isDeterministic('regex')).toBe(true)
     })
 
     it('returns false for non-deterministic scorers', () => {
@@ -265,6 +301,12 @@ describe('deterministic scorers', () => {
 
     it('dispatches to scoreJsonSchema', () => {
       const result = scoreDeterministic('jsonschema', '{"a": 1}', undefined, { required: ['a'], properties: { a: { type: 'number' } } })
+      expect(result).not.toBeNull()
+      expect(result!.total).toBe(10)
+    })
+
+    it('dispatches to scoreRegex', () => {
+      const result = scoreDeterministic('regex', 'abc123', '\\d+')
       expect(result).not.toBeNull()
       expect(result!.total).toBe(10)
     })

--- a/src/judge/deterministic.ts
+++ b/src/judge/deterministic.ts
@@ -215,8 +215,37 @@ export function scoreJsonSchema(output: string, schema: Record<string, unknown>)
   }
 }
 
+export function scoreRegex(output: string, pattern: string): JudgeScore {
+  let regex: RegExp
+  try {
+    // Support /pattern/flags format
+    const slashMatch = pattern.match(/^\/(.+)\/([gimsuy]*)$/)
+    if (slashMatch) {
+      regex = new RegExp(slashMatch[1], slashMatch[2])
+    } else {
+      regex = new RegExp(pattern)
+    }
+  } catch (err) {
+    return {
+      accuracy: 0, completeness: 0, conciseness: 0, total: 0,
+      reasoning: `Invalid regex pattern: ${err instanceof Error ? err.message : err}`,
+    }
+  }
+
+  if (regex.test(output)) {
+    return {
+      accuracy: 10, completeness: 10, conciseness: 10, total: 10,
+      reasoning: `Output matches regex pattern: ${pattern}`,
+    }
+  }
+  return {
+    accuracy: 0, completeness: 0, conciseness: 0, total: 0,
+    reasoning: `Output does not match regex pattern: ${pattern}`,
+  }
+}
+
 export function isDeterministic(scorer: string): boolean {
-  return scorer === 'json' || scorer === 'exact' || scorer === 'contains' || scorer === 'jsonschema' || scorer === 'tool_call'
+  return scorer === 'json' || scorer === 'exact' || scorer === 'contains' || scorer === 'jsonschema' || scorer === 'tool_call' || scorer === 'regex'
 }
 
 export function scoreDeterministic(
@@ -226,5 +255,6 @@ export function scoreDeterministic(
   if (scorer === 'exact') return scoreExact(output, expected ?? '')
   if (scorer === 'contains') return scoreContains(output, expected ?? '')
   if (scorer === 'jsonschema') return scoreJsonSchema(output, schema ?? {})
+  if (scorer === 'regex') return scoreRegex(output, expected ?? '')
   return null
 }

--- a/src/types/index.ts
+++ b/src/types/index.ts
@@ -80,8 +80,9 @@ export const EvalCaseSchema = z.object({
   tags: z.array(z.string()).default([]),
   // scorer: 'llm' uses LLM judge (default), 'json' parses output as JSON (pass/fail),
   // 'exact' checks exact string match, 'contains' checks substring presence,
-  // 'jsonschema' validates JSON output against a schema, 'tool_call' scores tool usage
-  scorer: z.enum(['llm', 'json', 'exact', 'contains', 'jsonschema', 'tool_call']).default('llm'),
+  // 'jsonschema' validates JSON output against a schema, 'tool_call' scores tool usage,
+  // 'regex' checks output against a regex pattern (expected field is the pattern)
+  scorer: z.enum(['llm', 'json', 'exact', 'contains', 'jsonschema', 'tool_call', 'regex']).default('llm'),
   schema: z.record(z.unknown()).optional(),
   turns: z.array(z.object({
     role: z.enum(['user', 'assistant']),


### PR DESCRIPTION
Closes #18

Adds `regex` scorer. The `expected` field is the regex pattern.

Supports:
- Plain patterns: `expected: '[0-9]+ miles'`
- Flagged patterns: `expected: '/hello/i'`
- Invalid patterns: 0/10 with descriptive error

Typecheck ✅ | 118 tests ✅ (+6 new)