### PR TITLE
fix: resolve duplicate and broken exports in src/index.ts

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -19,16 +19,12 @@
  * console.log(result.summary)
  * ```
  */
-export { loadConfig, loadEvalPack } from './core/config.js'
-export { runEvals } from './core/runner.js'
-export { judgeResponse } from './judge/llm.js'
-export { scoreDeterministic } from './judge/deterministic.js'
-export { VerdictRouter } from './router/index.js'
 
 // ─── Core runner ─────────────────────────────────────────────────────────────
 export { runEvals, computeConfigHash, loadCheckpoint, getCheckpointPath } from './core/runner.js'
 
 // ─── Config + pack loader ─────────────────────────────────────────────────────
+export { loadConfig, loadEvalPack } from './core/config.js'
 
 // ─── Eval registry ──────────────────────────────────────────────────────────
 export {
@@ -44,10 +40,12 @@ export {
 export type { Registry } from './core/registry.js'
 
 // ─── Judges ──────────────────────────────────────────────────────────────────
+export {
   judgeResponse,
   clearJudgeClientCache,
 } from './judge/llm.js'
 
+export {
   scoreJson,
   scoreExact,
   scoreContains,
@@ -63,7 +61,11 @@ export type { Registry } from './core/registry.js'
 // ─── Reporters ───────────────────────────────────────────────────────────────
 export { generateMarkdownReport } from './reporter/markdown.js'
 
+// ─── Router ──────────────────────────────────────────────────────────────────
+export { VerdictRouter } from './router/index.js'
+
 // ─── Database ────────────────────────────────────────────────────────────────
+export {
   getDb,
   initSchema,
   saveRunResult,


### PR DESCRIPTION
## Summary

Fixes pre-existing TypeScript errors in `src/index.ts` flagged by CI in recent PRs.

## Changes

- Remove duplicate exports of `runEvals`, `judgeResponse`, `scoreDeterministic` (were exported twice)
- Add missing `export` keyword to **Judges** and **Database** section blocks (bare `{...} from` syntax is invalid TS)
- Consolidate into clean flat structure grouped by section with comments
- No behavioral changes — same symbols exported, same sources

## Why it was broken

The programmatic API was assembled by merging partial export blocks. Several sections were missing their `export` prefix, and some symbols were added to the quick-access block at the top without removing the originals.

Fixes #64