### PR TITLE
perf: cache OpenAI client instances by base_url+api_key (closes #25)

### DIFF
--- a/src/judge/llm.ts
+++ b/src/judge/llm.ts
@@ -1,6 +1,28 @@
 import OpenAI from 'openai'
 import type { ModelConfig, JudgeConfig, JudgeScore } from '../types/index.js'
 
+const judgeClientCache = new Map<string, OpenAI>()
+
+function getOrCreateJudgeClient(baseUrl: string, apiKey: string): OpenAI {
+  const key = baseUrl + ':::' + apiKey
+  if (!judgeClientCache.has(key)) {
+    judgeClientCache.set(key, new OpenAI({
+      baseURL: baseUrl,
+      apiKey,
+      timeout: 30_000,
+      defaultHeaders: {
+        'HTTP-Referer': 'https://github.com/hnshah/verdict',
+        'X-Title': 'verdict',
+      },
+    }))
+  }
+  return judgeClientCache.get(key)!
+}
+
+export function clearJudgeClientCache(): void {
+  judgeClientCache.clear()
+}
+
 function buildPrompt(prompt: string, criteria: string, response: string, rubric: JudgeConfig['rubric']): string {
   return `You are an impartial evaluator. You do not know which AI model produced this response.
 
@@ -54,15 +76,8 @@ export async function judgeResponse(
   const baseURL = judgeModel.base_url
   if (!baseURL) throw new Error(`Judge model '${judgeModel.id}' has no base_url`)
 
-  const client = new OpenAI({
-    baseURL,
-    apiKey: judgeModel.api_key === 'none' ? 'no-key-required' : judgeModel.api_key,
-    timeout: 30_000,
-    defaultHeaders: {
-      'HTTP-Referer': 'https://github.com/hnshah/verdict',
-      'X-Title': 'verdict',
-    },
-  })
+  const apiKey = judgeModel.api_key === 'none' ? 'no-key-required' : (judgeModel.api_key ?? 'ollama')
+  const client = getOrCreateJudgeClient(baseURL, apiKey)
 
   const result = await client.chat.completions.create({
     model: judgeModel.model,

--- a/src/providers/compat.ts
+++ b/src/providers/compat.ts
@@ -10,6 +10,28 @@ import OpenAI from 'openai'
 import fs from 'fs'
 import type { ModelConfig, ModelResponse, ToolDef } from '../types/index.js'
 
+const clientCache = new Map<string, OpenAI>()
+
+function getOrCreateClient(baseUrl: string, apiKey: string, timeout?: number): OpenAI {
+  const key = baseUrl + ':::' + apiKey
+  if (!clientCache.has(key)) {
+    clientCache.set(key, new OpenAI({
+      baseURL: baseUrl,
+      apiKey,
+      timeout,
+      defaultHeaders: {
+        'HTTP-Referer': 'https://github.com/hnshah/verdict',
+        'X-Title': 'verdict',
+      },
+    }))
+  }
+  return clientCache.get(key)!
+}
+
+export function clearClientCache(): void {
+  clientCache.clear()
+}
+
 function loadImageAsBase64(imagePath: string): string | null {
   try {
     if (imagePath.startsWith('http://') || imagePath.startsWith('https://')) {
@@ -51,16 +73,8 @@ export async function callModel(
   const baseURL = config.base_url
   if (!baseURL) throw new Error(`Model '${config.id}' has no base_url`)
 
-  const client = new OpenAI({
-    baseURL,
-    apiKey: config.api_key === 'none' ? 'no-key-required' : config.api_key,
-    timeout: config.timeout_ms,
-    defaultHeaders: {
-      // Required by some providers (OpenRouter, etc.)
-      'HTTP-Referer': 'https://github.com/hnshah/verdict',
-      'X-Title': 'verdict',
-    },
-  })
+  const apiKey = config.api_key === 'none' ? 'no-key-required' : (config.api_key ?? 'ollama')
+  const client = getOrCreateClient(baseURL, apiKey, config.timeout_ms)
 
   const start = Date.now()
 
@@ -121,15 +135,8 @@ export async function callModelMultiTurn(
   const baseURL = config.base_url
   if (!baseURL) throw new Error(`Model '${config.id}' has no base_url`)
 
-  const client = new OpenAI({
-    baseURL,
-    apiKey: config.api_key === 'none' ? 'no-key-required' : config.api_key,
-    timeout: config.timeout_ms,
-    defaultHeaders: {
-      'HTTP-Referer': 'https://github.com/hnshah/verdict',
-      'X-Title': 'verdict',
-    },
-  })
+  const apiKey = config.api_key === 'none' ? 'no-key-required' : (config.api_key ?? 'ollama')
+  const client = getOrCreateClient(baseURL, apiKey, config.timeout_ms)
 
   const start = Date.now()
 
@@ -174,15 +181,8 @@ export async function callModelWithTools(
   const baseURL = config.base_url
   if (!baseURL) throw new Error(`Model '${config.id}' has no base_url`)
 
-  const client = new OpenAI({
-    baseURL,
-    apiKey: config.api_key === 'none' ? 'no-key-required' : config.api_key,
-    timeout: config.timeout_ms,
-    defaultHeaders: {
-      'HTTP-Referer': 'https://github.com/hnshah/verdict',
-      'X-Title': 'verdict',
-    },
-  })
+  const apiKey = config.api_key === 'none' ? 'no-key-required' : (config.api_key ?? 'ollama')
+  const client = getOrCreateClient(baseURL, apiKey, config.timeout_ms)
 
   const start = Date.now()
 


### PR DESCRIPTION
Closes #25

Previously: new OpenAI() was called on every model invocation — 100+ instances for a 25-case run.

Now: module-level Map cache keyed on base_url+api_key. Same client reused across all calls to the same provider endpoint.

Typecheck ✅ | 111 tests ✅