### PR TITLE
fix: replace placeholder URLs with real hnshah/verdict links

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -8,7 +8,7 @@ Thanks for your interest in improving Verdict! This guide will help you contribu
 
 ```bash
 # 1. Fork the repo
-gh repo fork yourusername/verdict
+gh repo fork hnshah/verdict
 
 # 2. Clone your fork
 git clone https://github.com/YOUR_USERNAME/verdict.git
@@ -50,7 +50,7 @@ npm test
 - Translation to other languages
 
 **Bug Fixes:**
-- See [issues labeled `bug`](https://github.com/yourusername/verdict/labels/bug)
+- See [issues labeled `bug`](https://github.com/hnshah/verdict/labels/bug)
 
 ### 💡 Medium Priority
 
@@ -79,7 +79,7 @@ npm test
 
 ### 1. Pick an Issue
 
-- Browse [open issues](https://github.com/yourusername/verdict/issues)
+- Browse [open issues](https://github.com/hnshah/verdict/issues)
 - Look for `good first issue` or `help wanted` labels
 - Comment saying you'd like to work on it
 
@@ -530,8 +530,7 @@ git push --tags
 
 **Stuck? Ask us!**
 
-- 💬 [Discord](https://discord.gg/verdict)
-- 🐛 [GitHub Issues](https://github.com/yourusername/verdict/issues)
+- 🐛 [GitHub Issues](https://github.com/hnshah/verdict/issues)
 - 📧 Email: verdictdevs@example.com
 
 **Before asking:**

--- a/README.md
+++ b/README.md
@@ -566,9 +566,8 @@ MIT
 
 ## Links
 
-- **GitHub:** https://github.com/yourusername/verdict
-- **Docs:** https://verdict.dev
-- **Discord:** https://discord.gg/verdict
+- **GitHub:** https://github.com/hnshah/verdict
+- **npm:** https://www.npmjs.com/package/verdict
 
 ---
 
@@ -591,7 +590,7 @@ MIT
 - Dataset generation (create eval packs from logs)
 - Model fine-tuning integration (eval → retrain loop)
 
-Vote on features: https://github.com/yourusername/verdict/discussions
+Vote on features: https://github.com/hnshah/verdict/discussions
 
 ---
 


### PR DESCRIPTION
Fixes #12

- Replace `yourusername/verdict` → `hnshah/verdict` in README.md and CONTRIBUTING.md
- Remove non-existent `discord.gg/verdict` and `verdict.dev` links
- Add npm package link

Note: The GIF demo item from #12 is tracked separately — that requires recording actual tool output and is a bigger effort.