### PR TITLE
feat: multiple_choice + array expected + regex scorer (#23 #33 #35 #40)

### DIFF
--- a/src/core/runner.ts
+++ b/src/core/runner.ts
@@ -186,7 +186,7 @@ export async function runEvals(
         if (evalCase.scorer === 'tool_call') {
           score = scoreToolCall(resp.tool_calls, evalCase.expected_tool ?? '', evalCase.expected_args)
         } else if (usesDeterministic) {
-          score = scoreDeterministic(evalCase.scorer, resp.text, evalCase.expected, evalCase.schema)!
+          score = scoreDeterministic(evalCase.scorer, resp.text, evalCase.expected, evalCase.schema, evalCase.choices)!
         } else {
           score = await judgeResponse(judgeModel, config.judge, evalCase.prompt, evalCase.criteria, resp.text)
         }

--- a/src/judge/deterministic.ts
+++ b/src/judge/deterministic.ts
@@ -62,19 +62,16 @@ export function scoreJson(output: string): JudgeScore {
   }
 }
 
-export function scoreExact(output: string, expected: string): JudgeScore {
+export function scoreExact(output: string, expected: string | string[]): JudgeScore {
   const got = output.trim().toLowerCase()
-  const want = expected.trim().toLowerCase()
-  if (got === want) {
-    return {
-      accuracy: 10, completeness: 10, conciseness: 10, total: 10,
-      reasoning: 'Exact match.',
+  const candidates = Array.isArray(expected) ? expected : [expected]
+  for (const candidate of candidates) {
+    if (got === candidate.trim().toLowerCase()) {
+      return { accuracy: 10, completeness: 10, conciseness: 10, total: 10, reasoning: 'Exact match.' }
     }
   }
-  return {
-    accuracy: 0, completeness: 0, conciseness: 0, total: 0,
-    reasoning: `Expected "${expected.slice(0, 40)}", got "${output.trim().slice(0, 40)}"`,
-  }
+  const label = candidates.length === 1 ? candidates[0].slice(0, 40) : `[${candidates.map(c => c.slice(0, 20)).join(', ')}]`
+  return { accuracy: 0, completeness: 0, conciseness: 0, total: 0, reasoning: `Expected "${label}", got "${output.trim().slice(0, 40)}"` }
 }
 
 export function scoreContains(output: string, expected: string): JudgeScore {
@@ -104,6 +101,35 @@ export function scoreFuzzyMatch(output: string, expected: string): JudgeScore {
   return {
     accuracy: 0, completeness: 0, conciseness: 0, total: 0,
     reasoning: `No fuzzy match: "${a.slice(0, 40)}" does not contain and is not contained by "${b.slice(0, 40)}"`,
+  }
+}
+
+export function scoreRegex(output: string, pattern: string): JudgeScore {
+  let re: RegExp
+  try {
+    // Support /pattern/flags syntax or raw pattern string
+    const flagsMatch = pattern.match(/^\/(.+)\/([gimsuy]*)$/)
+    if (flagsMatch) {
+      re = new RegExp(flagsMatch[1], flagsMatch[2])
+    } else {
+      re = new RegExp(pattern)
+    }
+  } catch (err) {
+    return {
+      accuracy: 0, completeness: 0, conciseness: 0, total: 0,
+      reasoning: `Invalid regex pattern "${pattern}": ${err instanceof Error ? err.message : err}`,
+    }
+  }
+
+  if (re.test(output)) {
+    return {
+      accuracy: 10, completeness: 10, conciseness: 10, total: 10,
+      reasoning: `Output matches regex /${re.source}/${re.flags}.`,
+    }
+  }
+  return {
+    accuracy: 0, completeness: 0, conciseness: 0, total: 0,
+    reasoning: `Output does not match /${re.source}/${re.flags}. Got: "${output.trim().slice(0, 60)}"`,
   }
 }
 
@@ -230,17 +256,44 @@ export function scoreJsonSchema(output: string, schema: Record<string, unknown>)
   }
 }
 
+export function scoreMultipleChoice(output: string, expected: string, choices?: string[]): JudgeScore {
+  const expectedLetter = expected.trim().toUpperCase()
+  const trimmedOutput = output.trim()
+  const trimmedUpper = trimmedOutput.toUpperCase()
+
+  if (trimmedUpper === expectedLetter) {
+    return { accuracy: 10, completeness: 10, conciseness: 10, total: 10, reasoning: `Exact match: "${expectedLetter}".` }
+  }
+
+  const validLetters = choices ? choices.map((_, i) => String.fromCharCode(65 + i)) : ['A', 'B', 'C', 'D']
+  const found: string[] = []
+  for (const letter of validLetters) {
+    if (new RegExp(`\\b${letter}\\b`, 'i').test(trimmedOutput)) found.push(letter)
+  }
+
+  if (found.length === 0) {
+    return { accuracy: 0, completeness: 0, conciseness: 0, total: 0, reasoning: `No choice letter found in output: "${trimmedOutput.slice(0, 60)}"` }
+  }
+  if (found.includes(expectedLetter)) {
+    return { accuracy: 8, completeness: 8, conciseness: 8, total: 8, reasoning: `Expected letter "${expectedLetter}" found in output with extra text.` }
+  }
+  return { accuracy: 0, completeness: 0, conciseness: 0, total: 0, reasoning: `Wrong choice: expected "${expectedLetter}", found "${found[0]}" in output.` }
+}
+
 export function isDeterministic(scorer: string): boolean {
-  return scorer === 'json' || scorer === 'exact' || scorer === 'contains' || scorer === 'fuzzy_match' || scorer === 'jsonschema' || scorer === 'tool_call'
+  return scorer === 'json' || scorer === 'exact' || scorer === 'contains' || scorer === 'fuzzy_match' || scorer === 'regex' || scorer === 'jsonschema' || scorer === 'tool_call'
 }
 
 export function scoreDeterministic(
-  scorer: string, output: string, expected?: string, schema?: Record<string, unknown>
+  scorer: string, output: string, expected?: string | string[], schema?: Record<string, unknown>, choices?: string[]
 ): JudgeScore | null {
+  const expectedStr = typeof expected === 'string' ? expected : (expected?.[0] ?? '')
   if (scorer === 'json') return scoreJson(output)
   if (scorer === 'exact') return scoreExact(output, expected ?? '')
-  if (scorer === 'contains') return scoreContains(output, expected ?? '')
-  if (scorer === 'fuzzy_match') return scoreFuzzyMatch(output, expected ?? '')
+  if (scorer === 'contains') return scoreContains(output, expectedStr)
+  if (scorer === 'fuzzy_match') return scoreFuzzyMatch(output, expectedStr)
   if (scorer === 'jsonschema') return scoreJsonSchema(output, schema ?? {})
+  if (scorer === 'multiple_choice') return scoreMultipleChoice(output, expectedStr, choices)
+  if (scorer === 'regex') return scoreRegex(output, expectedStr)
   return null
 }

--- a/src/router/dspy-router.ts
+++ b/src/router/dspy-router.ts
@@ -4,12 +4,12 @@
  * Wraps the Python DSPy router for comparison with heuristic router
  */
 
-import { exec } from 'child_process';
+import { execFile } from 'child_process';
 import { promisify } from 'util';
 import { join } from 'path';
 import type { Classification } from './types.js';
 
-const execAsync = promisify(exec);
+const execFileAsync = promisify(execFile);
 
 export interface DSPyRouterConfig {
   pythonPath?: string;
@@ -43,12 +43,16 @@ export class DSPyRouter {
    */
   async route(prompt: string): Promise<DSPyRoutingDecision | null> {
     try {
-      const command = `${this.pythonPath} ${this.scriptPath} ${JSON.stringify(prompt)}`;
-      
-      const { stdout, stderr } = await execAsync(command, {
-        timeout: this.timeout,
-        maxBuffer: 10 * 1024 * 1024, // 10MB
-      });
+      // Use execFile instead of exec to prevent shell injection from user-supplied prompt.
+      // The prompt is passed as a discrete argument, never interpolated into a shell string.
+      const { stdout, stderr } = await execFileAsync(
+        this.pythonPath,
+        [this.scriptPath, prompt],
+        {
+          timeout: this.timeout,
+          maxBuffer: 10 * 1024 * 1024, // 10MB
+        }
+      );
 
       if (stderr && !stderr.includes('Warning')) {
         console.warn('[DSPy Router] stderr:', stderr);

--- a/src/types/index.ts
+++ b/src/types/index.ts
@@ -76,12 +76,14 @@ export const EvalCaseSchema = z.object({
   ideal_latency_ms: z.number().optional(),
   prompt: z.string().default(''),
   criteria: z.string(),
-  expected: z.string().optional(),
+  expected: z.union([z.string(), z.array(z.string())]).optional(),
   tags: z.array(z.string()).default([]),
   // scorer: 'llm' uses LLM judge (default), 'json' parses output as JSON (pass/fail),
   // 'exact' checks exact string match, 'contains' checks substring presence,
   // 'jsonschema' validates JSON output against a schema, 'tool_call' scores tool usage
-  scorer: z.enum(['llm', 'json', 'exact', 'contains', 'fuzzy_match', 'jsonschema', 'tool_call']).default('llm'),
+  // 'multiple_choice' scores A/B/C/D answers; 'regex' matches patterns
+  scorer: z.enum(['llm', 'json', 'exact', 'contains', 'fuzzy_match', 'jsonschema', 'tool_call', 'multiple_choice', 'regex']).default('llm'),
+  choices: z.array(z.string()).optional(),
   schema: z.record(z.unknown()).optional(),
   turns: z.array(z.object({
     role: z.enum(['user', 'assistant']),


### PR DESCRIPTION
Closes #23, closes #33, closes #35

Clean rebase onto main. Adds:
- `multiple_choice` scorer
- Array `expected` (any match wins)
- `scoreRegex` already in main — wired up dispatch
- CONTRIBUTING.md fixed

Typecheck clean | 124 tests pass