### PR TITLE
feat: implement --fail-if-regression flag (closes #14)

### DIFF
--- a/README.md
+++ b/README.md
@@ -552,9 +552,13 @@ Depends on:
 Yes! Exit code non-zero if quality drops:
 
 ```bash
-verdict run --baseline production --fail-if-regression
-# → Exit 1 if new model worse than baseline
+verdict run --fail-if-regression
+# → Exit 1 if any model scores lower than its historical best (stored in SQLite)
 ```
+
+The `--fail-if-regression` flag compares each model's current average score against its
+historical best for the same eval pack. A regression is flagged when the score drops by
+more than 0.5 points. First runs (no history) are always treated as the baseline.
 
 ---
 

--- a/src/cli/commands/run.ts
+++ b/src/cli/commands/run.ts
@@ -20,6 +20,7 @@ interface RunOptions {
   noStore?: boolean
   category?: string[]
   json?: boolean
+  failIfRegression?: boolean
 }
 
 export async function runCommand(opts: RunOptions): Promise<void> {
@@ -173,6 +174,44 @@ export async function runCommand(opts: RunOptions): Promise<void> {
       log(chalk.dim(`  stored: ~/.verdict/results.db`))
     } catch (err) {
       console.warn(chalk.yellow(`  warning: failed to store results in DB: ${err instanceof Error ? err.message : err}`))
+    }
+  }
+
+  // Check for regressions against historical best scores in DB
+  if (opts.failIfRegression && !opts.noStore) {
+    try {
+      const { getDb, initSchema, getHistoricalBest } = await import('../../db/client.js')
+      const checkDb = getDb()
+      initSchema(checkDb)
+      const packName = opts.pack ?? config.packs[0] ?? 'unknown'
+      const packLabel = packName.replace(/^.*\//, '').replace(/\.ya?ml$/, '')
+      const REGRESSION_THRESHOLD = 0.5
+      const regressions: Array<{ model: string; current: number; best: number }> = []
+
+      for (const modelId of result.models) {
+        const summary = result.summary[modelId]
+        if (!summary) continue
+        const best = getHistoricalBest(checkDb, modelId, packLabel)
+        // Skip if no prior history (first run) or if current run IS the best
+        if (best === null) continue
+        if (summary.avg_total < best - REGRESSION_THRESHOLD) {
+          regressions.push({ model: modelId, current: summary.avg_total, best })
+        }
+      }
+
+      checkDb.close()
+
+      if (regressions.length > 0) {
+        log()
+        log(chalk.red.bold('  REGRESSION DETECTED'))
+        for (const r of regressions) {
+          log(chalk.red(`    ${r.model}: ${r.current.toFixed(2)} < historical best ${r.best.toFixed(2)} (threshold: ${REGRESSION_THRESHOLD})`))
+        }
+        log()
+        process.exit(1)
+      }
+    } catch (err) {
+      console.warn(chalk.yellow(`  warning: regression check failed: ${err instanceof Error ? err.message : err}`))
     }
   }
 

--- a/src/cli/index.ts
+++ b/src/cli/index.ts
@@ -37,6 +37,7 @@ program
   .option('--no-store', 'Skip persisting results to SQLite database')
   .option('--category <categories...>', 'Filter cases by category (repeatable)')
   .option('--json', 'Output results as JSON to stdout (for CI/CD pipelines)')
+  .option('--fail-if-regression', 'Exit with code 1 if any model scores lower than its historical best')
   .action(runCommand)
 
 const models = program

--- a/src/db/__tests__/client.test.ts
+++ b/src/db/__tests__/client.test.ts
@@ -1,6 +1,6 @@
 import { describe, it, expect, beforeEach } from 'vitest'
 import Database from 'better-sqlite3'
-import { initSchema, saveRunResult, queryHistory, parseSince } from '../client.js'
+import { initSchema, saveRunResult, queryHistory, parseSince, getHistoricalBest } from '../client.js'
 import type { RunResult } from '../../types/index.js'
 
 function createTestDb(): Database.Database {
@@ -298,6 +298,66 @@ describe('client', () => {
       const now = new Date()
       const diff = now.getTime() - result!.getTime()
       expect(diff).toBeGreaterThan(29 * 24 * 60 * 60 * 1000)
+    })
+  })
+
+  describe('getHistoricalBest', () => {
+    it('returns null when no history exists', () => {
+      expect(getHistoricalBest(db, 'nonexistent-model', 'general')).toBeNull()
+    })
+
+    it('returns the best score for a model+pack', () => {
+      saveRunResult(db, makeRunResult(), 'general')
+      const best = getHistoricalBest(db, 'qwen2.5:32b', 'general')
+      expect(best).toBe(9.2)
+    })
+
+    it('returns the highest score across multiple runs', () => {
+      saveRunResult(db, makeRunResult(), 'general')
+      saveRunResult(db, makeRunResult({
+        run_id: 'test-run-2',
+        summary: {
+          'qwen2.5:32b': {
+            model_id: 'qwen2.5:32b',
+            avg_total: 9.8,
+            avg_accuracy: 10,
+            avg_completeness: 10,
+            avg_conciseness: 10,
+            avg_latency_ms: 1100,
+            avg_tokens_per_sec: 0,
+            total_cost_usd: 0,
+            win_rate: 100,
+            wins: 1,
+            cases_run: 1,
+            avg_solve_rate: 0,
+          },
+          'llama4:8b': {
+            model_id: 'llama4:8b',
+            avg_total: 8.7,
+            avg_accuracy: 8,
+            avg_completeness: 9,
+            avg_conciseness: 9,
+            avg_latency_ms: 800,
+            avg_tokens_per_sec: 0,
+            total_cost_usd: 0,
+            win_rate: 0,
+            wins: 0,
+            cases_run: 1,
+            avg_solve_rate: 0,
+          },
+        },
+      }), 'general')
+
+      expect(getHistoricalBest(db, 'qwen2.5:32b', 'general')).toBe(9.8)
+    })
+
+    it('scopes best score to the correct pack', () => {
+      saveRunResult(db, makeRunResult(), 'general')
+      saveRunResult(db, makeRunResult({ run_id: 'test-run-2' }), 'reasoning')
+
+      expect(getHistoricalBest(db, 'qwen2.5:32b', 'general')).toBe(9.2)
+      expect(getHistoricalBest(db, 'qwen2.5:32b', 'reasoning')).toBe(9.2)
+      expect(getHistoricalBest(db, 'qwen2.5:32b', 'nonexistent')).toBeNull()
     })
   })
 })

--- a/src/db/client.ts
+++ b/src/db/client.ts
@@ -292,6 +292,17 @@ export function getJobs(db: Database.Database, opts: { status?: string; limit?: 
 }
 
 /**
+ * Returns the historical best avg score for a given model+pack combination.
+ * Returns null if no prior runs exist for this model+pack.
+ */
+export function getHistoricalBest(db: Database.Database, modelId: string, pack: string): number | null {
+  const row = db.prepare(
+    'SELECT MAX(score) as best FROM eval_results WHERE model_id = @modelId AND pack = @pack'
+  ).get({ modelId, pack }) as { best: number | null } | undefined
+  return row?.best ?? null
+}
+
+/**
  * Parse a relative time string like "7d", "24h", "30d", "1w" into a Date.
  * Returns null if the format is not recognized.
  */


### PR DESCRIPTION
Implements `--fail-if-regression` flag for the `verdict run` command.

When set, the command exits with a non-zero code if any score regresses compared to the stored baseline. Useful for CI/CD gates.

Closes #14