### PR TITLE
feat: Vera dashboard integration — Phase 1 + Phase 2 spec

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -27,7 +27,7 @@
         "@vitest/coverage-v8": "^4.1.1",
         "tsup": "^8.0.0",
         "tsx": "^4.7.0",
-        "typescript": "^5.4.0",
+        "typescript": "^5.9.3",
         "vitest": "^4.1.1"
       },
       "engines": {

--- a/package.json
+++ b/package.json
@@ -50,7 +50,7 @@
     "@vitest/coverage-v8": "^4.1.1",
     "tsup": "^8.0.0",
     "tsx": "^4.7.0",
-    "typescript": "^5.4.0",
+    "typescript": "^5.9.3",
     "vitest": "^4.1.1"
   },
   "keywords": [

--- a/src/cli/commands/dashboard.ts
+++ b/src/cli/commands/dashboard.ts
@@ -25,10 +25,28 @@ export interface DashboardResponse {
 export interface DashboardScore {
   total: number
   reasoning: string
+  dimensions?: {
+    accuracy: number
+    completeness: number
+    conciseness: number
+  }
+  structured_reasoning?: {
+    strengths: string[]
+    weaknesses: string[]
+    verdict: string
+  }
+}
+
+export interface DashboardRunMeta {
+  run_id: string
+  config_file?: string
+  verdict_version?: string
+  hardware?: string
 }
 
 export interface DashboardRun {
   run_id: string
+  run_meta?: DashboardRunMeta
   responses: Record<string, DashboardResponse>
   scores: Record<string, DashboardScore>
 }
@@ -62,6 +80,17 @@ interface ValidateOptions {
 interface PreviewOptions {
   input?: string
   port: string
+}
+
+interface ServeOptions {
+  results: string
+  port: string
+}
+
+interface DeployOptions {
+  to: string
+  results: string
+  output: string
 }
 
 // ─── Generate command ────────────────────────────────────────────────────────
@@ -281,14 +310,37 @@ export function aggregateResults(resultsDir: string, files: string[]): Dashboard
       }
 
       for (const [modelId, score] of Object.entries(c.scores || {})) {
-        scores[modelId] = {
+        const dashScore: DashboardScore = {
           total: score.total || 0,
           reasoning: score.reasoning || '',
         }
+
+        // Include per-dimension scores if available
+        if (typeof score.accuracy === 'number' && typeof score.completeness === 'number' && typeof score.conciseness === 'number') {
+          dashScore.dimensions = {
+            accuracy: score.accuracy,
+            completeness: score.completeness,
+            conciseness: score.conciseness,
+          }
+        }
+
+        // Include structured reasoning if available
+        if (score.structured_reasoning) {
+          dashScore.structured_reasoning = score.structured_reasoning as DashboardScore['structured_reasoning']
+        }
+
+        scores[modelId] = dashScore
       }
+
+      // Build run metadata from result-level metadata
+      const runMeta: DashboardRunMeta = { run_id: runId }
+      if (result.reproducibility?.config_file) runMeta.config_file = result.reproducibility.config_file
+      if (result.environment?.verdict_version) runMeta.verdict_version = result.environment.verdict_version
+      if (result.hardware) runMeta.hardware = `${result.hardware.cpu} ${result.hardware.ram_gb}GB`
 
       dashCase.runs.push({
         run_id: runId,
+        run_meta: runMeta,
         responses,
         scores,
       })
@@ -390,6 +442,128 @@ export function validateDashboardData(data: unknown): string[] {
   }
 
   return errors
+}
+
+// ─── Serve command ──────────────────────────────────────────────────────────
+
+export async function dashboardServeCommand(opts: ServeOptions): Promise<void> {
+  console.log()
+  console.log(chalk.bold('  verdict') + chalk.dim(' dashboard serve'))
+  console.log()
+
+  const resultsDir = path.resolve(opts.results)
+  if (!fs.existsSync(resultsDir)) {
+    console.error(chalk.red(`  ✗ Results directory not found: ${opts.results}`))
+    console.log(chalk.dim('  Run some evals first:'))
+    console.log(`    ${chalk.cyan('verdict run')}`)
+    process.exit(1)
+  }
+
+  const files = fs.readdirSync(resultsDir).filter(f => f.endsWith('.json'))
+  if (files.length === 0) {
+    console.error(chalk.red('  ✗ No result JSON files found'))
+    console.log(chalk.dim('  Run some evals first:'))
+    console.log(`    ${chalk.cyan('verdict run')}`)
+    process.exit(1)
+  }
+
+  // Find template
+  const templatePath = findTemplatePath('index.html')
+  if (!templatePath) {
+    console.error(chalk.red('  ✗ Dashboard template not found'))
+    process.exit(1)
+  }
+
+  const port = parseInt(opts.port, 10)
+  const { createServer } = await import('http')
+
+  const server = createServer((_req, res) => {
+    // Re-aggregate on every request for live reloading
+    const currentFiles = fs.readdirSync(resultsDir).filter(f => f.endsWith('.json'))
+    const dashboardData = aggregateResults(resultsDir, currentFiles)
+    const template = fs.readFileSync(templatePath, 'utf-8')
+    const html = template.replace('/*__DASHBOARD_DATA__*/null', JSON.stringify(dashboardData))
+
+    res.writeHead(200, { 'Content-Type': 'text/html; charset=utf-8' })
+    res.end(html)
+  })
+
+  server.listen(port, () => {
+    console.log(chalk.green(`  ✓ Dashboard serving at: ${chalk.cyan(`http://localhost:${port}`)}`))
+    console.log(chalk.dim(`    Results dir: ${resultsDir}`))
+    console.log(chalk.dim('    Auto-refreshes on each request'))
+    console.log(chalk.dim('    Press Ctrl+C to stop'))
+    console.log()
+  })
+}
+
+// ─── Deploy command ─────────────────────────────────────────────────────────
+
+export async function dashboardDeployCommand(opts: DeployOptions): Promise<void> {
+  console.log()
+  console.log(chalk.bold('  verdict') + chalk.dim(' dashboard deploy'))
+  console.log()
+
+  const resultsDir = path.resolve(opts.results)
+  if (!fs.existsSync(resultsDir)) {
+    console.error(chalk.red(`  ✗ Results directory not found: ${opts.results}`))
+    process.exit(1)
+  }
+
+  const spinner = ora('Generating dashboard...').start()
+
+  const files = fs.readdirSync(resultsDir).filter(f => f.endsWith('.json'))
+  if (files.length === 0) {
+    spinner.fail('No result JSON files found')
+    process.exit(1)
+  }
+
+  const dashboardData = aggregateResults(resultsDir, files)
+
+  // Find template
+  const templatePath = findTemplatePath('index.html')
+  if (!templatePath) {
+    spinner.fail('Dashboard template not found')
+    process.exit(1)
+  }
+
+  const template = fs.readFileSync(templatePath, 'utf-8')
+  const html = template.replace('/*__DASHBOARD_DATA__*/null', JSON.stringify(dashboardData))
+
+  // Create output directory
+  const outputDir = path.resolve(opts.output)
+  fs.mkdirSync(outputDir, { recursive: true })
+  const htmlPath = path.join(outputDir, 'index.html')
+  fs.writeFileSync(htmlPath, html)
+  fs.writeFileSync(path.join(outputDir, 'dashboard-data.json'), JSON.stringify(dashboardData, null, 2))
+
+  spinner.succeed('Dashboard generated')
+
+  const target = opts.to
+
+  if (target === 'github-pages') {
+    console.log()
+    console.log(chalk.green(`  ✓ Dashboard files written to: ${chalk.cyan(outputDir)}`))
+    console.log()
+    console.log(chalk.dim('  To deploy to GitHub Pages:'))
+    console.log(`    1. Commit the ${chalk.cyan(outputDir)} directory`)
+    console.log(`    2. Go to Settings → Pages → Source → Deploy from branch`)
+    console.log(`    3. Set folder to ${chalk.cyan('/' + path.relative(process.cwd(), outputDir))}`)
+    console.log()
+  } else if (target === 'cloudflare-pages') {
+    console.log()
+    console.log(chalk.green(`  ✓ Dashboard files written to: ${chalk.cyan(outputDir)}`))
+    console.log()
+    console.log(chalk.dim('  To deploy to Cloudflare Pages:'))
+    console.log(`    ${chalk.cyan(`npx wrangler pages deploy ${outputDir}`)}`)
+    console.log()
+  } else {
+    console.log()
+    console.log(chalk.green(`  ✓ Dashboard files written to: ${chalk.cyan(outputDir)}`))
+    console.log()
+    console.log(chalk.dim(`  Deploy the ${outputDir} directory to your hosting provider.`))
+    console.log()
+  }
 }
 
 // ─── Helpers ─────────────────────────────────────────────────────────────────

--- a/src/cli/index.ts
+++ b/src/cli/index.ts
@@ -15,7 +15,7 @@ import { publishCommand } from './commands/publish.js'
 import { leaderboardCommand } from './commands/leaderboard.js'
 import { reportCommand } from './commands/report.js'
 import { evalAddCommand, evalRemoveCommand, evalListCommand, evalInitCommand } from './commands/eval.js'
-import { dashboardGenerateCommand, dashboardValidateCommand, dashboardPreviewCommand } from './commands/dashboard.js'
+import { dashboardGenerateCommand, dashboardValidateCommand, dashboardPreviewCommand, dashboardServeCommand, dashboardDeployCommand } from './commands/dashboard.js'
 
 const program = new Command()
 
@@ -226,5 +226,20 @@ dashboard
   .option('-i, --input <path>', 'Input dashboard-data.json file', 'dashboard-data.json')
   .option('-p, --port <n>', 'Port to listen on', '3000')
   .action(dashboardPreviewCommand)
+
+dashboard
+  .command('serve')
+  .description('Serve dashboard locally from results directory (auto-refreshes)')
+  .option('-r, --results <dir>', 'Results directory', './results')
+  .option('-p, --port <n>', 'Port to listen on', '8080')
+  .action(dashboardServeCommand)
+
+dashboard
+  .command('deploy')
+  .description('Generate dashboard for deployment')
+  .option('--to <target>', 'Deployment target (github-pages, cloudflare-pages)', 'github-pages')
+  .option('-r, --results <dir>', 'Results directory', './results')
+  .option('-o, --output <dir>', 'Output directory for deploy artifacts', './published')
+  .action(dashboardDeployCommand)
 
 program.parse()

--- a/src/core/runner.ts
+++ b/src/core/runner.ts
@@ -2,7 +2,7 @@ import fs from 'fs'
 import path from 'path'
 import crypto from 'crypto'
 import { execSync } from 'child_process'
-import type { Config, EvalPack, RunResult, ModelSummary, CaseResult, Checkpoint, JudgeScore, Assertion } from '../types/index.js'
+import type { Config, EvalPack, RunResult, ModelSummary, CaseResult, Checkpoint, JudgeScore, Assertion, RunMeta } from '../types/index.js'
 import { callModel, callModelMultiTurn, callModelWithTools } from '../providers/compat.js'
 import { judgeResponse, judgeResponseCot } from '../judge/llm.js'
 import { scoreDeterministic, isDeterministic, scoreToolCall } from '../judge/deterministic.js'
@@ -196,7 +196,8 @@ export async function runEvals(
   onProgress?: (msg: string) => void,
   resume?: boolean,
   categoryFilter?: string[],
-  preload: boolean = true
+  preload: boolean = true,
+  configFile?: string
 ): Promise<RunResult> {
   const configHash = computeConfigHash(config)
   const log = onProgress ?? (() => {})
@@ -376,10 +377,18 @@ export async function runEvals(
 
   // Collect metadata
   const hardware = detectHardware()
+  const hwFormat = toRunResultFormat(hardware)
   const environment = detectEnvironment()
   const evalPackMetadata = extractEvalPackMetadata(packs)
   const packNames = packs.map(p => p.name)
-  
+
+  const runMeta: RunMeta = {
+    run_id: runId,
+    config_file: configFile || 'verdict.yaml',
+    verdict_version: environment.verdict_version,
+    hardware: `${hwFormat.cpu} ${hwFormat.ram_gb}GB`,
+  }
+
   return {
     run_id: runId,
     name: config.name,
@@ -387,8 +396,8 @@ export async function runEvals(
     models: modelIds,
     cases,
     summary,
-    // NEW: Complete metadata
-    hardware: toRunResultFormat(hardware),
+    run_meta: runMeta,
+    hardware: hwFormat,
     environment,
     eval_pack: evalPackMetadata,
     judge: {
@@ -398,7 +407,7 @@ export async function runEvals(
     },
     reproducibility: {
       command: buildReproCommand(config, packNames, modelIds),
-      config_file: 'verdict.yaml',
+      config_file: configFile || 'verdict.yaml',
       model_configs: buildModelConfigs(config)
     }
   }

--- a/src/types/index.ts
+++ b/src/types/index.ts
@@ -168,6 +168,7 @@ export interface JudgeScore {
   conciseness: number
   total: number
   reasoning: string
+  structured_reasoning?: StructuredReasoning
 }
 
 export interface CaseResult {
@@ -236,6 +237,19 @@ export interface ReproducibilityInfo {
   }>
 }
 
+export interface RunMeta {
+  run_id: string
+  config_file: string
+  verdict_version: string
+  hardware: string
+}
+
+export interface StructuredReasoning {
+  strengths: string[]
+  weaknesses: string[]
+  verdict: string
+}
+
 export interface RunResult {
   run_id: string
   name: string
@@ -245,7 +259,9 @@ export interface RunResult {
   summary: Record<string, ModelSummary>
   synthesis?: SynthesisResult
   baselineComparison?: BaselineComparison
-  // NEW: Comprehensive metadata
+  // Run-level metadata for reproducibility
+  run_meta?: RunMeta
+  // Comprehensive metadata
   hardware?: HardwareInfo
   environment?: EnvironmentInfo
   eval_pack?: EvalPackMetadata


### PR DESCRIPTION
Closes #69

Autonomously implemented by Oatis.

**Changes:**
- Extended `DashboardScore` with optional `dimensions` (accuracy/completeness/conciseness) and `structured_reasoning` fields
- Added `DashboardRunMeta` interface and attached `run_meta` to `DashboardRun`
- Updated `aggregateResults` to capture per-dimension scores, structured reasoning, and run metadata from result files
- Added `dashboardServeCommand` and `DeployOptions` stubs for Phase 2
- Extended `src/types/index.ts` with `RunMeta`, `StructuredReasoning` interfaces, and `structured_reasoning` on `JudgeScore`