### PR TITLE
fix: dashboard-data.json scan exclusion + initial published data + pages setup

### DIFF
--- a/dashboard/published/dashboard-data.json
+++ b/dashboard/published/dashboard-data.json
@@ -1,0 +1,1268 @@
+{
+  "meta": {
+    "total_runs": 4,
+    "total_cases": 18,
+    "total_models": 11,
+    "last_updated": "2026-03-30"
+  },
+  "models": {
+    "qwen7b": {
+      "name": "qwen7b"
+    },
+    "llama3.2-3b": {
+      "name": "llama3.2-3b"
+    },
+    "qwen2.5-7b": {
+      "name": "qwen2.5-7b"
+    },
+    "qwen2.5-coder-14b": {
+      "name": "qwen2.5-coder-14b"
+    },
+    "phi4-14b": {
+      "name": "phi4-14b"
+    },
+    "deepseek-r1-14b": {
+      "name": "deepseek-r1-14b"
+    },
+    "qwen2.5-coder-32b": {
+      "name": "qwen2.5-coder-32b"
+    },
+    "qwen3-coder-30b": {
+      "name": "qwen3-coder-30b"
+    },
+    "deepseek-r1-32b": {
+      "name": "deepseek-r1-32b"
+    },
+    "haiku": {
+      "name": "haiku"
+    },
+    "sonnet": {
+      "name": "sonnet"
+    }
+  },
+  "cases": [
+    {
+      "id": "simple-math",
+      "name": "simple math",
+      "suite": "quick dogfooding test",
+      "prompt": "What is 2 + 2?",
+      "runs": [
+        {
+          "run_id": "2026-03-29T20-38-27",
+          "run_meta": {
+            "run_id": "2026-03-29T20-38-27",
+            "config_file": "verdict.yaml",
+            "verdict_version": "0.2.0",
+            "hardware": "Apple M3 Ultra 256GB"
+          },
+          "responses": {
+            "qwen7b": {
+              "text": "2 + 2 equals 4.",
+              "latency_ms": 2369
+            }
+          },
+          "scores": {
+            "qwen7b": {
+              "total": 10,
+              "reasoning": "The response correctly states that 2 + 2 equals 4, addresses all criteria without additional information, and is concise.",
+              "dimensions": {
+                "accuracy": 10,
+                "completeness": 10,
+                "conciseness": 10
+              }
+            }
+          }
+        }
+      ]
+    },
+    {
+      "id": "simple-reasoning",
+      "name": "simple reasoning",
+      "suite": "quick dogfooding test",
+      "prompt": "If a train travels 60 miles per hour for 2 hours, how far does it go?",
+      "runs": [
+        {
+          "run_id": "2026-03-29T20-38-27",
+          "run_meta": {
+            "run_id": "2026-03-29T20-38-27",
+            "config_file": "verdict.yaml",
+            "verdict_version": "0.2.0",
+            "hardware": "Apple M3 Ultra 256GB"
+          },
+          "responses": {
+            "qwen7b": {
+              "text": "To find out how far the train goes, you can use the formula:\n\n\\[ \\text{Distance} = \\text{Speed} \\times \\text{Time} \\]\n\nGiven that the speed is 60 miles per hour and the time is 2 hours, you would calculate it as follows:\n\n\\[ \\text{Distance} = 60 \\, \\text{miles/hour} \\times 2 \\, \\text{hours} = 120 \\, \\text{miles} \\]\n\nSo, the train travels 120 miles.",
+              "latency_ms": 1232
+            }
+          },
+          "scores": {
+            "qwen7b": {
+              "total": 10,
+              "reasoning": "The response correctly calculates the distance and addresses all criteria succinctly.",
+              "dimensions": {
+                "accuracy": 10,
+                "completeness": 10,
+                "conciseness": 10
+              }
+            }
+          }
+        }
+      ]
+    },
+    {
+      "id": "ts-interface-1",
+      "name": "ts interface 1",
+      "suite": "code generation quality",
+      "prompt": "Create a TypeScript interface for a User with:\n- name (string, required)\n- email (string, required)\n- age (number, optional)\n- roles (array of strings, optional)\n",
+      "runs": [
+        {
+          "run_id": "2026-03-29T21-13-59",
+          "run_meta": {
+            "run_id": "2026-03-29T21-13-59",
+            "config_file": "verdict.yaml",
+            "verdict_version": "0.2.0",
+            "hardware": "Apple M3 Ultra 256GB"
+          },
+          "responses": {
+            "qwen7b": {
+              "text": "Certainly! Below is a TypeScript interface that defines the structure you've described:\n\n```typescript\ninterface User {\n    name: string;\n    email: string;\n    age?: number; // Optional property\n    roles?: string[]; // Optional array property\n}\n```\n\n### Explanation:\n- `name`: A required string.\n- `email`: A required string.\n- `age`: An optional number (denoted by the `?`).\n- `roles`: An optional array of strings (also denoted by the `?`).\n\nYou can use this interface to define and validate user objects in your TypeScript code. Here's an example of how you might create a user object using this interface:\n\n```typescript\nconst user: User = {\n    name: \"John Doe\",\n    email: \"john.doe@example.com\",\n    age: 30,\n    roles: [\"admin\", \"user\"]\n};\n\n// Or with optional properties:\nconst user2: User = {\n    name: \"Jane Smith\",\n    email: \"jane.smith@example.com\"\n};\n```\n\nThis setup ensures that any object conforming to the `User` interface will have a `name` and `email`, but may optionally include an `age` and/or `roles`.",
+              "latency_ms": 2583
+            }
+          },
+          "scores": {
+            "qwen7b": {
+              "total": 10,
+              "reasoning": "The response accurately defines the TypeScript interface with all required and optional fields correctly specified.",
+              "dimensions": {
+                "accuracy": 10,
+                "completeness": 10,
+                "conciseness": 10
+              }
+            }
+          }
+        }
+      ]
+    },
+    {
+      "id": "bugfix-1",
+      "name": "bugfix 1",
+      "suite": "code generation quality",
+      "prompt": "Fix this bug:\n\n```typescript\nfunction extractJson(text: string): string {\n  return text.replace(/^```json\\s*/, '').replace(/\\s*```$/, '');\n}\n```\n\nProblem: Fails when text has content before the fence like \"Here's an example:\\n```json\\n{...}\\n```\"\n",
+      "runs": [
+        {
+          "run_id": "2026-03-29T21-13-59",
+          "run_meta": {
+            "run_id": "2026-03-29T21-13-59",
+            "config_file": "verdict.yaml",
+            "verdict_version": "0.2.0",
+            "hardware": "Apple M3 Ultra 256GB"
+          },
+          "responses": {
+            "qwen7b": {
+              "text": "The issue with your current implementation is that it removes everything up to and including the first occurrence of `^```json\\s*` and everything after the last occurrence of `\\s*```$`. This can cause problems if there are other lines before or after the JSON code block.\n\nTo handle this correctly, you should look for a specific marker (like \"JSON:\" or any unique identifier) within the text to ensure that only the intended JSON content is extracted. Here's an improved version of your function:\n\n```typescript\nfunction extractJson(text: string): string {\n  // Look for a line containing \"JSON:\" and capture everything after it until the next fence.\n  const match = text.match(/(?<=\\n)(.*?)(?=^```)/s);\n  \n  if (match) {\n    return match[0].trim();\n  } else {\n    return '';\n  }\n}\n```\n\n### Explanation:\n- `/(?<=\\n)(.*?)(?=^` - This regular expression uses a positive lookbehind `(?<=\\n)` to ensure that the match starts after a newline character, and a positive lookahead `(?=^```)` to ensure it ends before the next fence.\n  - `.*?` is a non-greedy match for any characters (except newline) between the markers.\n- `.trim()` removes leading and trailing whitespace from the extracted content.\n\n### Example Usage:\n```typescript\nconst text = `\nHere's an example:\nJSON:\n{\n  \"name\": \"John\",\n  \"age\": 30,\n  \"city\": \"New York\"\n}\n`;\n\nconsole.log(extractJson(text)); // Output: {\n//   \"name\": \"John\",\n//   \"age\": 30,\n//   \"city\": \"New York\"\n// }\n```\n\nThis approach ensures that only the content between the markers is extracted, even if there are other lines before or after the JSON block.",
+              "latency_ms": 3854
+            }
+          },
+          "scores": {
+            "qwen7b": {
+              "total": 8.4,
+              "reasoning": "The response provides a correct and functional solution that addresses the criteria, but it could be more concise by removing unnecessary explanations.",
+              "dimensions": {
+                "accuracy": 8,
+                "completeness": 9,
+                "conciseness": 8
+              }
+            }
+          }
+        }
+      ]
+    },
+    {
+      "id": "python-processing-1",
+      "name": "python processing 1",
+      "suite": "code generation quality",
+      "prompt": "Write Python code to:\n1. Read a JSON file\n2. Filter items where status == \"active\"\n3. Sort by created_at descending\n4. Return top 10\n",
+      "runs": [
+        {
+          "run_id": "2026-03-29T21-13-59",
+          "run_meta": {
+            "run_id": "2026-03-29T21-13-59",
+            "config_file": "verdict.yaml",
+            "verdict_version": "0.2.0",
+            "hardware": "Apple M3 Ultra 256GB"
+          },
+          "responses": {
+            "qwen7b": {
+              "text": "Certainly! Below is a Python script that reads a JSON file, filters the items where `status` is `\"active\"`, sorts them by `created_at` in descending order, and returns the top 10 results.\n\n```python\nimport json\n\ndef read_and_process_json(file_path):\n    # Step 1: Read the JSON file\n    with open(file_path, 'r') as file:\n        data = json.load(file)\n    \n    # Step 2: Filter items where status == \"active\"\n    active_items = [item for item in data if item.get('status') == 'active']\n    \n    # Step 3: Sort by created_at descending\n    sorted_active_items = sorted(active_items, key=lambda x: x['created_at'], reverse=True)\n    \n    # Step 4: Return top 10\n    top_10_items = sorted_active_items[:10]\n    \n    return top_10_items\n\n# Example usage:\nfile_path = 'path/to/your/json/file.json'\ntop_10_results = read_and_process_json(file_path)\nprint(top_10_results)\n```\n\n### Explanation:\n\n- **Step 1:** The script opens and reads the JSON file using `json.load()`.\n- **Step 2:** A list comprehension is used to filter out items where the `status` key equals `\"active\"`.\n- **Step 3:** The filtered items are sorted by the `created_at` field in descending order.\n- **Step 4:** The top 10 items from the sorted list are returned.\n\n### Example JSON File (`file.json`):\n\n```json\n[\n    {\"id\": 1, \"status\": \"active\", \"created_at\": \"2023-09-01T15:00:00Z\"},\n    {\"id\": 2, \"status\": \"inactive\", \"created_at\": \"2023-08-30T14:00:00Z\"},\n    {\"id\": 3, \"status\": \"active\", \"created_at\": \"2023-09-05T16:00:00Z\"},\n    {\"id\": 4, \"status\": \"active\", \"created_at\": \"2023-08-25T17:00:00Z\"},\n    {\"id\": 5, \"status\": \"inactive\", \"created_at\": \"2023-09-02T18:00:00Z\"}\n]\n```\n\n### Output:\n\n```python\n[\n    {'id': 3, 'status': 'active', 'created_at': '2023-09-05T16:00:00Z'},\n    {'id': 1, 'status': 'active', 'created_at': '2023-09-01T15:00:00Z'},\n    {'id': 4, 'status': 'active', 'created_at': '2023-08-25T17:00:00Z'}\n]\n```\n\nThis output shows the top 3 active items sorted by `created_at` in descending order. Adjust the file path and JSON structure as needed for your specific use case.",
+              "latency_ms": 6707
+            }
+          },
+          "scores": {
+            "qwen7b": {
+              "total": 10,
+              "reasoning": "The response accurately addresses all specified criteria and is concise without padding.",
+              "dimensions": {
+                "accuracy": 10,
+                "completeness": 10,
+                "conciseness": 10
+              }
+            }
+          }
+        }
+      ]
+    },
+    {
+      "id": "error-handling-1",
+      "name": "error handling 1",
+      "suite": "code generation quality",
+      "prompt": "Add error handling to:\n\n```typescript\nconst data = JSON.parse(response);\nreturn data.results.map(r => r.id);\n```\n",
+      "runs": [
+        {
+          "run_id": "2026-03-29T21-13-59",
+          "run_meta": {
+            "run_id": "2026-03-29T21-13-59",
+            "config_file": "verdict.yaml",
+            "verdict_version": "0.2.0",
+            "hardware": "Apple M3 Ultra 256GB"
+          },
+          "responses": {
+            "qwen7b": {
+              "text": "Certainly! Adding error handling is crucial to ensure that your code can gracefully handle unexpected situations, such as invalid JSON or missing `results` in the response. Here's how you can add error handling to your TypeScript code:\n\n```typescript\ntry {\n    const data = JSON.parse(response);\n    if (Array.isArray(data.results)) {\n        return data.results.map(r => r.id);\n    } else {\n        throw new Error(\"Response does not contain an array under 'results'\");\n    }\n} catch (error) {\n    console.error(\"Error parsing response:\", error);\n    // You can handle the error appropriately, e.g., by returning an empty array or throwing a custom error\n    return [];\n}\n```\n\n### Explanation:\n1. **Try-Catch Block**: The `try` block attempts to parse the JSON and process it.\n2. **Array Check**: After parsing, we check if `data.results` is an array using `Array.isArray()`. If not, we throw an error.\n3. **Error Handling**: In the `catch` block, any errors that occur during parsing are caught, logged, and handled appropriately (in this case, by returning an empty array).\n\nThis approach ensures that your code can handle both JSON parsing errors and unexpected data structures in a robust manner.",
+              "latency_ms": 2570
+            }
+          },
+          "scores": {
+            "qwen7b": {
+              "total": 8.4,
+              "reasoning": "The response accurately addresses the criteria by handling JSON parse errors and missing results field, but it does not explicitly handle null/undefined values or return a safe default. It also could be more concise by combining some checks.",
+              "dimensions": {
+                "accuracy": 8,
+                "completeness": 9,
+                "conciseness": 8
+              }
+            }
+          }
+        }
+      ]
+    },
+    {
+      "id": "test-case-1",
+      "name": "test case 1",
+      "suite": "code generation quality",
+      "prompt": "Write a test for this function:\n\n```typescript\nfunction scoreToolCall(\n  toolCalls: ToolCall[] | undefined,\n  expectedTool: string\n): number {\n  if (!toolCalls?.length) {\n    return expectedTool === '' ? 10 : 0;\n  }\n  return toolCalls.some(t => t.name === expectedTool) ? 10 : 0;\n}\n```\n",
+      "runs": [
+        {
+          "run_id": "2026-03-29T21-13-59",
+          "run_meta": {
+            "run_id": "2026-03-29T21-13-59",
+            "config_file": "verdict.yaml",
+            "verdict_version": "0.2.0",
+            "hardware": "Apple M3 Ultra 256GB"
+          },
+          "responses": {
+            "qwen7b": {
+              "text": "To write a test for the `scoreToolCall` function, we can use a testing framework like Jest. Below is an example of how you might set up and run tests using Jest.\n\nFirst, ensure that you have Jest installed in your project:\n\n```bash\nnpm install --save-dev jest\n```\n\nNext, create or update your test file (e.g., `scoreToolCall.test.ts`):\n\n```typescript\nimport { scoreToolCall } from './path-to-your-file';\n\ndescribe('scoreToolCall', () => {\n  test('returns 10 when expected tool is empty and no tool calls are provided', () => {\n    const result = scoreToolCall([], '');\n    expect(result).toBe(10);\n  });\n\n  test('returns 10 when the expected tool name matches one of the tool calls', () => {\n    const toolCalls = [\n      { name: 'toolA' },\n      { name: 'toolB' },\n      { name: 'expectedTool' }\n    ];\n    const result = scoreToolCall(toolCalls, 'expectedTool');\n    expect(result).toBe(10);\n  });\n\n  test('returns 0 when the expected tool name does not match any of the tool calls', () => {\n    const toolCalls = [\n      { name: 'toolA' },\n      { name: 'toolB' }\n    ];\n    const result = scoreToolCall(toolCalls, 'expectedTool');\n    expect(result).toBe(0);\n  });\n\n  test('returns 10 when expected tool is empty and there are tool calls', () => {\n    const toolCalls = [\n      { name: 'toolA' },\n      { name: 'toolB' }\n    ];\n    const result = scoreToolCall(toolCalls, '');\n    expect(result).toBe(10);\n  });\n\n  test('returns 0 when expected tool is not empty and no matching tool call exists', () => {\n    const toolCalls = [\n      { name: 'toolA' },\n      { name: 'toolB' }\n    ];\n    const result = scoreToolCall(toolCalls, 'expectedTool');\n    expect(result).toBe(0);\n  });\n});\n```\n\nMake sure to replace `./path-to-your-file` with the actual path to your file containing the `scoreToolCall` function.\n\nTo run the tests, you can use the following command:\n\n```bash\nnpx jest\n```\n\nThis will execute all the test cases and provide feedback on whether they pass or fail.",
+              "latency_ms": 4998
+            }
+          },
+          "scores": {
+            "qwen7b": {
+              "total": 10,
+              "reasoning": "The evaluation meets all specified criteria accurately and concisely addresses the requirements.",
+              "dimensions": {
+                "accuracy": 10,
+                "completeness": 10,
+                "conciseness": 10
+              }
+            }
+          }
+        }
+      ]
+    },
+    {
+      "id": "refactor-1",
+      "name": "refactor 1",
+      "suite": "code generation quality",
+      "prompt": "Refactor this to be more maintainable:\n\n```typescript\nconst stripped = text\n  .replace(/^```(?:json)?\\s*/i, '')\n  .replace(/\\s*```$/, '')\n  .trim();\n\nif (stripped.startsWith('{') || stripped.startsWith('[')) {\n  try {\n    return JSON.parse(stripped);\n  } catch { return null; }\n}\nreturn null;\n```\n",
+      "runs": [
+        {
+          "run_id": "2026-03-29T21-13-59",
+          "run_meta": {
+            "run_id": "2026-03-29T21-13-59",
+            "config_file": "verdict.yaml",
+            "verdict_version": "0.2.0",
+            "hardware": "Apple M3 Ultra 256GB"
+          },
+          "responses": {
+            "qwen7b": {
+              "text": "Certainly! To make the code more maintainable, we can break it down into smaller functions and add comments for clarity. Here's a refactored version:\n\n```typescript\nfunction stripCodeBlocks(text: string): string {\n    // Remove leading and trailing code block delimiters if present.\n    return text\n        .replace(/^```(?:json)?\\s*/i, '')\n        .replace(/\\s*```$/, '')\n        .trim();\n}\n\nfunction parseJsonIfPossible(strippedText: string): any | null {\n    // Check if the stripped text starts with a JSON object or array.\n    if (strippedText.startsWith('{') || strippedText.startsWith('[')) {\n        try {\n            return JSON.parse(strippedText);\n        } catch {\n            // If parsing fails, return null.\n            return null;\n        }\n    }\n    // Return null if the text does not start with a JSON object or array.\n    return null;\n}\n\nfunction processText(text: string): any | null {\n    const stripped = stripCodeBlocks(text);\n    return parseJsonIfPossible(stripped);\n}\n\n// Example usage:\nconst inputText = \"```json\\n{\\n  \\\"key\\\": \\\"value\\\"\\n}\\n```\";\nconst result = processText(inputText);\nconsole.log(result); // Output: { key: 'value' }\n```\n\n### Explanation:\n\n1. **`stripCodeBlocks` Function**: This function handles the removal of code block delimiters and any leading or trailing whitespace.\n2. **`parseJsonIfPossible` Function**: This function checks if the stripped text starts with a JSON object or array and attempts to parse it. If parsing fails, it returns `null`.\n3. **`processText` Function**: This is the main function that combines the above two functions to process the input text.\n\nThis refactoring makes each part of the logic more modular and easier to understand and maintain.",
+              "latency_ms": 3830
+            }
+          },
+          "scores": {
+            "qwen7b": {
+              "total": 10,
+              "reasoning": "The refactored code meets all the specified criteria and is accurate, complete, and concise.",
+              "dimensions": {
+                "accuracy": 10,
+                "completeness": 10,
+                "conciseness": 10
+              }
+            }
+          }
+        }
+      ]
+    },
+    {
+      "id": "api-design-1",
+      "name": "api design 1",
+      "suite": "code generation quality",
+      "prompt": "Design a function signature for:\n\"Score a model's response against expected output using different scoring methods (exact, contains, LLM judge)\"\n",
+      "runs": [
+        {
+          "run_id": "2026-03-29T21-13-59",
+          "run_meta": {
+            "run_id": "2026-03-29T21-13-59",
+            "config_file": "verdict.yaml",
+            "verdict_version": "0.2.0",
+            "hardware": "Apple M3 Ultra 256GB"
+          },
+          "responses": {
+            "qwen7b": {
+              "text": "Certainly! Below is a proposed function signature for scoring a model's response against an expected output using various scoring methods:\n\n```python\ndef score_response(model_output: str, expected_output: str, scoring_method: str) -> float:\n    \"\"\"\n    Scores the model's response against the expected output based on the specified scoring method.\n\n    :param model_output: The output generated by the language model.\n    :param expected_output: The expected or correct output to compare against.\n    :param scoring_method: The method used for scoring, which can be 'exact', 'contains', or 'llm_judge'.\n    :return: A score indicating how well the model's response matches the expected output. \n             - For 'exact': 1.0 if exact match, 0.0 otherwise.\n             - For 'contains': 1.0 if expected_output is a substring of model_output, 0.0 otherwise.\n             - For 'llm_judge': A score between 0.0 and 1.0 based on the LLM's judgment (hypothetical implementation).\n    \"\"\"\n    pass\n```\n\n### Explanation:\n- **model_output**: The string output generated by the language model that needs to be scored.\n- **expected_output**: The reference or expected string against which the `model_output` is compared.\n- **scoring_method**: A string indicating the scoring method to use. It can take one of three values: `'exact'`, `'contains'`, or `'llm_judge'`.\n\n### Scoring Methods:\n1. **Exact Match (`'exact'`)**: \n   - Returns `1.0` if `model_output` is exactly equal to `expected_output`.\n   - Returns `0.0` otherwise.\n\n2. **Contains (`'contains'`)**:\n   - Returns `1.0` if `expected_output` is a substring of `model_output`.\n   - Returns `0.0` otherwise.\n\n3. **LLM Judge (`'llm_judge'`)**:\n   - This method would involve some form of judgment or evaluation by the LLM itself, possibly using natural language understanding techniques to determine how well the response matches the expected output.\n   - The return value is a float between `0.0` and `1.0`, where `1.0` indicates a perfect match.\n\n### Example Usage:\n```python\nscore = score_response(\"The quick brown fox\", \"quick brown\", 'contains')\nprint(score)  # Output: 1.0\n\nscore = score_response(\"The quick brown fox jumps over the lazy dog\", \"lazy dog\", 'exact')\nprint(score)  # Output: 0.0\n\nscore = score_response(\"The quick brown fox\", \"A quick brown fox\", 'llm_judge')\nprint(score)  # Output: 0.8 (hypothetical value)\n```\n\nThis function signature and scoring methods provide a flexible way to evaluate model responses based on different criteria, which can be useful in various applications such as natural language processing, chatbot evaluations, or general text generation tasks.",
+              "latency_ms": 6169
+            }
+          },
+          "scores": {
+            "qwen7b": {
+              "total": 9,
+              "reasoning": "Accurate content and criteria addressed. Minor room for improvement in conciseness by removing unnecessary words.",
+              "dimensions": {
+                "accuracy": 8,
+                "completeness": 10,
+                "conciseness": 9
+              }
+            }
+          }
+        }
+      ]
+    },
+    {
+      "id": "documentation-1",
+      "name": "documentation 1",
+      "suite": "code generation quality",
+      "prompt": "Write JSDoc for:\n\n```typescript\nfunction extractJson(text: string): string | null {\n  const match = text.match(/```(?:json)?\\s*\\n?([\\s\\S]*?)\\n?```/);\n  return match ? match[1].trim() : null;\n}\n```\n",
+      "runs": [
+        {
+          "run_id": "2026-03-29T21-13-59",
+          "run_meta": {
+            "run_id": "2026-03-29T21-13-59",
+            "config_file": "verdict.yaml",
+            "verdict_version": "0.2.0",
+            "hardware": "Apple M3 Ultra 256GB"
+          },
+          "responses": {
+            "qwen7b": {
+              "text": "Certainly! Below is the JSDoc comment for the provided TypeScript function:\n\n```typescript\n/**\n * Extracts JSON content enclosed in triple backticks (```) with an optional \"json\" keyword from a given string.\n *\n * @param text - The input string containing the JSON content.\n * @returns The extracted JSON content as a string, or null if no match is found.\n */\nfunction extractJson(text: string): string | null {\n  const match = text.match(/```(?:json)?\\s*\\n?([\\s\\S]*?)\\n?```/);\n  return match ? match[1].trim() : null;\n}\n```\n\n### Explanation of the JSDoc:\n- **`@param text - The input string containing the JSON content.`**: Describes the parameter `text`, which is expected to be a string that may contain JSON content enclosed in triple backticks.\n- **`@returns The extracted JSON content as a string, or null if no match is found.`**: Describes what the function returns. It will return the trimmed JSON content as a string if a match is found; otherwise, it returns `null`.\n\nThis JSDoc comment provides clear documentation for the function's purpose and expected behavior.",
+              "latency_ms": 2512
+            }
+          },
+          "scores": {
+            "qwen7b": {
+              "total": 9.2,
+              "reasoning": "The JSDoc is accurate and complete, but it could be slightly more concise by removing unnecessary spaces.",
+              "dimensions": {
+                "accuracy": 9,
+                "completeness": 10,
+                "conciseness": 8
+              }
+            }
+          }
+        }
+      ]
+    },
+    {
+      "id": "python-json-processing",
+      "name": "python json processing",
+      "suite": "python quick test",
+      "prompt": "Write a Python script that:\n1. Reads a JSON file containing a list of users\n2. Filters users where age >= 18 and status == \"active\"\n3. Sorts by registration_date (newest first)\n4. Writes top 20 to output.json\n\nInclude error handling for file operations and invalid data.\n",
+      "runs": [
+        {
+          "run_id": "2026-03-30T03-01-56",
+          "run_meta": {
+            "run_id": "2026-03-30T03-01-56",
+            "config_file": "verdict.yaml",
+            "verdict_version": "0.2.0",
+            "hardware": "Apple M3 Ultra 256GB"
+          },
+          "responses": {
+            "qwen2.5-7b": {
+              "text": "Certainly! Below is a Python script that accomplishes the tasks you've described:\n\n```python\nimport json\nfrom datetime import datetime\n\ndef read_json_file(file_path):\n    \"\"\"Reads a JSON file and returns its content as a list of dictionaries.\"\"\"\n    try:\n        with open(file_path, 'r') as file:\n            users = json.load(file)\n    except FileNotFoundError:\n        print(f\"Error: The file {file_path} was not found.\")\n        return []\n    except json.JSONDecodeError:\n        print(\"Error: Invalid JSON format in the file.\")\n        return []\n    else:\n        return users\n\ndef filter_users(users):\n    \"\"\"Filters users where age >= 18 and status == 'active'.\"\"\"\n    filtered_users = [user for user in users if user.get('age', 0) >= 18 and user.get('status', '') == 'active']\n    return filtered_users\n\ndef sort_users_by_registration_date(users):\n    \"\"\"Sorts the list of users by registration date (newest first).\"\"\"\n    try:\n        # Convert string to datetime for sorting\n        users.sort(key=lambda x: datetime.strptime(x['registration_date'], '%Y-%m-%d'), reverse=True)\n    except KeyError:\n        print(\"Error: 'registration_date' key not found in user data.\")\n    return users\n\ndef write_top_20_users(users, output_file):\n    \"\"\"Writes the top 20 filtered and sorted users to an output JSON file.\"\"\"\n    try:\n        with open(output_file, 'w') as file:\n            json.dump(users[:20], file, indent=4)\n    except IOError:\n        print(f\"Error: Could not write to {output_file}.\")\n\ndef main():\n    input_file = \"users.json\"\n    output_file = \"output.json\"\n\n    # Read the JSON file\n    users = read_json_file(input_file)\n\n    if not users:\n        return\n\n    # Filter users based on age and status\n    filtered_users = filter_users(users)\n\n    if not filtered_users:\n        print(\"No active users aged 18 or older found.\")\n        return\n\n    # Sort by registration date (newest first)\n    sorted_users = sort_users_by_registration_date(filtered_users)\n\n    # Write top 20 to output.json\n    write_top_20_users(sorted_users, output_file)\n\nif __name__ == \"__main__\":\n    main()\n```\n\n### Explanation:\n1. **Reading the JSON File**: The `read_json_file` function reads a JSON file and returns its content as a list of dictionaries.\n2. **Filtering Users**: The `filter_users` function filters users based on age (`age >= 18`) and status (`status == 'active'`).\n3. **Sorting by Registration Date**: The `sort_users_by_registration_date` function sorts the filtered users by their registration date in descending order (newest first). It uses a lambda function to convert the string representation of dates into datetime objects for proper sorting.\n4. **Writing Top 20 Users**: The `write_top_20_users` function writes the top 20 users from the sorted list to an output JSON file.\n\n### Error Handling:\n- File operations are handled with try-except blocks to catch and print appropriate error messages if the file is not found or if there's a JSON decoding issue.\n- Key errors are caught when sorting by `registration_date` to ensure that the key exists in each user dictionary.\n\nThis script should be run from a Python environment, and you need to have a valid `users.json` file with the appropriate structure.",
+              "latency_ms": 12294
+            },
+            "llama3.2-3b": {
+              "text": "Here's a Python script that fulfills your requirements:\n\n```python\nimport json\nfrom datetime import datetime\n\ndef load_users(file_path):\n    try:\n        with open(file_path, 'r') as f:\n            return json.load(f)\n    except FileNotFoundError:\n        print(\"File not found. Please check the file path.\")\n        return []\n    except json.JSONDecodeError:\n        print(\"Invalid JSON data in the file.\")\n        return []\n\ndef filter_users(users):\n    filtered_users = [user for user in users if 'age' in user and 'status' in user and user['age'] >= 18 and user['status'] == \"active\"]\n    return filtered_users\n\ndef sort_users_by_registration_date(users):\n    sorted_users = sorted(users, key=lambda x: datetime.strptime(x['registration_date'], '%Y-%m-%d'), reverse=True)\n    return sorted_users[:20]\n\ndef write_to_file(file_path, users):\n    try:\n        with open(file_path, 'w') as f:\n            json.dump(users, f, indent=4)\n    except Exception as e:\n        print(f\"Error writing to file: {e}\")\n\ndef main():\n    file_path = \"users.json\"\n    output_file_path = \"output.json\"\n\n    users = load_users(file_path)\n\n    if not users:\n        return\n\n    filtered_users = filter_users(users)\n    sorted_users = sort_users_by_registration_date(filtered_users)\n\n    write_to_file(output_file_path, sorted_users)\n\nif __name__ == \"__main__\":\n    main()\n```\n\nThis script assumes that the JSON file has a structure like this:\n\n```json\n[\n    {\n        \"id\": 1,\n        \"name\": \"John Doe\",\n        \"age\": 25,\n        \"status\": \"active\",\n        \"registration_date\": \"2022-01-01\"\n    },\n    {\n        \"id\": 2,\n        \"name\": \"Jane Doe\",\n        \"age\": 30,\n        \"status\": \"inactive\",\n        \"registration_date\": \"2021-06-01\"\n    },\n    ...\n]\n```\n\nThe script will filter out users who are less than 18 years old or inactive, sort the remaining users by their registration date in descending order (newest first), and write the top 20 users to `output.json`.",
+              "latency_ms": 14003
+            },
+            "qwen2.5-coder-14b": {
+              "text": "Certainly! Below is a Python script that performs the specified tasks:\n\n```python\nimport json\nfrom datetime import datetime\n\ndef read_json_file(file_path):\n    try:\n        with open(file_path, 'r') as file:\n            return json.load(file)\n    except FileNotFoundError:\n        print(f\"Error: The file {file_path} was not found.\")\n        return None\n    except json.JSONDecodeError:\n        print(\"Error: Failed to decode JSON from the file.\")\n        return None\n\ndef filter_and_sort_users(users):\n    try:\n        # Filter users where age >= 18 and status == \"active\"\n        filtered_users = [user for user in users if user.get('age', 0) >= 18 and user.get('status') == 'active']\n        \n        # Sort by registration_date (newest first)\n        sorted_users = sorted(filtered_users, key=lambda x: datetime.strptime(x['registration_date'], '%Y-%m-%d'), reverse=True)\n        \n        return sorted_users\n    except KeyError as e:\n        print(f\"Error: Missing key in user data - {e}\")\n        return []\n    except ValueError as e:\n        print(f\"Error: Invalid date format - {e}\")\n        return []\n\ndef write_json_file(file_path, users):\n    try:\n        with open(file_path, 'w') as file:\n            json.dump(users, file, indent=4)\n    except IOError:\n        print(\"Error: Failed to write to the output file.\")\n\ndef main():\n    input_file = 'input.json'\n    output_file = 'output.json'\n    \n    # Read users from JSON file\n    users = read_json_file(input_file)\n    if users is None:\n        return\n    \n    # Filter and sort users\n    filtered_sorted_users = filter_and_sort_users(users)\n    \n    # Write top 20 users to output.json\n    write_json_file(output_file, filtered_sorted_users[:20])\n\nif __name__ == \"__main__\":\n    main()\n```\n\n### Explanation:\n\n1. **Reading the JSON File**: The `read_json_file` function attempts to open and read the JSON file. It handles `FileNotFoundError` if the file does not exist and `json.JSONDecodeError` if the file content is not valid JSON.\n\n2. **Filtering and Sorting Users**: The `filter_and_sort_users` function filters users based on age and status, then sorts them by `registration_date`. It handles potential errors such as missing keys or invalid date formats.\n\n3. **Writing to a JSON File**: The `write_json_file` function writes the filtered and sorted list of users to an output file. It handles `IOError` if writing fails.\n\n4. **Main Function**: The `main` function orchestrates reading, filtering, sorting, and writing operations. It ensures that the script exits gracefully if any step fails.\n\n### Usage:\n\n- Ensure you have a JSON file named `input.json` in the same directory as the script.\n- Each user entry in the JSON should be a dictionary with keys like `age`, `status`, and `registration_date`.\n- The script will output the top 20 filtered and sorted users to `output.json`.",
+              "latency_ms": 19825
+            },
+            "phi4-14b": {
+              "text": "```python\nimport json\nfrom datetime import datetime\n\ndef read_json_file(file_path):\n    try:\n        with open(file_path, 'r') as file:\n            return json.load(file)\n    except FileNotFoundError:\n        print(f\"Error: The file {file_path} was not found.\")\n        return None\n    except json.JSONDecodeError:\n        print(\"Error: Failed to decode JSON from the file.\")\n        return None\n\ndef write_json_file(data, file_path):\n    try:\n        with open(file_path, 'w') as file:\n            json.dump(data, file, indent=4)\n    except IOError:\n        print(f\"Error: Could not write to {file_path}.\")\n\ndef filter_and_sort_users(users):\n    filtered_users = []\n    \n    for user in users:\n        try:\n            age = int(user.get('age', 0))\n            status = user.get('status', '')\n            registration_date = datetime.strptime(user['registration_date'], '%Y-%m-%d')\n            \n            if age >= 18 and status == \"active\":\n                filtered_users.append((user, registration_date))\n        except (ValueError, KeyError) as e:\n            print(f\"Warning: Skipping user due to invalid data - {e}\")\n    \n    # Sort by registration_date descending\n    sorted_users = sorted(filtered_users, key=lambda x: x[1], reverse=True)\n    \n    return [user for user, _ in sorted_users]\n\ndef main():\n    input_file_path = 'users.json'\n    output_file_path = 'output.json'\n\n    users = read_json_file(input_file_path)\n    if users is None:\n        return\n\n    filtered_sorted_users = filter_and_sort_users(users)\n\n    # Get top 20 users\n    top_20_users = filtered_sorted_users[:20]\n\n    write_json_file(top_20_users, output_file_path)\n\nif __name__ == \"__main__\":\n    main()\n```\n\n### Explanation:\n\n1. **Reading JSON File**: The `read_json_file` function attempts to open and read a JSON file. It includes error handling for file not found and JSON decoding errors.\n\n2. **Writing JSON File**: The `write_json_file` function writes data to a specified JSON file, with error handling for IO operations.\n\n3. **Filtering and Sorting Users**:\n   - The `filter_and_sort_users` function filters users based on age (>= 18) and status (\"active\").\n   - It handles potential errors in data conversion and missing keys.\n   - Users are sorted by their registration date, with the newest first.\n\n4. **Main Function**: \n   - Reads from 'users.json'.\n   - Filters and sorts the users.\n   - Writes the top 20 users to 'output.json'.\n\nThis script ensures robustness against common file and data errors.",
+              "latency_ms": 16376
+            },
+            "deepseek-r1-14b": {
+              "text": "Here's a Python script that meets your requirements:\n\n```python\nimport json\nfrom datetime import datetime\n\ndef main():\n    # Read input file\n    try:\n        with open('input.json', 'r') as infile:\n            data = json.load(infile)\n    except IOError as e:\n        print(f\"Error reading file: {e}\")\n        return\n    except json.JSONDecodeError as e:\n        print(f\"Error decoding JSON: {e}\")\n        return\n\n    # Filter users\n    filtered_users = []\n    for user in data:\n        try:\n            if (user['age'] >= 18 and user['status'] == \"active\"):\n                # Validate date format\n                datetime.strptime(user['registration_date'], \"%Y-%m-%d\")\n                filtered_users.append(user)\n        except KeyError as e:\n            print(f\"Missing key in user data: {e}\")\n            continue\n        except ValueError as e:\n",
+              "latency_ms": 41182
+            },
+            "qwen2.5-coder-32b": {
+              "text": "Certainly! Below is a Python script that accomplishes the tasks you've outlined. It reads a JSON file, filters users based on age and status, sorts them by registration date, and writes the top 20 results to an output file.\n\n```python\nimport json\nfrom datetime import datetime\n\ndef read_json_file(file_path):\n    try:\n        with open(file_path, 'r') as file:\n            data = json.load(file)\n        return data\n    except FileNotFoundError:\n        print(f\"Error: The file {file_path} was not found.\")\n        return None\n    except json.JSONDecodeError:\n        print(f\"Error: The file {file_path} is not a valid JSON file.\")\n        return None\n\ndef filter_and_sort_users(users):\n    try:\n        # Filter users where age >= 18 and status == \"active\"\n        filtered_users = [\n            user for user in users\n            if isinstance(user, dict) and\n               'age' in user and isinstance(user['age'], int) and user['age'] >= 18 and\n               'status' in user and user['status'] == \"active\" and\n               'registration_date' in user and isinstance(user['registration_date'], str)\n        ]\n        \n        # Sort by registration_date (newest first)\n        filtered_users.sort(key=lambda x: datetime.strptime(x['registration_date'], '%Y-%m-%d'), reverse=True)\n        \n        return filtered_users\n    except KeyError as e:\n        print(f\"Error: Missing key in user data - {e}\")\n        return []\n    except ValueError as e:\n        print(f\"Error: Invalid date format - {e}\")\n        return []\n\ndef write_json_file(file_path, data):\n    try:\n        with open(file_path, 'w') as file:\n            json.dump(data, file, indent=4)\n        print(f\"Data successfully written to {file_path}.\")\n    except IOError as e:\n        print(f\"Error: Could not write to the file {file_path} - {e}\")\n\ndef main():\n    input_file = 'users.json'\n    output_file = 'output.json'\n    \n    users_data = read_json_file(input_file)\n    if users_data is None:\n        return\n    \n    filtered_sorted_users = filter_and_sort_users(users_data)\n    \n    # Get top 20 users\n    top_20_users = filtered_sorted_users[:20]\n    \n    write_json_file(output_file, top_20_users)\n\nif __name__ == \"__main__\":\n    main()\n```\n\n### Explanation:\n1. **Reading the JSON File**: The `read_json_file` function reads the JSON file and handles errors such as file not found or invalid JSON format.\n2. **Filtering and Sorting Users**: The `filter_and_sort_users` function filters users based on age and status, sorts them by registration date in descending order, and handles potential errors like missing keys or incorrect data types.\n3. **Writing to Output File**: The `write_json_file` function writes the filtered and sorted list of users to an output file, handling any I/O errors that might occur.\n\n### Assumptions:\n- The JSON file (`users.json`) contains a list of user dictionaries.\n- Each user dictionary has keys: `age`, `status`, and `registration_date`.\n- The `registration_date` is in the format `YYYY-MM-DD`.\n\nMake sure to replace `'users.json'` with the actual path to your input JSON file.",
+              "latency_ms": 46388
+            },
+            "qwen3-coder-30b": {
+              "text": "```python\nimport json\nfrom datetime import datetime\nimport os\n\ndef read_users_from_json(filename):\n    \"\"\"Read users from JSON file with error handling\"\"\"\n    try:\n        with open(filename, 'r', encoding='utf-8') as file:\n            data = json.load(file)\n            return data\n    except FileNotFoundError:\n        print(f\"Error: File '{filename}' not found.\")\n        return None\n    except json.JSONDecodeError as e:\n        print(f\"Error: Invalid JSON format in '{filename}': {e}\")\n        return None\n    except Exception as e:\n        print(f\"Error reading file '{filename}': {e}\")\n        return None\n\ndef validate_user_data(user):\n    \"\"\"Validate user data structure\"\"\"\n    required_fields = ['name', 'age', 'status', 'registration_date']\n    \n    # Check if user is a dictionary\n    if not isinstance(user, dict):\n        return False, \"User data must be a dictionary\"\n    \n    # Check required fields\n    for field in required_fields:\n        if field not in user:\n            return False, f\"Missing required field: {field}\"\n    \n    # Validate data types\n    if not isinstance(user['age'], (int, float)):\n        return False, \"Age must be a number\"\n    \n    if not isinstance(user['status'], str):\n        return False, \"Status must be a string\"\n    \n    if not isinstance(user['registration_date'], str):\n        return False, \"Registration date must be a string\"\n    \n    # Validate date format\n    try:\n        datetime.strptime(user['registration_date'], '%Y-%m-%d')\n    except ValueError:\n        return False, \"Registration date must be in YYYY-MM-DD format\"\n    \n    return True, \"Valid\"\n\ndef filter_and_sort_users(users):\n    \"\"\"Filter users and sort by registration date\"\"\"\n    if not users:\n        return []\n    \n    # Filter users (age >= 18 and status == \"active\")\n    filtered_users = []\n    invalid_users = []\n    \n    for i, user in enumerate(users):\n        is_valid, message = validate_user_data(user)\n        \n        if not is_valid:\n            invalid_users.append((i, message))\n            print(f\"Warning: Invalid user data at index {i}: {message}\")\n            continue\n        \n        if user['age'] >= 18 and user['status'].lower() == 'active':\n            filtered_users.append(user)\n    \n    # Sort by registration_date (newest first)\n    try:\n        filtered_users.sort(\n            key=lambda x: datetime.strptime(x['registration_date'], '%Y-%m-%d'),\n            reverse=True\n        )\n    except Exception as e:\n        print(f\"Error sorting users: {e}\")\n        return []\n    \n    return filtered_users\n\ndef write_users_to_json(users, filename):\n    \"\"\"Write users to JSON file with error handling\"\"\"\n    try:\n        with open(filename, 'w', encoding='utf-8') as file:\n            json.dump(users, file, indent=2, ensure_ascii=False)\n        print(f\"Successfully wrote {len(users)} users to '{filename}'\")\n        return True\n    except Exception as e:\n        print(f\"Error writing to file '{filename}': {e}\")\n        return False\n\ndef main():\n    \"\"\"Main function to execute the user filtering process\"\"\"\n    input_file = 'users.json'\n    output_file = 'output.json'\n    \n    print(\"Starting user filtering process...\")\n    \n    # Step 1: Read users from JSON file\n    print(f\"Reading users from '{input_file}'...\")\n    users_data = read_users_from_json(input_file)\n    \n    if users_data is None:\n        print(\"Failed to read users data. Exiting.\")\n        return\n    \n    # Ensure data is a list\n    if not isinstance(users_data, list):\n        print(f\"Error: Expected a list of users, got {type(users_data)}\")\n        return\n    \n    print(f\"Loaded {len(users_data)} users from '{input_file}'\")\n    \n    # Step 2 & 3: Filter and sort users\n    print(\"Filtering and sorting users...\")\n    filtered_sorted_users = filter_and_sort_users(users_data)\n    \n    # Step 4: Take top 20 and write to output file\n    top_20_users = filtered_sorted_users[:20]\n    \n    print(f\"Found {len(top_20_users)} active users aged 18 or older\")\n    \n    if top_20_users:\n        print(\"Writing top 20 users to 'output.json'...\")\n        success = write_users_to_json(top_20_users, output_file)\n        if success:\n            print(\"Process completed successfully!\")\n        else:\n            print(\"Failed to write output file.\")\n    else:\n        print(\"No users match the criteria. Writing empty array to output file...\")\n        success = write_users_to_json([], output_file)\n        if success:\n            print(\"Process completed successfully!\")\n\n# Example usage with sample data\ndef",
+              "latency_ms": 20196
+            },
+            "deepseek-r1-32b": {
+              "text": "Here's a Python script that meets your requirements:\n\n```python\nimport json\nfrom datetime import datetime\nimport argparse\n\ndef read_json_file(file_path):\n    try:\n        with open(file_path, 'r') as file:\n            data = json.load(file)\n            return data\n    except FileNotFoundError:\n        print(f\"Error: Input file '{file_path}' not found.\")\n        return None\n    except json.JSONDecodeError:\n        print(\"Error: Invalid JSON format in input file.\")\n        return None\n\ndef write_json_file(data, file_path):\n    try:\n        with open(file_path, 'w') as file:\n            json.dump(data, file, indent=4)\n        print(f\"Successfully wrote to '{file_path}'\")\n    except IOError:\n        print(f\"Error: Could not write to output file '{file_path}'\")\n\ndef process_users(users):\n    filtered = []\n    for user in users:\n        try:\n            if user.get('age', 0) >= 18 and user.get('status') == 'active':\n                filtered.append(user)\n        except KeyError as e:\n            print(f\"Invalid data format: Missing key '{e.args[0]}'\")\n    \n    # Convert registration_date strings to datetime objects for comparison\n    try:\n        sorted_users = sorted(filtered, \n                             key=lambda x: datetime.strptime(x['registration_date'], '%Y-%m-%d'),\n                             reverse=True)\n    except KeyError as e:\n        print(f\"Invalid data format: Missing key '{e.args[0]}'\")\n        return []\n    \n    # Take top 20 users\n    top_20 = sorted_users[:20]\n    return top_20\n\ndef main():\n    parser = argparse.ArgumentParser(description='Process user data')\n    parser.add_argument('--input', type=str, default='input.json',\n                       help='Input JSON file path (default: input.json)')\n    parser",
+              "latency_ms": 48894
+            },
+            "haiku": {
+              "text": "I'll create a robust Python script with comprehensive error handling for this task.\n\nNow let me create a sample input file for testing:\n\nNow let's test the script:\n\nLet's verify the output:\n\nPerfect! Now let's create a README with usage instructions:\n\n## Summary\n\nCreated a production-ready Python script with:\n\n**Core Features:**\n- Reads JSON user list from `users.json`\n- Filters users: age ≥ 18 AND status == \"active\"\n- Sorts by registration_date (newest first)\n- Outputs top 20 to `output.json`\n\n**Error Handling:**\n- File not found / permission errors\n- Invalid JSON parsing\n- Missing required fields (warns & skips)\n- Invalid age values (warns & skips)\n- Invalid date formats (warns & skips)\n- Wrong data structure validation\n\n**Bonus Features:**\n- Multiple date format support (ISO 8601, DD/MM/YYYY, MM/DD/YYYY)\n- Detailed logging to stderr (warnings separate from output)\n- Type validation and user-friendly error messages\n- Configurable parameters (min_age, required_status, top_n)\n- Clean code with docstrings and type hints\n\nThe test run successfully filtered 6 users from the sample data, correctly excluding users under 18 and non-active users, then sorted them by registration date with the newest first.",
+              "latency_ms": 58398
+            },
+            "sonnet": {
+              "text": "I'll create a Python script with robust error handling for filtering and processing user data.\n\nI've created a comprehensive Python script with the following features:\n\n## Key Features\n\n**1. File Operations with Error Handling:**\n- Checks if input file exists and is readable\n- Creates output directory if needed\n- Handles JSON parsing errors\n- Proper encoding (UTF-8) for international characters\n\n**2. Data Validation:**\n- Validates each user record has required fields (`age`, `status`, `registration_date`)\n- Type checking for age (numeric) and status (string)\n- Warns about invalid records but continues processing\n- Validates the input is a list\n\n**3. Date Parsing:**\n- Supports multiple common date formats (ISO 8601, US/EU formats)\n- Gracefully handles unparseable dates with warnings\n\n**4. Core Functionality:**\n- Filters: age >= 18 AND status == \"active\" (case-insensitive)\n- Sorts by registration_date (newest first)\n- Returns top 20 users\n\n**5. Flexibility:**\n- Command-line arguments: `./filter_users.py [input.json] [output.json] [top_n]`\n- Defaults: `users.json` → `output.json` (top 20)\n\n## Usage\n\n```bash\n# Default (users.json → output.json, top 20)\npython filter_users.py\n\n# Custom files\npython filter_users.py data/users.json results/filtered.json\n\n# Custom limit\npython filter_users.py users.json output.json 50\n```\n\n## Error Handling\n\n- **Missing file**: Clear error message\n- **Invalid JSON**: Shows parse error location\n- **Wrong data structure**: Reports expected vs. actual type\n- **Invalid users**: Warns but continues with valid records\n- **Bad dates**: Warns and skips those users\n- **Write failures**: Reports OS-level errors\n\nThe script follows Python best practices with type hints, docstrings, and informative output messages.",
+              "latency_ms": 40406
+            }
+          },
+          "scores": {
+            "qwen2.5-7b": {
+              "total": 7,
+              "reasoning": "Uses .sort() instead of required sorted() function, missing ValueError handling for date parsing, but otherwise implements logic correctly with good error handling.",
+              "dimensions": {
+                "accuracy": 7,
+                "completeness": 7,
+                "conciseness": 7
+              }
+            },
+            "llama3.2-3b": {
+              "total": 7.4,
+              "reasoning": "Meets most requirements but fails to handle missing registration_date field gracefully, which would cause KeyError crashes despite checking age/status fields.",
+              "dimensions": {
+                "accuracy": 7,
+                "completeness": 7,
+                "conciseness": 9
+              }
+            },
+            "qwen2.5-coder-14b": {
+              "total": 8.8,
+              "reasoning": "Meets all requirements with proper error handling, clean code structure, and graceful handling of missing fields; explanation is thorough but slightly verbose.",
+              "dimensions": {
+                "accuracy": 9,
+                "completeness": 9,
+                "conciseness": 8
+              }
+            },
+            "phi4-14b": {
+              "total": 7.4,
+              "reasoning": "Works correctly with good error handling but fails to use list comprehension/filter() as explicitly required, and the tuple-unpacking approach is more complex than necessary.",
+              "dimensions": {
+                "accuracy": 8,
+                "completeness": 7,
+                "conciseness": 7
+              }
+            },
+            "deepseek-r1-14b": {
+              "total": 4,
+              "reasoning": "Code is truncated mid-function, missing sorting and output writing entirely, uses for-loop instead of required list comprehension/filter, and adds unnecessary date validation.",
+              "dimensions": {
+                "accuracy": 4,
+                "completeness": 3,
+                "conciseness": 6
+              }
+            },
+            "qwen2.5-coder-32b": {
+              "total": 9,
+              "reasoning": "Meets all requirements with proper error handling and conventions, though code is somewhat verbose with defensive isinstance checks and the explanation adds length.",
+              "dimensions": {
+                "accuracy": 9,
+                "completeness": 10,
+                "conciseness": 7
+              }
+            },
+            "qwen3-coder-30b": {
+              "total": 6.2,
+              "reasoning": "Code is incomplete (cuts off at end), uses for loop instead of required list comprehension/filter(), and is overly verbose with unnecessary validation beyond spec.",
+              "dimensions": {
+                "accuracy": 7,
+                "completeness": 6,
+                "conciseness": 5
+              }
+            },
+            "deepseek-r1-32b": {
+              "total": 5.2,
+              "reasoning": "Script is literally incomplete (cuts off mid-line), fails to use required list comprehension/filter() for filtering, but core logic present is mostly correct with proper error handling.",
+              "dimensions": {
+                "accuracy": 6,
+                "completeness": 4,
+                "conciseness": 6
+              }
+            },
+            "haiku": {
+              "total": 2.8,
+              "reasoning": "Response describes creating a script with correct features but fails to show any actual code, making it impossible to verify the must-have requirements like json.load(), filter logic, or error handling implementation.",
+              "dimensions": {
+                "accuracy": 3,
+                "completeness": 2,
+                "conciseness": 4
+              }
+            },
+            "sonnet": {
+              "total": 3.2,
+              "reasoning": "Response describes script features comprehensively but fails to provide the actual Python code requested, making verification impossible and delivery incomplete.",
+              "dimensions": {
+                "accuracy": 3,
+                "completeness": 2,
+                "conciseness": 6
+              }
+            }
+          }
+        }
+      ]
+    },
+    {
+      "id": "python-api-client",
+      "name": "python api client",
+      "suite": "python quick test",
+      "prompt": "Create a Python function that fetches data from a REST API with retry logic:\n\n```python\ndef fetch_with_retry(url: str, max_retries: int = 3) -> dict:\n    \"\"\"\n    Fetch JSON data from URL with exponential backoff retry.\n    Raises exception after max_retries failed attempts.\n    \"\"\"\n    pass  # implement this\n```\n\nRequirements:\n- Use requests library\n- Retry on network errors and 5xx status codes\n- Exponential backoff (1s, 2s, 4s)\n- Don't retry on 4xx errors\n- Log each attempt\n",
+      "runs": [
+        {
+          "run_id": "2026-03-30T03-01-56",
+          "run_meta": {
+            "run_id": "2026-03-30T03-01-56",
+            "config_file": "verdict.yaml",
+            "verdict_version": "0.2.0",
+            "hardware": "Apple M3 Ultra 256GB"
+          },
+          "responses": {
+            "llama3.2-3b": {
+              "text": "Here's a Python function that fetches data from a REST API with retry logic using the `requests` library and the `logging` module for logging attempts:\n\n```python\nimport requests\nimport logging\nimport time\nfrom functools import wraps\n\n# Set up logging\nlogging.basicConfig(level=logging.INFO, format='%(asctime)s - %(levelname)s - %(message)s')\n\ndef fetch_with_retry(url: str, max_retries: int = 3) -> dict:\n    \"\"\"\n    Fetch JSON data from URL with exponential backoff retry.\n    Raises exception after max_retries failed attempts.\n    \"\"\"\n    def decorator(func):\n        @wraps(func)\n        def wrapper(*args, **kwargs):\n            for attempt in range(max_retries + 1):  # include the initial request\n                try:\n                    response = func(url, *args, **kwargs)\n                    if response.status_code >= 500:  # 5xx status codes\n                        logging.warning(f\"Attempt {attempt+1} failed with status code {response.status_code}. Retrying in {2**attempt} seconds.\")\n                        time.sleep(2**attempt)  # exponential backoff\n                    elif response.status_code < 400:  # 4xx status codes, don't retry\n                        logging.warning(f\"Attempt {attempt+1} failed with status code {response.status_code}. Retrying in {2**attempt} seconds.\")\n                        time.sleep(2**attempt)  # exponential backoff\n                    else:\n                        return response.json()\n                except requests.RequestException as e:\n                    logging.error(f\"Attempt {attempt+1} failed: {e}\")\n                    if attempt < max_retries:\n                        time.sleep(2**attempt)  # exponential backoff\n            raise Exception(\"All attempts failed\")\n        return wrapper\n    return decorator\n\n# Example usage:\n\n@fetch_with_retry('https://api.example.com/data')\ndef fetch_data(url):\n    response = requests.get(url)\n    return response\n\ntry:\n    data = fetch_data()\n    print(data)\nexcept Exception as e:\n    logging.error(e)\n```\n\nThis function uses a decorator to wrap the `requests.get()` call, which allows us to log each attempt and implement retry logic. The `fetch_with_retry` function takes an optional `max_retries` parameter, which specifies how many times we should retry before raising an exception.\n\nThe decorator uses a loop to make up to `max_retries + 1` attempts at fetching the data. If any of these attempts fail (i.e., raise a `requests.RequestException`), it logs the error and waits for the specified amount of time before making the next attempt. This is done using exponential backoff, where the wait time doubles with each retry.\n\nIf all attempts fail, the decorator raises an exception with a message indicating that all attempts failed.",
+              "latency_ms": 13222
+            },
+            "qwen2.5-7b": {
+              "text": "Certainly! Below is the implementation of the `fetch_with_retry` function that meets your requirements. This function uses the `requests` library to make HTTP requests and implements exponential backoff with retries for network errors and 5xx status codes.\n\n```python\nimport logging\nimport time\nfrom requests.exceptions import RequestException, ConnectionError, HTTPError\n\ndef fetch_with_retry(url: str, max_retries: int = 3) -> dict:\n    \"\"\"\n    Fetch JSON data from URL with exponential backoff retry.\n    Raises exception after max_retries failed attempts.\n    \"\"\"\n    retries = 0\n    base_delay = 1  # Initial delay in seconds\n\n    while retries < max_retries:\n        try:\n            response = requests.get(url)\n            response.raise_for_status()  # Raise an HTTPError for bad responses (4xx and 5xx)\n\n            if response.status_code >= 500:  # Retry on 5xx errors\n                logging.warning(f\"Retrying due to 5xx error: {response.status_code}\")\n                time.sleep(base_delay * (2 ** retries))  # Exponential backoff\n                retries += 1\n            else:\n                return response.json()\n\n        except ConnectionError as e:\n            logging.error(f\"Connection error occurred: {e}\")\n            time.sleep(base_delay * (2 ** retries))\n            retries += 1\n\n        except HTTPError as e:\n            if response.status_code < 500:  # Do not retry on 4xx errors\n                raise e from None\n            else:\n                logging.warning(f\"Retrying due to 5xx error: {response.status_code}\")\n                time.sleep(base_delay * (2 ** retries))\n                retries += 1\n\n        except RequestException as e:\n            logging.error(f\"Request failed: {e}\")\n            time.sleep(base_delay * (2 ** retries))\n            retries += 1\n\n    raise Exception(\"Max retries exceeded\")\n\n# Example usage\nif __name__ == \"__main__\":\n    import requests\n    \n    url = \"https://api.example.com/data\"\n    \n    try:\n        data = fetch_with_retry(url)\n        print(data)\n    except Exception as e:\n        logging.error(f\"Failed to fetch data: {e}\")\n```\n\n### Explanation:\n\n1. **Logging**: The `logging` module is used to log each attempt.\n2. **Exponential Backoff**: The delay between retries increases exponentially (1s, 2s, 4s).\n3. **Retry Logic**:\n   - Retries are attempted for network errors (`ConnectionError`) and 5xx status codes.\n   - 4xx errors are not retried as they indicate client-side issues.\n4. **HTTP Error Handling**: The `response.raise_for_status()` method is used to raise an exception for HTTP errors (400-699).\n5. **Request Exception**: A generic `RequestException` is caught to handle any other request-related exceptions.\n\n### Example Usage:\nThe example usage at the bottom demonstrates how to use this function with a sample URL. Make sure to replace `\"https://api.example.com/data\"` with your actual API endpoint.\n\nThis implementation should meet your requirements for fetching data from a REST API with retry logic and exponential backoff.",
+              "latency_ms": 15078
+            },
+            "qwen2.5-coder-14b": {
+              "text": "To implement the `fetch_with_retry` function with the specified requirements, you can use the `requests` library to handle HTTP requests and implement a retry mechanism with exponential backoff. Here's how you can do it:\n\n```python\nimport requests\nimport time\nfrom requests.exceptions import RequestException\n\ndef fetch_with_retry(url: str, max_retries: int = 3) -> dict:\n    \"\"\"\n    Fetch JSON data from URL with exponential backoff retry.\n    Raises exception after max_retries failed attempts.\n    \"\"\"\n    attempt = 0\n    while attempt < max_retries:\n        try:\n            response = requests.get(url)\n            # Check for successful status codes (2xx)\n            if response.status_code >= 200 and response.status_code < 300:\n                return response.json()\n            elif response.status_code >= 500:\n                print(f\"Attempt {attempt + 1} failed with status code: {response.status_code}\")\n            else:\n                # Don't retry on 4xx errors\n                raise Exception(f\"Client error: {response.status_code}\")\n        except RequestException as e:\n            print(f\"Attempt {attempt + 1} failed with exception: {e}\")\n\n        # Exponential backoff\n        time.sleep(2 ** attempt)\n        attempt += 1\n\n    # If all attempts fail, raise an exception\n    raise Exception(\"Max retries reached. All attempts failed.\")\n\n# Example usage:\n# data = fetch_with_retry('https://api.example.com/data')\n```\n\n### Explanation:\n\n1. **Imports**: We import necessary modules: `requests` for making HTTP requests, `time` for handling delays, and `RequestException` from `requests.exceptions` to catch network-related errors.\n\n2. **Function Definition**: The function `fetch_with_retry` takes a URL and an optional `max_retries` parameter (default is 3).\n\n3. **Retry Loop**: We use a `while` loop to attempt the request up to `max_retries` times.\n\n4. **Request Handling**:\n   - We make a GET request to the specified URL.\n   - If the response status code is in the 2xx range, we return the JSON data.\n   - If the status code is in the 5xx range, we log the failure and continue retrying.\n   - For 4xx errors, we raise an exception immediately as these are client-side errors that should not be retried.\n\n5. **Exception Handling**: We catch `RequestException` to handle network-related errors gracefully.\n\n6. **Exponential Backoff**: After each failed attempt, we wait for a time duration that doubles with each retry (1s, 2s, 4s).\n\n7. **Max Retries Reached**: If all attempts fail, an exception is raised indicating that the maximum number of retries has been reached.\n\nThis function provides a robust way to handle transient errors and network issues when fetching data from a REST API.",
+              "latency_ms": 18310
+            },
+            "phi4-14b": {
+              "text": "```python\nimport time\nimport logging\nimport requests\n\ndef fetch_with_retry(url: str, max_retries: int = 3) -> dict:\n    \"\"\"\n    Fetch JSON data from URL with exponential backoff retry.\n    Raises exception after max_retries failed attempts.\n    \"\"\"\n    attempt = 0\n    while attempt < max_retries:\n        try:\n            response = requests.get(url)\n            if response.status_code >= 500:  # Retry on server errors (5xx)\n                raise requests.exceptions.RequestException(f\"Server error: {response.status_code}\")\n            elif response.status_code >= 400:  # Do not retry on client errors (4xx)\n                response.raise_for_status()\n            return response.json()  # Return JSON data if successful\n        except requests.exceptions.RequestException as e:\n            attempt += 1\n            wait_time = 2 ** attempt  # Exponential backoff\n            logging.warning(f\"Attempt {attempt} failed: {e}. Retrying in {wait_time}s...\")\n            time.sleep(wait_time)\n    raise Exception(\"Max retries exceeded\")\n\n# Example usage\nif __name__ == \"__main__\":\n    url = \"https://api.example.com/data\"\n    try:\n        data = fetch_with_retry(url)\n        print(data)\n    except Exception as e:\n        logging.error(f\"Failed to fetch data: {e}\")\n```\n\n### Explanation:\n\n1. **Import Libraries**: Import necessary libraries (`time`, `logging`, and `requests`).\n\n2. **Function Definition**: Define the function `fetch_with_retry` with parameters `url` (the API endpoint) and `max_retries` (default is 3).\n\n3. **Retry Logic**:\n   - Initialize an attempt counter.\n   - Use a while loop to retry up to `max_retries`.\n   - Inside the try block, make a GET request using `requests.get(url)`.\n   - Check if the response status code indicates a server error (5xx). If so, raise an exception to trigger a retry.\n   - For client errors (4xx), use `response.raise_for_status()` to handle them without retrying.\n   - If successful, return the JSON data.\n\n4. **Exception Handling**:\n   - Catch exceptions related to network issues or server errors.\n   - Increment the attempt counter and calculate the wait time using exponential backoff (`2 ** attempt`).\n   - Log a warning message with details of the failed attempt and retry delay.\n   - Sleep for the calculated wait time before retrying.\n\n5. **Max Retries Exceeded**:\n   - If all retries are exhausted, raise an exception indicating that max retries have been exceeded.\n\n6. **Example Usage**: Demonstrate how to use the function in a script with logging configured to capture warnings and errors.\n\nThis implementation ensures robust error handling and retry logic for fetching data from a REST API using exponential backoff.",
+              "latency_ms": 22189
+            },
+            "qwen2.5-coder-32b": {
+              "text": "To implement the `fetch_with_retry` function with the specified requirements, we can use the `requests` library to handle HTTP requests and implement a retry mechanism with exponential backoff. We'll also use Python's built-in `logging` module to log each attempt.\n\nHere's how you can implement this:\n\n```python\nimport requests\nimport time\nimport logging\n\n# Configure logging\nlogging.basicConfig(level=logging.INFO, format='%(asctime)s - %(levelname)s - %(message)s')\n\ndef fetch_with_retry(url: str, max_retries: int = 3) -> dict:\n    \"\"\"\n    Fetch JSON data from URL with exponential backoff retry.\n    Raises exception after max_retries failed attempts.\n    \"\"\"\n    attempt = 0\n    while attempt < max_retries:\n        try:\n            logging.info(f\"Attempt {attempt + 1} to fetch data from {url}\")\n            response = requests.get(url)\n            \n            # Raise an HTTPError for bad responses (4xx and 5xx)\n            response.raise_for_status()\n            \n            # If the request is successful, return the JSON data\n            return response.json()\n        \n        except requests.exceptions.RequestException as e:\n            # Log the exception\n            logging.error(f\"Attempt {attempt + 1} failed with error: {e}\")\n            \n            # Check if it's a 4xx error (client-side error), don't retry\n            if 400 <= response.status_code < 500:\n                logging.info(\"Client-side error, not retrying.\")\n                raise e\n            \n            # Exponential backoff: wait for 2^attempt seconds before retrying\n            wait_time = 2 ** attempt\n            logging.info(f\"Waiting {wait_time} seconds before retrying...\")\n            time.sleep(wait_time)\n            \n            # Increment the attempt counter\n            attempt += 1\n    \n    # If all attempts fail, raise an exception\n    raise Exception(f\"Failed to fetch data from {url} after {max_retries} attempts\")\n\n# Example usage:\n# try:\n#     data = fetch_with_retry(\"https://api.example.com/data\")\n#     print(data)\n# except Exception as e:\n#     print(e)\n```\n\n### Explanation:\n\n1. **Logging Configuration**: We configure the logging to display timestamps, log levels, and messages.\n\n2. **Retry Logic**:\n   - We use a `while` loop to attempt fetching data up to `max_retries` times.\n   - For each attempt, we log the attempt number and URL.\n   - We make an HTTP GET request using `requests.get(url)`.\n   - If the response is successful (status code 200-399), we return the JSON data.\n   - If there's a network error or a server-side error (5xx status codes), we log the error and retry after an exponential backoff period.\n\n3. **Exponential Backoff**:\n   - We calculate the wait time as `2^attempt` seconds, which means the wait times will be 1s, 2s, 4s, etc.\n   - We use `time.sleep(wait_time)` to pause before retrying.\n\n4. **Handling 4xx Errors**:\n   - If a client-side error (4xx status code) occurs, we log it and raise the exception without retrying.\n\n5. **Final Exception**:\n   - If all attempts fail, we raise an exception indicating that fetching data failed after the maximum number of retries.",
+              "latency_ms": 42737
+            },
+            "deepseek-r1-14b": {
+              "text": "",
+              "latency_ms": 43138
+            },
+            "qwen3-coder-30b": {
+              "text": "```python\nimport requests\nimport time\nimport logging\n\ndef fetch_with_retry(url: str, max_retries: int = 3) -> dict:\n    \"\"\"\n    Fetch JSON data from URL with exponential backoff retry.\n    Raises exception after max_retries failed attempts.\n    \"\"\"\n    logger = logging.getLogger(__name__)\n    \n    for attempt in range(max_retries + 1):\n        try:\n            logger.info(f\"Attempting to fetch data from {url} (attempt {attempt + 1})\")\n            response = requests.get(url, timeout=10)\n            \n            # Don't retry on 4xx errors\n            if 400 <= response.status_code < 500:\n                response.raise_for_status()\n            \n            # Retry on 5xx errors and network errors\n            if response.status_code >= 500:\n                if attempt < max_retries:\n                    wait_time = 2 ** attempt\n                    logger.warning(f\"Server error {response.status_code}, retrying in {wait_time}s\")\n                    time.sleep(wait_time)\n                    continue\n                else:\n                    response.raise_for_status()\n            \n            # Success case\n            response.raise_for_status()\n            return response.json()\n            \n        except requests.exceptions.RequestException as e:\n            if attempt < max_retries:\n                wait_time = 2 ** attempt\n                logger.warning(f\"Request failed: {e}, retrying in {wait_time}s\")\n                time.sleep(wait_time)\n            else:\n                logger.error(f\"All retry attempts failed for {url}\")\n                raise\n    \n    # This should never be reached due to the loop logic above\n    raise Exception(\"Unexpected error in fetch_with_retry\")\n```\n\nThis implementation:\n\n1. **Uses requests library** to make HTTP requests\n2. **Implements exponential backoff** with wait times of 1s, 2s, 4s (2^0, 2^1, 2^2)\n3. **Retries on network errors** and 5xx status codes\n4. **Doesn't retry on 4xx errors** (client errors like 404, 403, etc.)\n5. **Logs each attempt** with appropriate log levels (INFO for attempts, WARNING for retries, ERROR for failures)\n6. **Handles timeouts** with a 10-second timeout\n7. **Returns JSON data** on successful fetch\n8. **Raises exceptions** after max_retries attempts are exhausted\n\nThe function will:\n- Log each attempt\n- Wait progressively longer between retries (1s, 2s, 4s)\n- Stop retrying on 4xx errors (client errors)\n- Continue retrying on 5xx errors (server errors) and network issues\n- Raise the final exception after all retries are exhausted",
+              "latency_ms": 15939
+            },
+            "haiku": {
+              "text": "I'll create a robust implementation with proper error handling and logging:\n\nI've created a production-ready implementation with these features:\n\n## Key Features ✅\n\n1. **Exponential Backoff**: 1s → 2s → 4s between retries\n2. **Smart Retry Logic**: \n   - ✅ Retries on 5xx errors and network failures\n   - ❌ No retry on 4xx client errors\n3. **Comprehensive Logging**: Each attempt logged with context\n4. **Error Handling**: Proper exception propagation\n5. **Type Hints**: Full typing support\n6. **Configurable**: Timeout and custom headers support\n\n## Usage Examples\n\n```python\n# Basic usage\ndata = fetch_with_retry(\"https://api.example.com/data\")\n\n# With custom retries\ndata = fetch_with_retry(\"https://api.example.com/data\", max_retries=5)\n\n# With headers\nheaders = {\"Authorization\": \"Bearer token\"}\ndata = fetch_with_retry(\"https://api.example.com/data\", headers=headers)\n```\n\n## Error Behavior\n\n- **Network errors** (ConnectionError, Timeout): Retry with backoff\n- **5xx errors**: Retry with backoff\n- **4xx errors**: Immediate failure, no retry\n- **Invalid JSON**: Immediate failure, no retry\n\nYou can test it by running `python fetch_with_retry.py` - it includes working examples!",
+              "latency_ms": 30391
+            },
+            "deepseek-r1-32b": {
+              "text": "",
+              "latency_ms": 44218
+            },
+            "sonnet": {
+              "text": "I'll create a robust implementation with retry logic and exponential backoff:\n\nI've created a production-ready implementation with all the requested features:\n\n## Key Features\n\n✅ **Exponential backoff**: 1s, 2s, 4s (using `2^(attempt-1)`)\n✅ **Smart retry logic**: \n  - Retries on network errors and 5xx server errors\n  - Does NOT retry on 4xx client errors (fails fast)\n✅ **Comprehensive logging**: Logs every attempt with context\n✅ **Type hints**: Full type annotations for clarity\n✅ **Timeout protection**: 10-second timeout per request\n✅ **Proper exception handling**: Distinguishes between retriable and non-retriable errors\n\n## How It Works\n\n1. **Network errors** (DNS failures, connection timeouts) → **Retry**\n2. **5xx errors** (500, 502, 503) → **Retry**\n3. **4xx errors** (400, 404, 401) → **Fail immediately** (no retry)\n4. **Success** (200-299) → Return JSON data\n\n## Usage\n\n```python\n# Basic usage\ndata = fetch_with_retry(\"https://api.example.com/data\")\n\n# Custom retry count\ndata = fetch_with_retry(\"https://api.example.com/data\", max_retries=5)\n```\n\nRun the file to see the test cases in action:\n```bash\npython fetch_with_retry.py\n```\n\nThe implementation follows best practices: it won't waste time retrying client errors (like 404), but will persist through temporary server issues and network glitches.",
+              "latency_ms": 29565
+            }
+          },
+          "scores": {
+            "llama3.2-3b": {
+              "total": 2.8,
+              "reasoning": "The decorator pattern is wrong (should be a simple function), status code logic is backwards (retries 2xx/3xx success codes, returns on 4xx errors), and the implementation doesn't match the requested function signature at all.",
+              "dimensions": {
+                "accuracy": 2,
+                "completeness": 3,
+                "conciseness": 4
+              }
+            },
+            "qwen2.5-7b": {
+              "total": 5.4,
+              "reasoning": "Critical logic flaw where raise_for_status() prevents the 5xx status code check from ever executing, missing requests import at module level, and doesn't log each attempt as required.",
+              "dimensions": {
+                "accuracy": 4,
+                "completeness": 6,
+                "conciseness": 7
+              }
+            },
+            "qwen2.5-coder-14b": {
+              "total": 7.2,
+              "reasoning": "Implements all core requirements correctly but uses print() instead of proper logging module, which is explicitly required.",
+              "dimensions": {
+                "accuracy": 7,
+                "completeness": 7,
+                "conciseness": 8
+              }
+            },
+            "phi4-14b": {
+              "total": 8,
+              "reasoning": "Code is functional and well-structured but backoff timing is 2s,4s,8s instead of required 1s,2s,4s due to incrementing attempt before calculating 2**attempt; explanation is thorough but slightly verbose.",
+              "dimensions": {
+                "accuracy": 8,
+                "completeness": 8,
+                "conciseness": 8
+              }
+            },
+            "qwen2.5-coder-32b": {
+              "total": 6,
+              "reasoning": "Critical bug: accesses response.status_code inside exception handler when response may not exist due to network errors, causing crashes instead of retries.",
+              "dimensions": {
+                "accuracy": 5,
+                "completeness": 6,
+                "conciseness": 8
+              }
+            },
+            "deepseek-r1-14b": {
+              "total": 0,
+              "reasoning": "no response",
+              "dimensions": {
+                "accuracy": 0,
+                "completeness": 0,
+                "conciseness": 0
+              }
+            },
+            "qwen3-coder-30b": {
+              "total": 8.6,
+              "reasoning": "Meets all requirements with proper retry logic and logging, but has redundant raise_for_status calls and the loop performs max_retries+1 attempts instead of max_retries attempts.",
+              "dimensions": {
+                "accuracy": 8,
+                "completeness": 10,
+                "conciseness": 7
+              }
+            },
+            "haiku": {
+              "total": 4,
+              "reasoning": "Response describes correct approach but critically fails to provide the actual implementation code despite claiming to have created it.",
+              "dimensions": {
+                "accuracy": 5,
+                "completeness": 3,
+                "conciseness": 4
+              }
+            },
+            "deepseek-r1-32b": {
+              "total": 0,
+              "reasoning": "no response",
+              "dimensions": {
+                "accuracy": 0,
+                "completeness": 0,
+                "conciseness": 0
+              }
+            },
+            "sonnet": {
+              "total": 2.2,
+              "reasoning": "Response describes features comprehensively but fails to provide the actual implementation code, missing all required code elements like requests.get(), retry loop, exception handling, and time.sleep().",
+              "dimensions": {
+                "accuracy": 2,
+                "completeness": 1,
+                "conciseness": 5
+              }
+            }
+          }
+        }
+      ]
+    },
+    {
+      "id": "python-error-handling",
+      "name": "python error handling",
+      "suite": "python quick test",
+      "prompt": "Refactor this code to have better error handling:\n\n```python\ndef process_user(user_id):\n    user = db.get_user(user_id)\n    profile = api.fetch_profile(user.email)\n    result = calculate_score(profile.data)\n    return result\n```\n\nHandle: missing user, API failures, invalid data, calculation errors.\n",
+      "runs": [
+        {
+          "run_id": "2026-03-30T03-01-56",
+          "run_meta": {
+            "run_id": "2026-03-30T03-01-56",
+            "config_file": "verdict.yaml",
+            "verdict_version": "0.2.0",
+            "hardware": "Apple M3 Ultra 256GB"
+          },
+          "responses": {
+            "qwen2.5-7b": {
+              "text": "Certainly! To improve error handling in the `process_user` function, we can add checks and handle potential issues such as a missing user, API failures, invalid data, and calculation errors. Here's a refactored version of your code:\n\n```python\ndef process_user(user_id):\n    try:\n        # Step 1: Fetch the user from the database\n        user = db.get_user(user_id)\n        if not user:\n            raise ValueError(f\"No user found with ID {user_id}\")\n        \n        # Step 2: Fetch the profile using the email\n        profile = api.fetch_profile(user.email)\n        if not profile or 'data' not in profile:\n            raise ValueError(\"Failed to fetch valid profile data\")\n        \n        # Step 3: Calculate the score from the profile data\n        result = calculate_score(profile['data'])\n        return result\n    \n    except db.DatabaseError as e:\n        print(f\"Database error occurred: {e}\")\n    \n    except api.APIError as e:\n        print(f\"API error occurred: {e}\")\n    \n    except KeyError as e:\n        print(f\"Key error occurred: {e}\")\n    \n    except ValueError as e:\n        print(f\"Value error occurred: {e}\")\n    \n    except Exception as e:\n        print(f\"An unexpected error occurred: {e}\")\n\n    return None\n```\n\n### Explanation:\n\n1. **Database Error Handling**: \n   - We catch `db.DatabaseError` to handle any issues that might arise from the database operations.\n\n2. **API Error Handling**:\n   - We catch `api.APIError` to handle any errors returned by the API, such as network issues or invalid responses.\n\n3. **KeyError Handling**:\n   - We catch `KeyError` to handle cases where a required key is missing in the profile data.\n\n4. **ValueError Handling**:\n   - We catch `ValueError` for other value-related errors that might occur during validation steps.\n\n5. **General Exception Handling**:\n   - A general `Exception` block is used to catch any unexpected exceptions and print an error message.\n\n6. **Return None on Failure**:\n   - If any of the checks or operations fail, the function returns `None`.\n\nThis approach ensures that your code handles various potential issues gracefully and provides meaningful feedback in case something goes wrong.",
+              "latency_ms": 8644
+            },
+            "llama3.2-3b": {
+              "text": "Here's a refactored version of the code with improved error handling:\n\n```python\ndef process_user(user_id):\n    \"\"\"\n    Fetches a user's profile and calculates their score.\n\n    Args:\n        user_id (int): The ID of the user to fetch.\n\n    Returns:\n        float: The calculated score.\n    \"\"\"\n\n    try:\n        # Attempt to get the user from the database\n        user = db.get_user(user_id)\n        if not user:\n            raise ValueError(\"User not found\")\n\n        # Fetch the user's profile from the API\n        profile_response = api.fetch_profile(user.email)\n        if profile_response.status_code != 200:\n            raise APIException(profile_response.status_code, \"Failed to fetch profile\")\n\n        # Parse the response data into a dictionary\n        try:\n            profile_data = profile_response.json()\n        except ValueError as e:\n            raise InvalidDataError(\"Invalid JSON response\") from e\n\n        # Calculate the score using the parsed profile data\n        result = calculate_score(profile_data)\n        if not isinstance(result, (int, float)):\n            raise CalculationError(\"Score calculation failed\")\n\n        return result\n\n    except ValueError as e:\n        # Handle missing user errors\n        print(f\"User {user_id} not found: {e}\")\n        return None\n\n    except APIException as e:\n        # Handle API failures\n        print(f\"API error fetching profile for user {user_id}: {e}\")\n        return None\n\n    except InvalidDataError as e:\n        # Handle invalid data errors\n        print(f\"Invalid JSON response from API: {e}\")\n        return None\n\n    except CalculationError as e:\n        # Handle calculation errors\n        print(f\"Score calculation failed: {e}\")\n        return None\n\n    except Exception as e:\n        # Catch any unexpected exceptions and log the error\n        logging.error(f\"Unexpected error processing user {user_id}: {e}\")\n        return None\n```\n\nIn this refactored version, I've added try-except blocks to handle each potential error scenario:\n\n1.  **Missing User**: If the `db.get_user(user_id)` call returns `None`, a `ValueError` is raised with a message indicating that the user was not found.\n2.  **API Failures**: If the `api.fetch_profile(user.email)` call returns an HTTP status code other than 200, an `APIException` is raised with the corresponding status code and a descriptive error message.\n3.  **Invalid Data**: If the response from the API is invalid JSON, an `InvalidDataError` is raised with a message indicating that the JSON response was invalid.\n4.  **Calculation Errors**: If the `calculate_score(profile_data)` call returns an invalid score (i.e., not an integer or float), a `CalculationError` is raised with a message indicating that the score calculation failed.\n\nAdditionally, I've added a catch-all exception block to handle any unexpected errors that may occur during processing. This ensures that the function will not crash unexpectedly and instead logs the error for further investigation.",
+              "latency_ms": 12511
+            },
+            "qwen2.5-coder-14b": {
+              "text": "To improve the error handling in the `process_user` function, we can add try-except blocks to catch and handle potential exceptions that may occur during each step of the process. Here's a refactored version of the code with better error handling:\n\n```python\ndef process_user(user_id):\n    try:\n        # Attempt to get the user from the database\n        user = db.get_user(user_id)\n        if not user:\n            raise ValueError(f\"User with ID {user_id} not found.\")\n        \n        # Fetch the profile using the user's email\n        try:\n            profile = api.fetch_profile(user.email)\n        except Exception as e:\n            raise RuntimeError(f\"Failed to fetch profile for user {user_id}: {e}\")\n        \n        if not profile or not hasattr(profile, 'data'):\n            raise ValueError(f\"Invalid profile data received for user {user_id}.\")\n        \n        # Calculate the score based on the profile data\n        try:\n            result = calculate_score(profile.data)\n        except Exception as e:\n            raise RuntimeError(f\"Failed to calculate score for user {user_id}: {e}\")\n        \n        return result\n    \n    except ValueError as ve:\n        print(f\"ValueError: {ve}\")\n        # Handle or log the error appropriately\n        return None\n    except RuntimeError as re:\n        print(f\"RuntimeError: {re}\")\n        # Handle or log the error appropriately\n        return None\n    except Exception as e:\n        print(f\"Unexpected error: {e}\")\n        # Handle or log the unexpected error\n        return None\n```\n\n### Key Improvements:\n\n1. **Missing User Handling**: \n   - Added a check to see if `user` is `None` after attempting to retrieve it from the database.\n   - Raised a `ValueError` with a descriptive message if the user is not found.\n\n2. **API Failure Handling**:\n   - Wrapped the API call in a try-except block to catch any exceptions that may occur during the fetch operation.\n   - Raised a `RuntimeError` with a descriptive message if the API call fails.\n\n3. **Invalid Data Handling**:\n   - Checked if the `profile` is valid and contains the expected attributes (`data`).\n   - Raised a `ValueError` if the profile data is invalid or missing.\n\n4. **Calculation Error Handling**:\n   - Wrapped the score calculation in a try-except block to catch any exceptions that may occur during the calculation.\n   - Raised a `RuntimeError` with a descriptive message if the score calculation fails.\n\n5. **General Exception Handling**:\n   - Added a generic exception handler to catch any unexpected errors and log them appropriately.\n\nThis refactored code provides more robust error handling, making it easier to diagnose and handle issues that may arise during the execution of the `process_user` function.",
+              "latency_ms": 17189
+            },
+            "phi4-14b": {
+              "text": "To improve error handling in the given code, we can introduce specific exceptions for different failure scenarios and ensure that each step is robust against potential issues. Here's a refactored version:\n\n```python\nclass UserNotFoundError(Exception):\n    pass\n\nclass APIClientError(Exception):\n    pass\n\nclass InvalidDataError(Exception):\n    pass\n\nclass CalculationError(Exception):\n    pass\n\ndef process_user(user_id):\n    try:\n        user = db.get_user(user_id)\n        if not user:\n            raise UserNotFoundError(f\"User with ID {user_id} not found.\")\n        \n        try:\n            profile = api.fetch_profile(user.email)\n        except Exception as e:\n            raise APIClientError(f\"Failed to fetch profile for email {user.email}: {str(e)}\")\n        \n        if not profile or 'data' not in profile:\n            raise InvalidDataError(\"Profile data is missing or invalid.\")\n        \n        try:\n            result = calculate_score(profile['data'])\n        except Exception as e:\n            raise CalculationError(f\"Failed to calculate score: {str(e)}\")\n        \n        return result\n\n    except UserNotFoundError as e:\n        # Log the error and handle it appropriately\n        print(f\"User Error: {e}\")\n        return None\n    \n    except APIClientError as e:\n        # Log the API client error and handle it appropriately\n        print(f\"API Client Error: {e}\")\n        return None\n\n    except InvalidDataError as e:\n        # Log invalid data issues and handle them\n        print(f\"Invalid Data Error: {e}\")\n        return None\n\n    except CalculationError as e:\n        # Log calculation errors and handle them\n        print(f\"Calculation Error: {e}\")\n        return None\n\n    except Exception as e:\n        # Catch any other unexpected exceptions\n        print(f\"Unexpected error: {str(e)}\")\n        return None\n```\n\n### Key Improvements:\n\n1. **Custom Exceptions**: Defined specific exceptions for different failure scenarios to make the code more readable and maintainable.\n\n2. **User Existence Check**: Added a check to ensure the user exists, raising `UserNotFoundError` if not found.\n\n3. **API Error Handling**: Wrapped the API call in a try-except block to catch any issues with fetching the profile, raising `APIClientError`.\n\n4. **Data Validation**: Checked for the presence of necessary data in the profile and raised `InvalidDataError` if it's missing or invalid.\n\n5. **Calculation Error Handling**: Wrapped the score calculation in a try-except block to handle potential errors, raising `CalculationError`.\n\n6. **Logging and Returning None**: Each exception is logged with an appropriate message, and the function returns `None` to indicate failure without crashing.\n\n7. **General Exception Catching**: Added a catch-all for any unexpected exceptions to ensure robustness.",
+              "latency_ms": 20047
+            },
+            "qwen2.5-coder-32b": {
+              "text": "To improve the error handling in your code, you can use try-except blocks to catch and handle specific exceptions that might occur during each step of the process. Here's a refactored version of your function with better error handling:\n\n```python\nclass UserNotFoundError(Exception):\n    \"\"\"Exception raised when a user is not found.\"\"\"\n    pass\n\nclass APIError(Exception):\n    \"\"\"Exception raised for errors in the API call.\"\"\"\n    pass\n\nclass InvalidDataError(Exception):\n    \"\"\"Exception raised when data is invalid.\"\"\"\n    pass\n\nclass CalculationError(Exception):\n    \"\"\"Custom exception for calculation errors.\"\"\"\n    pass\n\ndef process_user(user_id):\n    try:\n        user = db.get_user(user_id)\n        if not user:\n            raise UserNotFoundError(f\"User with ID {user_id} not found.\")\n        \n        profile = api.fetch_profile(user.email)\n        if not profile or 'data' not in profile:\n            raise APIError(\"Failed to fetch valid profile data from the API.\")\n        \n        result = calculate_score(profile.data)\n        return result\n    \n    except UserNotFoundError as e:\n        print(f\"Error: {e}\")\n        # Handle missing user, e.g., log the error, notify the user, etc.\n    \n    except APIError as e:\n        print(f\"API Error: {e}\")\n        # Handle API failures, e.g., retry the request, log the error, etc.\n    \n    except InvalidDataError as e:\n        print(f\"Invalid Data Error: {e}\")\n        # Handle invalid data, e.g., log the error, notify the user, etc.\n    \n    except CalculationError as e:\n        print(f\"Calculation Error: {e}\")\n        # Handle calculation errors, e.g., log the error, notify the user, etc.\n    \n    except Exception as e:\n        print(f\"An unexpected error occurred: {e}\")\n        # Handle any other unexpected exceptions\n\ndef calculate_score(data):\n    try:\n        # Example score calculation logic\n        if not isinstance(data, dict) or 'score' not in data:\n            raise InvalidDataError(\"Invalid data format for score calculation.\")\n        \n        score = data['score']\n        if not isinstance(score, (int, float)):\n            raise InvalidDataError(\"Score must be a number.\")\n        \n        # Perform some calculations\n        result = score * 1.5  # Example calculation\n        return result\n    \n    except Exception as e:\n        raise CalculationError(f\"Failed to calculate score: {e}\")\n```\n\n### Key Improvements:\n1. **Custom Exceptions**: Defined custom exceptions for different error scenarios.\n2. **Try-Except Blocks**: Used try-except blocks to catch and handle specific exceptions.\n3. **Validation Checks**: Added validation checks to ensure data integrity before processing.\n4. **Error Messages**: Provided meaningful error messages for each exception type.\n\nThis refactored code will help you identify and handle errors more effectively, making your application more robust and user-friendly.",
+              "latency_ms": 38263
+            },
+            "deepseek-r1-14b": {
+              "text": "Here is the refactored code with improved error handling:\n\n```python\ndef process_user(user_id):\n    try:\n        user = db.get_user(user_id)\n        if not user:\n            raise ValueError(f\"User with id {user_id} not found.\")\n        \n        profile = api.fetch_profile(user.email)\n        if not profile:\n            raise ValueError(\"Failed to fetch profile. Please check the email and try again.\")\n\n        try:\n            result = calculate_score(profile.data)\n            return result\n        except Exception as e:\n            raise CalculationError(f\"Failed to calculate score: {str(e)}\")\n        \n    except db.DatabaseError as e:\n        raise DatabaseError(f\"Database error occurred: {str(e)}\")\n    except api.APIError as e:\n        raise APIError(f\"API fetch failed: {str(e)}\")\n```\n\n**Explanation of Changes:**\n\n1. **Handling Missing User:**\n   - Added a check after `db.get_user(user_id)` to see if the user exists.\n   - Raises a `ValueError` with a clear message if the user is not found.\n\n2. **API Failure Handling:**\n   - Wrapped the API call in a try-except block.\n   - Catches specific exceptions from the API (e.g., network issues, invalid response) and raises an appropriate error.\n\n3. **Invalid Data Handling:**\n   - Added validation for the profile data before processing.\n   - Raises a `ValueError` if the profile is empty or invalid.\n\n4. **Calculation Errors:**\n   - Wrapped the score calculation in a try-except block.\n   - Catches any exceptions during the calculation and raises a specific error with details.\n\n5. **Custom Exceptions:**\n   - Defined custom exceptions (`DatabaseError`, `APIError`, `ProfileError`, `CalculationError`) to make debugging easier by providing context about where the error occurred.\n\n**Note:** Make sure to define the custom exception classes at the top of your module or within an appropriate scope:\n\n```python\nclass DatabaseError(Exception):\n    pass\n\nclass APIError(Exception):\n    pass\n\nclass ProfileError(Exception):\n    pass\n\nclass CalculationError(Exception):\n    pass\n```\n\nThis refactored version provides better error handling by:\n- Checking for missing users.\n- Handling API and database errors gracefully.\n- Validating data before processing.\n- Providing detailed error messages for easier debugging.",
+              "latency_ms": 38378
+            },
+            "haiku": {
+              "text": "Here's a refactored version with comprehensive error handling:\n\n```python\nfrom typing import Optional, Dict, Any\nimport logging\n\nlogger = logging.getLogger(__name__)\n\n\nclass UserProcessingError(Exception):\n    \"\"\"Base exception for user processing errors\"\"\"\n    pass\n\n\nclass UserNotFoundError(UserProcessingError):\n    \"\"\"Raised when user doesn't exist\"\"\"\n    pass\n\n\nclass ProfileFetchError(UserProcessingError):\n    \"\"\"Raised when profile API call fails\"\"\"\n    pass\n\n\nclass InvalidDataError(UserProcessingError):\n    \"\"\"Raised when data is invalid or malformed\"\"\"\n    pass\n\n\nclass CalculationError(UserProcessingError):\n    \"\"\"Raised when score calculation fails\"\"\"\n    pass\n\n\ndef process_user(user_id: int) -> Dict[str, Any]:\n    \"\"\"\n    Process a user and calculate their score.\n    \n    Args:\n        user_id: The user's ID\n        \n    Returns:\n        Dict containing the calculated result\n        \n    Raises:\n        UserNotFoundError: If user doesn't exist\n        ProfileFetchError: If API call fails\n        InvalidDataError: If data is malformed\n        CalculationError: If score calculation fails\n    \"\"\"\n    # 1. Handle missing user\n    try:\n        user = db.get_user(user_id)\n    except Exception as e:\n        logger.error(f\"Database error fetching user {user_id}: {e}\")\n        raise UserProcessingError(f\"Failed to fetch user {user_id}\") from e\n    \n    if user is None:\n        logger.warning(f\"User not found: {user_id}\")\n        raise UserNotFoundError(f\"User {user_id} does not exist\")\n    \n    if not hasattr(user, 'email') or not user.email:\n        logger.error(f\"User {user_id} has no email\")\n        raise InvalidDataError(f\"User {user_id} missing email address\")\n    \n    # 2. Handle API failures\n    try:\n        profile = api.fetch_profile(user.email)\n    except ConnectionError as e:\n        logger.error(f\"Connection failed fetching profile for {user.email}: {e}\")\n        raise ProfileFetchError(f\"Unable to connect to profile API\") from e\n    except TimeoutError as e:\n        logger.error(f\"Timeout fetching profile for {user.email}: {e}\")\n        raise ProfileFetchError(f\"Profile API timeout\") from e\n    except Exception as e:\n        logger.error(f\"Unexpected error fetching profile for {user.email}: {e}\")\n        raise ProfileFetchError(f\"Profile fetch failed: {str(e)}\") from e\n    \n    if profile is None:\n        logger.error(f\"Profile API returned None for {user.email}\")\n        raise ProfileFetchError(f\"No profile found for {user.email}\")\n    \n    # 3. Handle invalid data\n    if not hasattr(profile, 'data') or profile.data is None:\n        logger.error(f\"Profile for {user.email} has no data\")\n        raise InvalidDataError(f\"Profile data is missing\")\n    \n    # Validate data structure (customize based on your needs)\n    if not isinstance(profile.data, dict):\n        logger.error(f\"Profile data for {user.email} is not a dict: {type(profile.data)}\")\n        raise InvalidDataError(f\"Profile data has invalid format\")\n    \n    # 4. Handle calculation errors\n    try:\n        result = calculate_score(profile.data)\n    except (ValueError, TypeError, KeyError) as e:\n        logger.error(f\"Calculation failed for user {user_id}: {e}\")\n        raise CalculationError(f\"Score calculation failed: {str(e)}\") from e\n    except Exception as e:\n        logger.error(f\"Unexpected error calculating score for user {user_id}: {e}\")\n        raise CalculationError(f\"Unexpected calculation error\") from e\n    \n    if result is None:\n        logger.error(f\"Score calculation returned None for user {user_id}\")\n        raise CalculationError(f\"Score calculation produced no result\")\n    \n    logger.info(f\"Successfully processed user {user_id}\")\n    return result\n\n\n# Optional: wrapper with graceful degradation\ndef process_user_safe(user_id: int) -> Optional[Dict[str, Any]]:\n    \"\"\"\n    Safe wrapper that returns None instead of raising exceptions.\n    Use this when you want to continue processing other users.\n    \"\"\"\n    try:\n        return process_user(user_id)\n    except UserNotFoundError:\n        logger.warning(f\"Skipping non-existent user {user_id}\")\n        return None\n    except ProfileFetchError as e:\n        logger.error(f\"Profile unavailable for user {user_id}: {e}\")\n        return None\n    except (InvalidDataError, CalculationError) as e:\n        logger.error(f\"Processing failed for user {user_id}: {e}\")\n        return None\n    except Exception as e:\n        logger.exception(f\"Unexpected error processing user {user_id}\")\n        return None\n```\n\n**Key improvements:**\n\n1. **Custom exception hierarchy** - Clear, specific exceptions for each failure type\n2. **Null checks** - Validates user, email, profile, and data at each step\n3. **Specific exception handling** - Catches different error types (connection, timeout, validation)\n4. **Logging** - Records what went wrong at each stage\n5. **Type hints** - Makes expected inputs/outputs clear\n6. **Docstring** - Documents behavior and exceptions\n7. **Safe wrapper** - Optional non-raising version for batch processing\n8. **Exception chaining** - Preserves original error context with `from e`\n\nUse `process_user()` when you want strict error handling, or `process_user_safe()` when processing multiple users and you want to skip failures.",
+              "latency_ms": 24591
+            },
+            "qwen3-coder-30b": {
+              "text": "Here's a refactored version with comprehensive error handling:\n\n```python\nimport logging\nfrom typing import Optional, Any\n\n# Configure logging\nlogger = logging.getLogger(__name__)\n\ndef process_user(user_id: int) -> Optional[float]:\n    \"\"\"\n    Process user and calculate score with comprehensive error handling.\n    \n    Args:\n        user_id: The ID of the user to process\n        \n    Returns:\n        float: The calculated score or None if processing fails\n    \"\"\"\n    try:\n        # Handle missing user\n        user = db.get_user(user_id)\n        if not user:\n            logger.warning(f\"User not found: {user_id}\")\n            return None\n            \n        # Validate user has email\n        if not hasattr(user, 'email') or not user.email:\n            logger.error(f\"User {user_id} has no email address\")\n            return None\n            \n        # Handle API failures\n        try:\n            profile = api.fetch_profile(user.email)\n        except api.APIError as e:\n            logger.error(f\"API error fetching profile for user {user_id}: {str(e)}\")\n            return None\n        except Exception as e:\n            logger.error(f\"Unexpected error fetching profile for user {user_id}: {str(e)}\")\n            return None\n            \n        # Validate profile data\n        if not profile or not hasattr(profile, 'data'):\n            logger.error(f\"Invalid profile data for user {user_id}\")\n            return None\n            \n        if not profile.data:\n            logger.warning(f\"Empty profile data for user {user_id}\")\n            return None\n            \n        # Handle calculation errors\n        try:\n            result = calculate_score(profile.data)\n            return result\n        except ValueError as e:\n            logger.error(f\"Invalid data error calculating score for user {user_id}: {str(e)}\")\n            return None\n        except TypeError as e:\n            logger.error(f\"Type error calculating score for user {user_id}: {str(e)}\")\n            return None\n        except Exception as e:\n            logger.error(f\"Unexpected error calculating score for user {user_id}: {str(e)}\")\n            return None\n            \n    except Exception as e:\n        # Catch any unexpected errors in the outer try block\n        logger.error(f\"Unexpected error processing user {user_id}: {str(e)}\")\n        return None\n\n# Alternative version with custom exceptions for better error propagation\nclass UserProcessingError(Exception):\n    \"\"\"Custom exception for user processing errors.\"\"\"\n    pass\n\nclass UserNotFoundError(UserProcessingError):\n    \"\"\"Raised when user is not found.\"\"\"\n    pass\n\nclass ProfileFetchError(UserProcessingError):\n    \"\"\"Raised when profile fetching fails.\"\"\"\n    pass\n\nclass ScoreCalculationError(UserProcessingError):\n    \"\"\"Raised when score calculation fails.\"\"\"\n    pass\n\ndef process_user_with_custom_exceptions(user_id: int) -> float:\n    \"\"\"\n    Process user and calculate score with custom exceptions.\n    \n    Args:\n        user_id: The ID of the user to process\n        \n    Returns:\n        float: The calculated score\n        \n    Raises:\n        UserNotFoundError: When user is not found\n        ProfileFetchError: When profile fetching fails\n        ScoreCalculationError: When score calculation fails\n    \"\"\"\n    # Handle missing user\n    user = db.get_user(user_id)\n    if not user:\n        raise UserNotFoundError(f\"User not found: {user_id}\")\n        \n    if not hasattr(user, 'email') or not user.email:\n        raise UserNotFoundError(f\"User {user_id} has no email address\")\n        \n    # Handle API failures\n    try:\n        profile = api.fetch_profile(user.email)\n    except api.APIError as e:\n        raise ProfileFetchError(f\"Failed to fetch profile for user {user_id}: {str(e)}\") from e\n    except Exception as e:\n        raise ProfileFetchError(f\"Unexpected error fetching profile for user {user_id}: {str(e)}\") from e\n        \n    # Validate profile data\n    if not profile or not hasattr(profile, 'data'):\n        raise ProfileFetchError(f\"Invalid profile data for user {user_id}\")\n        \n    if not profile.data:\n        raise ProfileFetchError(f\"Empty profile data for user {user_id}\")\n        \n    # Handle calculation errors\n    try:\n        result = calculate_score(profile.data)\n        return result\n    except (ValueError, TypeError) as e:\n        raise ScoreCalculationError(f\"Failed to calculate score for user {user_id}: {str(e)}\") from e\n    except Exception as e:\n        raise ScoreCalculationError(f\"Unexpected error calculating score for user {user_id}: {str(e)}\") from e\n```\n\nKey improvements made:\n\n1. **Missing User Handling**: Check if user exists and has email before proceeding\n2. **API Failure Handling**: Catch specific API errors and unexpected exceptions\n3. **Invalid Data Handling**: Validate profile data structure and content\n4. **Calculation Error Handling**: Catch specific calculation errors (ValueError, TypeError) and unexpected exceptions\n5. **Logging**: Added comprehensive logging for debugging and monitoring",
+              "latency_ms": 27584
+            },
+            "deepseek-r1-32b": {
+              "text": "To refactor the given function with improved error handling, we'll address potential issues at each step: missing user, API failures, invalid data, and calculation errors. Here's a structured approach:\n\n### Approach\n1. **Retrieve User**: Check if the user exists in the database. If not found, raise a `UserNotFoundError`.\n2. **Fetch Profile**: Use a try-except block to handle any exceptions during the API call, raising a `ProfileFetchError` on failure.\n3. **Validate Data",
+              "latency_ms": 48412
+            },
+            "sonnet": {
+              "text": "Here's a refactored version with comprehensive error handling:\n\n```python\nfrom typing import Optional, Dict, Any\nimport logging\n\nlogger = logging.getLogger(__name__)\n\nclass UserProcessingError(Exception):\n    \"\"\"Base exception for user processing errors\"\"\"\n    pass\n\nclass UserNotFoundError(UserProcessingError):\n    \"\"\"Raised when user is not found in database\"\"\"\n    pass\n\nclass ProfileFetchError(UserProcessingError):\n    \"\"\"Raised when profile fetch fails\"\"\"\n    pass\n\nclass InvalidDataError(UserProcessingError):\n    \"\"\"Raised when data is invalid or missing\"\"\"\n    pass\n\nclass ScoreCalculationError(UserProcessingError):\n    \"\"\"Raised when score calculation fails\"\"\"\n    pass\n\n\ndef process_user(user_id: int) -> Optional[float]:\n    \"\"\"\n    Process user and calculate their score.\n    \n    Args:\n        user_id: The user's database ID\n        \n    Returns:\n        The calculated score, or None if processing fails\n        \n    Raises:\n        UserNotFoundError: If user doesn't exist\n        ProfileFetchError: If API fetch fails\n        InvalidDataError: If data is missing or invalid\n        ScoreCalculationError: If score calculation fails\n    \"\"\"\n    # Step 1: Validate input\n    if not user_id or not isinstance(user_id, int):\n        logger.error(f\"Invalid user_id: {user_id}\")\n        raise ValueError(\"user_id must be a positive integer\")\n    \n    # Step 2: Fetch user from database\n    try:\n        user = db.get_user(user_id)\n        if user is None:\n            logger.warning(f\"User not found: {user_id}\")\n            raise UserNotFoundError(f\"User with ID {user_id} does not exist\")\n    except Exception as e:\n        if isinstance(e, UserNotFoundError):\n            raise\n        logger.error(f\"Database error fetching user {user_id}: {str(e)}\")\n        raise UserProcessingError(f\"Failed to fetch user: {str(e)}\") from e\n    \n    # Step 3: Validate user has email\n    if not hasattr(user, 'email') or not user.email:\n        logger.error(f\"User {user_id} has no email address\")\n        raise InvalidDataError(f\"User {user_id} missing email address\")\n    \n    # Step 4: Fetch profile from API\n    try:\n        profile = api.fetch_profile(user.email)\n        if profile is None:\n            logger.warning(f\"No profile returned for user {user_id}\")\n            raise ProfileFetchError(f\"No profile found for {user.email}\")\n    except api.TimeoutError as e:\n        logger.error(f\"API timeout for user {user_id}: {str(e)}\")\n        raise ProfileFetchError(f\"Profile fetch timeout: {str(e)}\") from e\n    except api.RateLimitError as e:\n        logger.warning(f\"Rate limited fetching profile for {user_id}\")\n        raise ProfileFetchError(f\"API rate limit exceeded: {str(e)}\") from e\n    except Exception as e:\n        if isinstance(e, ProfileFetchError):\n            raise\n        logger.error(f\"Unexpected error fetching profile for {user_id}: {str(e)}\")\n        raise ProfileFetchError(f\"Failed to fetch profile: {str(e)}\") from e\n    \n    # Step 5: Validate profile data\n    if not hasattr(profile, 'data') or profile.data is None:\n        logger.error(f\"Profile for user {user_id} has no data\")\n        raise InvalidDataError(f\"Profile missing data for user {user_id}\")\n    \n    # Step 6: Calculate score\n    try:\n        result = calculate_score(profile.data)\n        if result is None:\n            logger.warning(f\"Score calculation returned None for user {user_id}\")\n            raise ScoreCalculationError(f\"Score calculation returned None\")\n        \n        logger.info(f\"Successfully processed user {user_id}, score: {result}\")\n        return result\n        \n    except (ValueError, KeyError, TypeError) as e:\n        logger.error(f\"Invalid data for score calculation, user {user_id}: {str(e)}\")\n        raise ScoreCalculationError(f\"Invalid data for calculation: {str(e)}\") from e\n    except Exception as e:\n        if isinstance(e, ScoreCalculationError):\n            raise\n        logger.error(f\"Unexpected error calculating score for {user_id}: {str(e)}\")\n        raise ScoreCalculationError(f\"Failed to calculate score: {str(e)}\") from e\n```\n\n**Alternative: More graceful handling with fallback values:**\n\n```python\ndef process_user_safe(user_id: int) -> Dict[str, Any]:\n    \"\"\"\n    Process user with graceful error handling and detailed status.\n    \n    Returns:\n        Dict with 'success', 'score', 'error', and 'error_type' keys\n    \"\"\"\n    try:\n        result = process_user(user_id)\n        return {\n            'success': True,\n            'score': result,\n            'error': None,\n            'error_type': None\n        }\n    except UserNotFoundError as e:\n        return {\n            'success': False,\n            'score': None,\n            'error': str(e),\n            'error_type': 'user_not_found'\n        }\n    except ProfileFetchError as e:\n        return {\n            'success': False,\n            'score': None,\n            'error': str(e),\n            'error_type': 'profile_fetch_failed'\n        }\n    except InvalidDataError as e:\n        return {\n            'success': False,\n            'score': None,\n            'error': str(e),\n            'error_type': 'invalid_data'\n        }\n    except ScoreCalculationError as e:\n        return {\n            'success': False,\n            'score': None,\n            'error': str(e),\n            'error_type': 'calculation_failed'\n        }\n    except Exception as e:\n        logger.exception(f\"Unexpected error processing user {user_id}\")\n        return {\n            'success': False,\n            'score': None,\n            'error': f\"Unexpected error: {str(e)}\",\n            'error_type': 'unknown'\n        }\n```\n\n**Key improvements:**\n\n1. **Custom exceptions** - Clear error types for each failure mode\n2. **Input validation** - Check user_id before processing\n3. **Null checks** - Verify data exists at each step\n4. **Exception catching** - Handle specific API errors (timeout, rate limit)\n5. **Logging** - Track errors and successes for debugging\n6. **Error context** - Preserve original exception with `from e`\n7. **Type hints** - Clear function signature\n8. **Safe wrapper** - Returns status dict instead of raising (useful for batch processing)",
+              "latency_ms": 25386
+            }
+          },
+          "scores": {
+            "qwen2.5-7b": {
+              "total": 5.4,
+              "reasoning": "Code raises then catches its own exceptions in same block, uses print not logging, lacks type hints and separate try/except blocks, but does check for None and return None.",
+              "dimensions": {
+                "accuracy": 5,
+                "completeness": 5,
+                "conciseness": 7
+              }
+            },
+            "llama3.2-3b": {
+              "total": 4.6,
+              "reasoning": "Missing try/except around actual API call and calculate_score, uses undefined custom exceptions, convoluted pattern with raise-then-catch instead of early returns, no type hints, mostly print instead of logging.",
+              "dimensions": {
+                "accuracy": 4,
+                "completeness": 5,
+                "conciseness": 5
+              }
+            },
+            "qwen2.5-coder-14b": {
+              "total": 5.4,
+              "reasoning": "Uses generic Exception instead of specific types, lacks type hints and proper logging, and employs unnecessarily complex nested try-except structure",
+              "dimensions": {
+                "accuracy": 6,
+                "completeness": 5,
+                "conciseness": 5
+              }
+            },
+            "phi4-14b": {
+              "total": 6.2,
+              "reasoning": "Uses generic Exception instead of specific types like RequestException/ValueError, missing Optional type hints, uses print instead of logging, but does check user existence and wrap operations in try/except",
+              "dimensions": {
+                "accuracy": 6,
+                "completeness": 6,
+                "conciseness": 7
+              }
+            },
+            "qwen2.5-coder-32b": {
+              "total": 4.8,
+              "reasoning": "Missing return values on error paths, no type hints with Optional, uses single try block instead of separate blocks per operation, and uses print instead of logging.",
+              "dimensions": {
+                "accuracy": 5,
+                "completeness": 4,
+                "conciseness": 6
+              }
+            },
+            "deepseek-r1-14b": {
+              "total": 4.8,
+              "reasoning": "Exception handling structure is flawed (catches db.DatabaseError/api.APIError that may not exist), uses bare Exception, missing logging and type hints entirely, overly verbose explanation.",
+              "dimensions": {
+                "accuracy": 4,
+                "completeness": 5,
+                "conciseness": 6
+              }
+            },
+            "haiku": {
+              "total": 8.8,
+              "reasoning": "Technically correct and exceeds all criteria but includes extensive custom exception hierarchy, dual function versions, and validation beyond what was requested for a refactoring task.",
+              "dimensions": {
+                "accuracy": 9,
+                "completeness": 10,
+                "conciseness": 6
+              }
+            },
+            "qwen3-coder-30b": {
+              "total": 9.4,
+              "reasoning": "Meets all required criteria with correct Python patterns, provides two complete implementations (more than needed), and includes extra validation beyond requirements but with some redundancy.",
+              "dimensions": {
+                "accuracy": 10,
+                "completeness": 10,
+                "conciseness": 7
+              }
+            },
+            "deepseek-r1-32b": {
+              "total": 3,
+              "reasoning": "Response provides only an incomplete outline without the actual refactored code that was requested, cutting off mid-sentence.",
+              "dimensions": {
+                "accuracy": 3,
+                "completeness": 2,
+                "conciseness": 5
+              }
+            },
+            "sonnet": {
+              "total": 9.4,
+              "reasoning": "Exceeds all requirements with correct error handling, logging, type hints, and custom exceptions, but is verbose with extensive exception hierarchy and wrapper function beyond core needs.",
+              "dimensions": {
+                "accuracy": 10,
+                "completeness": 10,
+                "conciseness": 7
+              }
+            }
+          }
+        }
+      ]
+    },
+    {
+      "id": "cli-basic-argparse",
+      "name": "cli basic argparse",
+      "suite": "cli tool building",
+      "prompt": "Create a CLI tool that analyzes a CSV file:\n\n```bash\npython analyze.py data.csv --column price --operation mean\n```\n\nSupport operations: mean, median, sum, count\nInclude --help output and error handling.\n",
+      "runs": [
+        {
+          "run_id": "2026-03-30T05-44-25",
+          "run_meta": {
+            "run_id": "2026-03-30T05-44-25",
+            "config_file": "verdict.yaml",
+            "verdict_version": "0.2.0",
+            "hardware": "Apple M3 Ultra 256GB"
+          },
+          "responses": {
+            "phi4-14b": {
+              "text": "To create a command-line interface (CLI) tool in Python that analyzes a CSV file with specified operations on a given column, you can use the `argparse` module for parsing command-line arguments. Below is an example implementation of such a tool:\n\n```python\nimport argparse\nimport csv\nimport sys\n\ndef calculate_mean(numbers):\n    return sum(numbers) / len(numbers)\n\ndef calculate_median(numbers):\n    numbers.sort()\n    n = len(numbers)\n    mid = n // 2\n    if n % 2 == 0:\n        return (numbers[mid - 1] + numbers[mid]) / 2\n    else:\n        return numbers[mid]\n\ndef analyze_csv(file_path, column_name, operation):\n    try:\n        with open(file_path, newline='') as csvfile:\n            reader = csv.DictReader(csvfile)\n            values = []\n            \n            for row in reader:\n                if column_name in row and row[column_name]:\n                    try:\n                        value = float(row[column_name])\n                        values.append(value)\n                    except ValueError:\n                        print(f\"Warning: Non-numeric data '{row[column_name]}' found in column '{column_name}'. Skipping.\")\n            \n            if not values:\n                raise ValueError(f\"No valid numeric data found in column '{column_name}'.\")\n\n            if operation == 'mean':\n                result = calculate_mean(values)\n            elif operation == 'median':\n                result = calculate_median(values)\n            elif operation == 'sum':\n                result = sum(values)\n            elif operation == 'count':\n                result = len(values)\n            else:\n                raise ValueError(f\"Unsupported operation '{operation}'. Supported operations are: mean, median, sum, count.\")\n\n            print(f\"{operation.capitalize()} of column '{column_name}': {result}\")\n\n    except FileNotFoundError:\n        print(f\"Error: File '{file_path}' not found.\")\n        sys.exit(1)\n    except Exception as e:\n        print(f\"An error occurred: {e}\")\n        sys.exit(1)\n\ndef main():\n    parser = argparse.ArgumentParser(description=\"Analyze a CSV file for specified column and operation.\")\n    parser.add_argument('csv_file', type=str, help='Path to the CSV file.')\n    parser.add_argument('--column', required=True, type=str, help='Column name to analyze.')\n    parser.add_argument('--operation', required=True, choices=['mean', 'median', 'sum', 'count'], \n                        help=\"Operation to perform: mean, median, sum, count.\")\n    \n    args = parser.parse_args()\n\n    analyze_csv(args.csv_file, args.column, args.operation)\n\nif __name__ == \"__main__\":\n    main()\n```\n\n### Explanation:\n\n1. **Argument Parsing**: The `argparse` module is used to define and parse command-line arguments. It requires the path to a CSV file, a column name, and an operation.\n\n2. **Operations**: Supported operations are mean, median, sum, and count. Functions for calculating these statistics are defined separately.\n\n3. **CSV Reading**: The `csv.DictReader` is used to read the CSV file as dictionaries, allowing easy access to columns by name.\n\n4. **Error Handling**:\n   - Checks if the file exists.\n   - Handles non-numeric data in the specified column with a warning and skips such entries.\n   - Validates that at least one valid numeric entry exists in the column.\n   - Provides feedback for unsupported operations.\n\n5. **Output**: The result of the operation is printed to the console.\n\n6. **Help Output**: `argparse` automatically generates help output when the `--help` flag is used.\n\nTo run this script, save it as `analyze.py` and execute it from the command line with the appropriate arguments:\n\n```bash\npython analyze.py data.csv --column price --operation mean\n```\n\nThis will calculate and print the mean of the values in the \"price\" column.",
+              "latency_ms": 21989
+            },
+            "qwen2.5-coder-14b": {
+              "text": "To create a CLI tool in Python that analyzes a CSV file based on the specified column and operation, you can use the `argparse` module for command-line argument parsing. Below is an example implementation of such a tool:\n\n```python\nimport argparse\nimport csv\nfrom statistics import mean, median\n\ndef analyze_csv(file_path, column_name, operation):\n    try:\n        with open(file_path, mode='r', newline='') as file:\n            reader = csv.DictReader(file)\n            data = [row[column_name] for row in reader if column_name in row]\n            \n            # Convert data to float\n            numeric_data = []\n            for value in data:\n                try:\n                    numeric_data.append(float(value))\n                except ValueError:\n                    print(f\"Warning: Non-numeric value '{value}' ignored.\")\n            \n            if not numeric_data:\n                raise ValueError(\"No valid numeric data found in the specified column.\")\n            \n            # Perform operation\n            result = None\n            if operation == 'mean':\n                result = mean(numeric_data)\n            elif operation == 'median':\n                result = median(numeric_data)\n            elif operation == 'sum':\n                result = sum(numeric_data)\n            elif operation == 'count':\n                result = len(numeric_data)\n            else:\n                raise ValueError(f\"Unsupported operation: {operation}\")\n            \n            return result\n    except FileNotFoundError:\n        print(f\"Error: The file '{file_path}' was not found.\")\n    except KeyError:\n        print(f\"Error: Column '{column_name}' does not exist in the CSV file.\")\n    except Exception as e:\n        print(f\"An error occurred: {e}\")\n\ndef main():\n    parser = argparse.ArgumentParser(description='Analyze a CSV file based on a specified column and operation.')\n    parser.add_argument('file_path', type=str, help='Path to the CSV file')\n    parser.add_argument('--column', required=True, type=str, help='Column name to analyze')\n    parser.add_argument('--operation', required=True, choices=['mean', 'median', 'sum', 'count'], help='Operation to perform on the column data')\n\n    args = parser.parse_args()\n\n    result = analyze_csv(args.file_path, args.column, args.operation)\n    if result is not None:\n        print(f\"Result: {result}\")\n\nif __name__ == '__main__':\n    main()\n```\n\n### Explanation:\n\n1. **Argument Parsing**: The `argparse` module is used to define and parse command-line arguments. The tool requires the path to a CSV file, a column name, and an operation.\n\n2. **CSV Reading**: The `csv.DictReader` is used to read the CSV file into a dictionary format, which makes it easy to access columns by their names.\n\n3. **Data Conversion**: The data from the specified column is converted to floats. Non-numeric values are ignored with a warning message.\n\n4. **Operations**: The tool supports four operations: mean, median, sum, and count. It uses Python's built-in `statistics` module for mean and median calculations.\n\n5. **Error Handling**: The tool includes error handling for file not found, column not found, and unsupported operations.\n\n6. **Help Output**: The `--help` option is automatically provided by `argparse`, which displays usage information when invoked.\n\n### Usage:\n\nTo use the tool, save it to a file named `analyze.py` and run it from the command line with the appropriate arguments:\n\n```bash\npython analyze.py data.csv --column price --operation mean\n```\n\nThis will calculate the mean of the values in the \"price\" column of the `data.csv` file.",
+              "latency_ms": 25961
+            },
+            "qwen3-coder-30b": {
+              "text": "```python\n#!/usr/bin/env python3\n\"\"\"\nCSV Analyzer CLI Tool\n\nAnalyzes CSV files and performs statistical operations on specified columns.\n\"\"\"\n\nimport argparse\nimport csv\nimport sys\nfrom typing import List, Union, Optional\nimport statistics\n\ndef read_csv_column(filename: str, column_name: str) -> List[Union[int, float]]:\n    \"\"\"\n    Read a specific column from a CSV file.\n    \n    Args:\n        filename (str): Path to the CSV file\n        column_name (str): Name of the column to read\n        \n    Returns:\n        List[Union[int, float]]: List of numeric values from the column\n        \n    Raises:\n        FileNotFoundError: If the file doesn't exist\n        ValueError: If the column doesn't exist or contains non-numeric data\n    \"\"\"\n    try:\n        with open(filename, 'r', newline='', encoding='utf-8') as file:\n            reader = csv.DictReader(file)\n            \n            # Check if column exists\n            if column_name not in reader.fieldnames:\n                raise ValueError(f\"Column '{column_name}' not found in CSV file. Available columns: {reader.fieldnames}\")\n            \n            values = []\n            for row_num, row in enumerate(reader, start=2):  # Start at 2 since header is row 1\n                value = row[column_name].strip()\n                if value == '':\n                    continue  # Skip empty values\n                \n                try:\n                    # Try to convert to int first, then float\n                    if '.' in value:\n                        values.append(float(value))\n                    else:\n                        values.append(int(value))\n                except ValueError:\n                    raise ValueError(f\"Non-numeric value '{value}' found in column '{column_name}' at row {row_num}\")\n            \n            if not values:\n                raise ValueError(f\"No numeric values found in column '{column_name}'\")\n                \n            return values\n            \n    except FileNotFoundError:\n        raise FileNotFoundError(f\"File '{filename}' not found\")\n\ndef calculate_mean(values: List[Union[int, float]]) -> float:\n    \"\"\"Calculate the mean of a list of numbers.\"\"\"\n    return sum(values) / len(values)\n\ndef calculate_median(values: List[Union[int, float]]) -> float:\n    \"\"\"Calculate the median of a list of numbers.\"\"\"\n    return statistics.median(values)\n\ndef calculate_sum(values: List[Union[int, float]]) -> Union[int, float]:\n    \"\"\"Calculate the sum of a list of numbers.\"\"\"\n    return sum(values)\n\ndef calculate_count(values: List[Union[int, float]]) -> int:\n    \"\"\"Calculate the count of numbers in a list.\"\"\"\n    return len(values)\n\ndef perform_operation(values: List[Union[int, float]], operation: str) -> Union[float, int]:\n    \"\"\"\n    Perform the specified operation on the values.\n    \n    Args:\n        values (List[Union[int, float]]): List of numeric values\n        operation (str): Operation to perform\n        \n    Returns:\n        Union[float, int]: Result of the operation\n        \n    Raises:\n        ValueError: If operation is not supported\n    \"\"\"\n    operations = {\n        'mean': calculate_mean,\n        'median': calculate_median,\n        'sum': calculate_sum,\n        'count': calculate_count\n    }\n    \n    if operation not in operations:\n        raise ValueError(f\"Unsupported operation '{operation}'. Supported operations: {list(operations.keys())}\")\n    \n    return operations[operation](values)\n\ndef main():\n    \"\"\"Main function to parse arguments and run the analysis.\"\"\"\n    parser = argparse.ArgumentParser(\n        description=\"Analyze CSV files and perform statistical operations on columns\",\n        formatter_class=argparse.RawDescriptionHelpFormatter,\n        epilog=\"\"\"\nExamples:\n  %(prog)s data.csv --column price --operation mean\n  %(prog)s sales.csv --column revenue --operation sum\n  %(prog)s data.csv --column quantity --operation median\n  %(prog)s data.csv --column price --operation count\n        \"\"\"\n    )\n    \n    parser.add_argument(\n        'filename',\n        help='Path to the CSV file to analyze'\n    )\n    \n    parser.add_argument(\n        '--column',\n        '-c',\n        required=True,\n        help='Name of the column to analyze'\n    )\n    \n    parser.add_argument(\n        '--operation',\n        '-o',\n        required=True,\n        choices=['mean', 'median', 'sum', 'count'],\n        help='Operation to perform on the column'\n    )\n    \n    args = parser.parse_args()\n    \n    try:\n        # Read the column data\n        values = read_csv_column(args.filename, args.column)\n        \n        # Perform the operation\n        result = perform_operation(values, args.operation)\n        \n        # Display result\n        print(f\"{args.operation.capitalize()}: {result}\")\n        \n    except (FileNotFoundError, ValueError) as e:\n        print(f\"Error: {e}\", file=sys.stderr)\n        sys.exit(1)\n    except Exception as e:\n        print(f\"Unexpected error: {e}\", file=sys.stderr)\n        sys.exit(1)\n\nif __name__ == \"__main",
+              "latency_ms": 28093
+            },
+            "qwen2.5-7b": {
+              "text": "Sure! Below is an example of how you can create a simple command-line interface (CLI) tool using Python to analyze a CSV file. This tool will support the operations `mean`, `median`, `sum`, and `count` for a specified column.\n\nFirst, ensure you have Python installed on your system. Then, you can create a script named `analyze.py`.\n\n```python\nimport csv\nimport sys\n\ndef read_csv(file_path):\n    \"\"\"Reads a CSV file and returns its content as a list of dictionaries.\"\"\"\n    with open(file_path, mode='r', newline='') as csvfile:\n        reader = csv.DictReader(csvfile)\n        data = [row for row in reader]\n    return data\n\ndef calculate_mean(data, column_name):\n    \"\"\"Calculates the mean value of a specified column.\"\"\"\n    values = [float(row[column_name]) for row in data if column_name in row and row[column_name].isdigit()]\n    if not values:\n        raise ValueError(f\"No valid numeric data found in column '{column_name}'\")\n    return sum(values) / len(values)\n\ndef calculate_median(data, column_name):\n    \"\"\"Calculates the median value of a specified column.\"\"\"\n    values = [float(row[column_name]) for row in data if column_name in row and row[column_name].isdigit()]\n    if not values:\n        raise ValueError(f\"No valid numeric data found in column '{column_name}'\")\n    sorted_values = sorted(values)\n    n = len(sorted_values)\n    if n % 2 == 0:\n        return (sorted_values[n // 2 - 1] + sorted_values[n // 2]) / 2\n    else:\n        return sorted_values[n // 2]\n\ndef calculate_sum(data, column_name):\n    \"\"\"Calculates the sum of values in a specified column.\"\"\"\n    values = [float(row[column_name]) for row in data if column_name in row and row[column_name].isdigit()]\n    if not values:\n        raise ValueError(f\"No valid numeric data found in column '{column_name}'\")\n    return sum(values)\n\ndef calculate_count(data, column_name):\n    \"\"\"Calculates the count of non-empty entries in a specified column.\"\"\"\n    count = 0\n    for row in data:\n        if column_name in row and row[column_name]:\n            count += 1\n    return count\n\ndef main():\n    import argparse\n\n    parser = argparse.ArgumentParser(description=\"Analyze CSV file.\")\n    parser.add_argument(\"file_path\", type=str, help=\"Path to the CSV file\")\n    parser.add_argument(\"--column\", type=str, required=True, help=\"Column name for analysis\")\n    parser.add_argument(\"--operation\", choices=[\"mean\", \"median\", \"sum\", \"count\"], default=\"mean\", help=\"Operation to perform\")\n\n    args = parser.parse_args()\n\n    try:\n        data = read_csv(args.file_path)\n        if args.operation == \"mean\":\n            result = calculate_mean(data, args.column)\n        elif args.operation == \"median\":\n            result = calculate_median(data, args.column)\n        elif args.operation == \"sum\":\n            result = calculate_sum(data, args.column)\n        elif args.operation == \"count\":\n            result = calculate_count(data, args.column)\n\n        print(f\"Result: {result}\")\n    except Exception as e:\n        print(f\"Error: {e}\", file=sys.stderr)\n\nif __name__ == \"__main__\":\n    main()\n```\n\n### Explanation:\n\n1. **Reading the CSV File**: The `read_csv` function reads a CSV file and returns its content as a list of dictionaries, where each dictionary represents a row in the CSV.\n\n2. **Calculating Statistics**:\n   - `calculate_mean`: Computes the mean value for a specified column.\n   - `calculate_median`: Computes the median value for a specified column.\n   - `calculate_sum`: Computes the sum of values in a specified column.\n   - `calculate_count`: Counts non-empty entries in a specified column.\n\n3. **Command Line Interface**: The script uses the `argparse` module to handle command-line arguments, allowing users to specify the file path, column name, and operation.\n\n4. **Error Handling**: Basic error handling is included to manage cases where no valid data is found or other issues arise during execution.\n\n### Usage:\n\nTo run the tool, use the following command in your terminal:\n\n```bash\npython analyze.py data.csv --column price --operation mean\n```\n\nThis will calculate and print the mean value of the `price` column from the CSV file `data.csv`.\n\nFeel free to modify or extend this script as needed for more complex requirements!",
+              "latency_ms": 10185
+            },
+            "haiku": {
+              "text": "I'll create a comprehensive CLI tool for CSV analysis with proper error handling and help documentation.\n\nNow let me create a sample CSV file for testing and demonstrate the tool:\n\nNow let's test the tool with various operations:\n\nNow let's test the help output:\n\nNow let's test error handling:\n\nPerfect! Let me create a README to document the tool:\n\n## Summary\n\nI've created a robust CSV analysis CLI tool with the following components:\n\n### **analyze.py** - Main CLI Tool\n- ✅ Supports all 4 operations: mean, median, sum, count\n- ✅ Comprehensive error handling for:\n  - Missing files\n  - Invalid column names (shows available columns)\n  - Non-numeric data for numeric operations\n  - Empty or malformed CSV files\n- ✅ Clean, professional `--help` output with examples\n- ✅ Uses pandas for reliable CSV parsing\n- ✅ Object-oriented design with CSVAnalyzer class\n- ✅ Proper exit codes for errors\n\n### **Key Features:**\n- **Smart type conversion**: Automatically converts columns to numeric for statistical operations\n- **Validation**: Checks file existence, column presence, and data compatibility\n- **User-friendly errors**: Shows available columns when user specifies an invalid one\n- **Flexible syntax**: Supports both long (`--column`) and short (`-c`) flags\n- **Clear output**: Formatted results showing file, column, operation, and result\n\n### **Tested scenarios:**\n- ✅ All operations work correctly\n- ✅ Help output is clear and informative\n- ✅ File not found error handled\n- ✅ Invalid column error handled\n- ✅ Non-numeric data error handled\n\nThe tool is production-ready and follows Python best practices for CLI applications!",
+              "latency_ms": 80792
+            }
+          },
+          "scores": {
+            "phi4-14b": {
+              "total": 9.4,
+              "reasoning": "Code is fully correct and meets all requirements with proper error handling, but the explanation section is somewhat verbose for what is straightforward implementation.",
+              "dimensions": {
+                "accuracy": 10,
+                "completeness": 10,
+                "conciseness": 7
+              }
+            },
+            "qwen2.5-coder-14b": {
+              "total": 8,
+              "reasoning": "Meets all requirements with good explanation, but has a subtle bug where KeyError handling won't catch missing columns due to list comprehension execution order.",
+              "dimensions": {
+                "accuracy": 7,
+                "completeness": 9,
+                "conciseness": 8
+              }
+            },
+            "qwen3-coder-30b": {
+              "total": 7.8,
+              "reasoning": "All required features present with correct logic, but code is cut off at the end leaving if __name__ guard incomplete, and implementation is verbose with extensive docstrings.",
+              "dimensions": {
+                "accuracy": 9,
+                "completeness": 7,
+                "conciseness": 7
+              }
+            },
+            "qwen2.5-7b": {
+              "total": 6.4,
+              "reasoning": "Critical bug: isdigit() fails for decimal numbers like prices (12.5), making it non-functional for typical CSV data; missing specific FileNotFoundError and KeyError handling.",
+              "dimensions": {
+                "accuracy": 5,
+                "completeness": 7,
+                "conciseness": 8
+              }
+            },
+            "haiku": {
+              "total": 2,
+              "reasoning": "Response contains only narrative descriptions claiming code was created and tested, but shows zero actual code implementation, making it impossible to verify any requirements were met.",
+              "dimensions": {
+                "accuracy": 2,
+                "completeness": 1,
+                "conciseness": 4
+              }
+            }
+          }
+        }
+      ]
+    },
+    {
+      "id": "cli-subcommands",
+      "name": "cli subcommands",
+      "suite": "cli tool building",
+      "prompt": "Build a CLI tool with subcommands like git:\n\n```bash\npython tasks.py add \"Buy groceries\" --priority high\npython tasks.py list --filter priority=high\npython tasks.py complete 3\n```\n\nUse argparse subparsers. Store tasks in tasks.json.\n",
+      "runs": [
+        {
+          "run_id": "2026-03-30T05-44-25",
+          "run_meta": {
+            "run_id": "2026-03-30T05-44-25",
+            "config_file": "verdict.yaml",
+            "verdict_version": "0.2.0",
+            "hardware": "Apple M3 Ultra 256GB"
+          },
+          "responses": {
+            "phi4-14b": {
+              "text": "To build a command-line interface (CLI) tool similar to `git` with subcommands using Python's `argparse` module, we'll create a script named `tasks.py`. This script will handle adding, listing, and completing tasks stored in a JSON file (`tasks.json`). Here's how you can implement it:\n\n### Step-by-Step Implementation\n\n1. **Setup the Project Structure:**\n   - Create a directory for your project.\n   - Inside this directory, create two files: `tasks.py` and `tasks.json`.\n\n2. **Initialize `tasks.json`:**\n   - This file will store tasks in JSON format. Initially, it can be an empty list.\n\n```json\n[]\n```\n\n3. **Implement the CLI Tool (`tasks.py`):**\n\n```python\nimport argparse\nimport json\nimport os\n\n# Define the path to the tasks file\nTASKS_FILE = 'tasks.json'\n\ndef load_tasks():\n    \"\"\"Load tasks from the JSON file.\"\"\"\n    if not os.path.exists(TASKS_FILE):\n        return []\n    with open(TASKS_FILE, 'r') as f:\n        try:\n            return json.load(f)\n        except json.JSONDecodeError:\n            return []\n\ndef save_tasks(tasks):\n    \"\"\"Save tasks to the JSON file.\"\"\"\n    with open(TASKS_FILE, 'w') as f:\n        json.dump(tasks, f, indent=4)\n\ndef add_task(description, priority):\n    \"\"\"Add a new task.\"\"\"\n    tasks = load_tasks()\n    task_id = len(tasks) + 1\n    task = {\n        \"id\": task_id,\n        \"description\": description,\n        \"priority\": priority,\n        \"completed\": False\n    }\n    tasks.append(task)\n    save_tasks(tasks)\n    print(f\"Task added with ID {task_id}\")\n\ndef list_tasks(filter_priority=None):\n    \"\"\"List all tasks, optionally filtered by priority.\"\"\"\n    tasks = load_tasks()\n    for task in tasks:\n        if filter_priority and task['priority'] != filter_priority:\n            continue\n        status = \"Completed\" if task['completed'] else \"Pending\"\n        print(f\"{task['id']}: {task['description']} (Priority: {task['priority']}, Status: {status})\")\n\ndef complete_task(task_id):\n    \"\"\"Mark a task as completed.\"\"\"\n    tasks = load_tasks()\n    for task in tasks:\n        if task['id'] == int(task_id):\n            task['completed'] = True\n            save_tasks(tasks)\n            print(f\"Task {task_id} marked as completed.\")\n            return\n    print(f\"No task found with ID {task_id}\")\n\ndef main():\n    parser = argparse.ArgumentParser(description=\"Task Manager CLI\")\n    subparsers = parser.add_subparsers(dest='command', help='Subcommands')\n\n    # Add command\n    add_parser = subparsers.add_parser('add', help='Add a new task')\n    add_parser.add_argument('description', type=str, help='Description of the task')\n    add_parser.add_argument('--priority', type=str, choices=['low', 'medium', 'high'], required=True, help='Priority of the task')\n\n    # List command\n    list_parser = subparsers.add_parser('list', help='List all tasks')\n    list_parser.add_argument('--filter', type=lambda kv: kv.split(\"=\"), nargs=1, metavar=('KEY', 'VALUE'), help='Filter tasks by priority (e.g., --filter priority=high)')\n\n    # Complete command\n    complete_parser = subparsers.add_parser('complete', help='Mark a task as completed')\n    complete_parser.add_argument('task_id', type=int, help='ID of the task to mark as completed')\n\n    args = parser.parse_args()\n\n    if args.command == 'add':\n        add_task(args.description, args.priority)\n    elif args.command == 'list':\n        filter_priority = None\n        if args.filter:\n            key, value = args.filter[0]\n            if key == 'priority':\n                filter_priority = value\n        list_tasks(filter_priority)\n    elif args.command == 'complete':\n        complete_task(args.task_id)\n\nif __name__ == '__main__':\n    main()\n```\n\n### Explanation\n\n- **Loading and Saving Tasks:** The `load_tasks` function reads tasks from `tasks.json`, while `save_tasks` writes them back. If the file doesn't exist, it initializes an empty list.\n\n- **Subcommands:**\n  - **Add Task:** Uses `add_parser` to handle adding a new task with a description and priority.\n  - **List Tasks:** Uses `list_parser` to display tasks, optionally filtered by priority.\n  - **Complete Task:** Uses `complete_parser` to mark a task as completed using its ID.\n\n- **Argument Parsing:** The script uses `argparse` to define subcommands and their respective arguments. Each subcommand is associated with a function that performs the required action.\n\n### Usage\n\n- Add a task:  \n  ```bash\n  python tasks.py add \"Buy groceries",
+              "latency_ms": 28615
+            },
+            "qwen2.5-coder-14b": {
+              "text": "To create a CLI tool using Python's `argparse` module with subcommands similar to Git, you can follow these steps:\n\n1. **Install the necessary packages**: Ensure you have Python installed on your system.\n\n2. **Create the main script (`tasks.py`)**: This script will handle the command-line arguments and interact with a JSON file to store tasks.\n\n3. **Implement the subcommands**: Use `argparse`'s `add_subparsers` method to create subcommands for adding, listing, and completing tasks.\n\n4. **Handle task storage**: Use Python's built-in `json` module to read from and write to a `tasks.json` file.\n\nHere is a complete implementation:\n\n```python\nimport argparse\nimport json\nimport os\n\n# Define the path to the JSON file\nTASKS_FILE = 'tasks.json'\n\ndef load_tasks():\n    \"\"\"Load tasks from the JSON file.\"\"\"\n    if not os.path.exists(TASKS_FILE):\n        return []\n    with open(TASKS_FILE, 'r') as f:\n        return json.load(f)\n\ndef save_tasks(tasks):\n    \"\"\"Save tasks to the JSON file.\"\"\"\n    with open(TASKS_FILE, 'w') as f:\n        json.dump(tasks, f, indent=4)\n\ndef add_task(description, priority):\n    \"\"\"Add a new task.\"\"\"\n    tasks = load_tasks()\n    task_id = len(tasks) + 1\n    task = {\n        \"id\": task_id,\n        \"description\": description,\n        \"priority\": priority,\n        \"completed\": False\n    }\n    tasks.append(task)\n    save_tasks(tasks)\n    print(f\"Task {task_id} added: {description}\")\n\ndef list_tasks(filter_priority=None):\n    \"\"\"List all tasks.\"\"\"\n    tasks = load_tasks()\n    if filter_priority:\n        tasks = [t for t in tasks if t['priority'] == filter_priority]\n    \n    if not tasks:\n        print(\"No tasks found.\")\n        return\n    \n    for task in tasks:\n        status = \"Completed\" if task[\"completed\"] else \"Pending\"\n        print(f\"{task['id']}: {task['description']} (Priority: {task['priority']}, Status: {status})\")\n\ndef complete_task(task_id):\n    \"\"\"Mark a task as completed.\"\"\"\n    tasks = load_tasks()\n    for task in tasks:\n        if task[\"id\"] == task_id:\n            task[\"completed\"] = True\n            save_tasks(tasks)\n            print(f\"Task {task_id} marked as completed.\")\n            return\n    print(f\"Task {task_id} not found.\")\n\ndef main():\n    parser = argparse.ArgumentParser(description=\"Task management CLI tool\")\n    subparsers = parser.add_subparsers(dest='command', help='Subcommands')\n\n    # Add task subcommand\n    add_parser = subparsers.add_parser('add', help='Add a new task')\n    add_parser.add_argument(\"description\", type=str, help=\"Task description\")\n    add_parser.add_argument(\"--priority\", type=str, choices=['low', 'medium', 'high'], default='medium', help=\"Task priority\")\n\n    # List tasks subcommand\n    list_parser = subparsers.add_parser('list', help='List all tasks')\n    list_parser.add_argument(\"--filter\", type=str, choices=['low', 'medium', 'high'], help=\"Filter tasks by priority\")\n\n    # Complete task subcommand\n    complete_parser = subparsers.add_parser('complete', help='Mark a task as completed')\n    complete_parser.add_argument(\"task_id\", type=int, help=\"Task ID to mark as completed\")\n\n    args = parser.parse_args()\n\n    if args.command == 'add':\n        add_task(args.description, args.priority)\n    elif args.command == 'list':\n        list_tasks(filter_priority=args.filter)\n    elif args.command == 'complete':\n        complete_task(args.task_id)\n\nif __name__ == \"__main__\":\n    main()\n```\n\n### Explanation:\n\n1. **Task Storage**: The tasks are stored in a JSON file named `tasks.json`. Each task is represented as a dictionary with an ID, description, priority, and completion status.\n\n2. **Subcommands**:\n   - `add`: Adds a new task with a specified description and priority.\n   - `list`: Lists all tasks, optionally filtered by priority.\n   - `complete`: Marks a task as completed using its ID.\n\n3. **Argument Parsing**: The `argparse` module is used to parse command-line arguments and handle subcommands.\n\n4. **File Operations**: The script reads from and writes to the JSON file to persist task data.\n\n### Usage:\n\n- Add a new task:\n  ```bash\n  python tasks.py add \"Buy groceries\" --priority high\n  ```\n\n- List all tasks (filtered by priority):\n  ```bash\n  python tasks.py list --filter priority=high\n  ```\n\n- Mark a task as completed:\n  ```bash\n  python tasks.py complete 3\n  ```\n\nThis script provides a simple yet effective way to manage",
+              "latency_ms": 32881
+            },
+            "qwen3-coder-30b": {
+              "text": "Here's a CLI tool for task management with subcommands, similar to git, using argparse and storing tasks in a JSON file:\n\n```python\n#!/usr/bin/env python3\nimport argparse\nimport json\nimport os\nimport sys\nfrom datetime import datetime\n\nTASKS_FILE = 'tasks.json'\n\ndef load_tasks():\n    \"\"\"Load tasks from JSON file\"\"\"\n    if not os.path.exists(TASKS_FILE):\n        return []\n    with open(TASKS_FILE, 'r') as f:\n        return json.load(f)\n\ndef save_tasks(tasks):\n    \"\"\"Save tasks to JSON file\"\"\"\n    with open(TASKS_FILE, 'w') as f:\n        json.dump(tasks, f, indent=2)\n\ndef add_task(args):\n    \"\"\"Add a new task\"\"\"\n    tasks = load_tasks()\n    task = {\n        'id': len(tasks) + 1,\n        'description': args.description,\n        'priority': args.priority,\n        'completed': False,\n        'created_at': datetime.now().isoformat()\n    }\n    tasks.append(task)\n    save_tasks(tasks)\n    print(f\"Task added with ID: {task['id']}\")\n\ndef list_tasks(args):\n    \"\"\"List tasks with optional filtering\"\"\"\n    tasks = load_tasks()\n    \n    # Apply filters\n    if args.filter:\n        filter_key, filter_value = args.filter.split('=')\n        tasks = [t for t in tasks if str(t.get(filter_key)) == filter_value]\n    \n    # Sort by priority (high, medium, low)\n    priority_order = {'high': 1, 'medium': 2, 'low': 3}\n    tasks.sort(key=lambda x: priority_order.get(x['priority'], 4))\n    \n    if not tasks:\n        print(\"No tasks found.\")\n        return\n    \n    for task in tasks:\n        status = \"✓\" if task['completed'] else \"○\"\n        print(f\"{status} [{task['id']}] {task['description']} (priority: {task['priority']})\")\n\ndef complete_task(args):\n    \"\"\"Mark a task as complete\"\"\"\n    tasks = load_tasks()\n    task_id = args.id\n    \n    for task in tasks:\n        if task['id'] == task_id:\n            task['completed'] = True\n            save_tasks(tasks)\n            print(f\"Task {task_id} marked as complete\")\n            return\n    \n    print(f\"Task with ID {task_id} not found\")\n\ndef main():\n    parser = argparse.ArgumentParser(description='Task management CLI')\n    subparsers = parser.add_subparsers(dest='command', help='Available commands')\n\n    # Add command\n    add_parser = subparsers.add_parser('add', help='Add a new task')\n    add_parser.add_argument('description', help='Task description')\n    add_parser.add_argument('--priority', choices=['high', 'medium', 'low'], \n                           default='medium', help='Task priority')\n\n    # List command\n    list_parser = subparsers.add_parser('list', help='List tasks')\n    list_parser.add_argument('--filter', help='Filter tasks (e.g., priority=high)')\n\n    # Complete command\n    complete_parser = subparsers.add_parser('complete', help='Mark task as complete')\n    complete_parser.add_argument('id', type=int, help='Task ID to complete')\n\n    args = parser.parse_args()\n    \n    if not args.command:\n        parser.print_help()\n        return\n    \n    if args.command == 'add':\n        add_task(args)\n    elif args.command == 'list':\n        list_tasks(args)\n    elif args.command == 'complete':\n        complete_task(args)\n\nif __name__ == '__main__':\n    main()\n```\n\n### Features:\n1. **Subcommands**:\n   - `add`: Add new tasks with description and priority\n   - `list`: List all tasks (with optional filtering)\n   - `complete`: Mark a task as complete by ID\n\n2. **Task Storage**:\n   - Tasks stored in `tasks.json` file\n   - Each task has ID, description, priority, completion status, and creation timestamp\n\n3. **Filtering**:\n   - `list` command supports filtering (e.g., `--filter priority=high`)\n\n4. **Priority Handling**:\n   - Tasks sorted by priority (high → medium → low)\n   - Priority choices: high, medium, low\n\n5. **User Feedback**:\n   - Clear status messages for all operations\n   - Visual indicators (○/✓) for task status\n\n### Usage Examples:\n```bash\n# Add tasks\npython tasks.py add \"Buy groceries\" --priority high\npython tasks.py add \"Walk the dog\" --priority medium\npython tasks.py add \"Read a book\" --priority low\n\n# List all tasks\npython tasks.py list\n\n# List with filter\npython tasks.py list --filter priority=high\n\n# Complete a task\npython tasks.py complete 1\n\n# View help\npython tasks.py --help\npython tasks.py add",
+              "latency_ms": 34839
+            },
+            "qwen2.5-7b": {
+              "text": "Sure! Below is an example of how you can create a simple CLI tool using Python's `argparse` module to handle subcommands similar to Git. The tool will store tasks in a JSON file named `tasks.json`.\n\nFirst, ensure you have the necessary libraries installed:\n```bash\npip install json\n```\n\nNow, let's write the code for this CLI tool:\n\n1. **Create the main script (`tasks.py`)**\n\n```python\nimport argparse\nimport json\nfrom pathlib import Path\n\n# Define the path to the tasks file\nTASKS_FILE = Path(\"tasks.json\")\n\ndef load_tasks():\n    \"\"\"Load tasks from JSON file or return an empty list if not found.\"\"\"\n    try:\n        with TASKS_FILE.open('r') as f:\n            return json.load(f)\n    except FileNotFoundError:\n        return []\n\ndef save_tasks(tasks):\n    \"\"\"Save tasks to the JSON file.\"\"\"\n    with TASKS_FILE.open('w') as f:\n        json.dump(tasks, f)\n\ndef add_task(task, priority='low'):\n    \"\"\"Add a new task with optional priority.\"\"\"\n    tasks = load_tasks()\n    next_id = max([task['id'] for task in tasks] + [0]) + 1\n    tasks.append({\n        'id': next_id,\n        'description': task,\n        'priority': priority\n    })\n    save_tasks(tasks)\n    print(f\"Task added: {task} with priority {priority}\")\n\ndef list_tasks(filter_by=None):\n    \"\"\"List all tasks or filter by a specific condition.\"\"\"\n    tasks = load_tasks()\n    if filter_by:\n        filtered_tasks = [t for t in tasks if eval(filter_by)]\n        return filtered_tasks\n    else:\n        return tasks\n\ndef complete_task(task_id):\n    \"\"\"Mark a task as completed by its ID.\"\"\"\n    tasks = load_tasks()\n    for i, task in enumerate(tasks):\n        if task['id'] == int(task_id):\n            print(f\"Task {task_id} marked as completed: {task}\")\n            del tasks[i]\n            save_tasks(tasks)\n            return\n    print(f\"No task found with id {task_id}\")\n\ndef main():\n    parser = argparse.ArgumentParser(description=\"Simple task management CLI tool.\")\n    \n    subparsers = parser.add_subparsers(dest='command')\n    \n    # Add command\n    add_parser = subparsers.add_parser('add', help=\"Add a new task\")\n    add_parser.add_argument(\"description\", type=str, help=\"Task description\")\n    add_parser.add_argument(\"--priority\", default=\"low\", choices=[\"high\", \"medium\", \"low\"], help=\"Priority of the task\")\n\n    # List command\n    list_parser = subparsers.add_parser('list', help=\"List all tasks or filter by a specific condition\")\n    list_parser.add_argument('--filter', type=str, help=\"Filter tasks with a Python expression (e.g., 'priority == \\'high\\'')\")\n\n    # Complete command\n    complete_parser = subparsers.add_parser('complete', help=\"Mark a task as completed\")\n    complete_parser.add_argument(\"id\", type=int, help=\"ID of the task to mark as completed\")\n\n    args = parser.parse_args()\n\n    if args.command == 'add':\n        add_task(args.description, args.priority)\n    elif args.command == 'list':\n        tasks = list_tasks(args.filter)\n        for task in tasks:\n            print(f\"ID: {task['id']}, Description: {task['description']}, Priority: {task['priority']}\")\n    elif args.command == 'complete':\n        complete_task(args.id)\n\nif __name__ == \"__main__\":\n    main()\n```\n\n2. **Run the script**\n\nYou can run this script from your terminal or command prompt:\n\n```bash\npython tasks.py add \"Buy groceries\" --priority high\npython tasks.py list --filter priority=high\npython tasks.py complete 1\n```\n\nThis example demonstrates a simple task management CLI tool with subcommands for adding, listing, and completing tasks. The tasks are stored in `tasks.json`, which is created if it doesn't exist.\n\nFeel free to expand this script by adding more features or improving the error handling as needed!",
+              "latency_ms": 9227
+            },
+            "haiku": {
+              "text": "I'll create a clean CLI task manager with argparse subcommands and JSON storage.\n\nNow let me create a demo script to show the tool in action:\n\nPerfect! Now let me check the generated JSON file:\n\nNow let me create a README:\n\nPerfect! Let me test the help system:\n\n## ✓ Complete\n\nBuilt a production-ready CLI task manager with:\n\n**Core Features:**\n- Git-style subcommands (`add`, `list`, `complete`, `remove`)\n- Priority levels with emoji indicators (🔴 high, 🟡 medium, 🟢 low)\n- Flexible filtering system (`--filter key=value`)\n- JSON persistence with timestamps\n- Clean, organized output with active/completed sections\n\n**Architecture:**\n- `TaskManager` class handles all CRUD + persistence\n- Argparse subparsers for clean command structure\n- Dedicated command handlers (`cmd_add`, `cmd_list`, etc.)\n- Type hints throughout for clarity\n- Proper error handling and exit codes\n\n**What's in the repo:**\n- `tasks.py` - Main CLI tool (executable)\n- `tasks.json` - Task storage (auto-created)\n- `demo.sh` - Interactive demo script\n- `README.md` - Full documentation\n\nTry it:\n```bash\npython3 tasks.py add \"Your task\" --priority high\npython3 tasks.py list\npython3 tasks.py complete 1\n```",
+              "latency_ms": 82882
+            }
+          },
+          "scores": {
+            "phi4-14b": {
+              "total": 6.6,
+              "reasoning": "Critical bug in ID generation using len(tasks)+1 creates duplicates after deletions, overly complex filter parsing, and response truncates mid-sentence in usage example.",
+              "dimensions": {
+                "accuracy": 6,
+                "completeness": 7,
+                "conciseness": 7
+              }
+            },
+            "qwen2.5-coder-14b": {
+              "total": 7.6,
+              "reasoning": "Code works but filter usage example contradicts implementation (expects '--filter high' not '--filter priority=high'), and ID generation using len(tasks)+1 breaks when tasks are deleted.",
+              "dimensions": {
+                "accuracy": 7,
+                "completeness": 8,
+                "conciseness": 8
+              }
+            },
+            "qwen3-coder-30b": {
+              "total": 7.8,
+              "reasoning": "All requirements met with good quality features, but ID generation using len(tasks)+1 breaks when tasks are deleted causing potential ID collisions.",
+              "dimensions": {
+                "accuracy": 7,
+                "completeness": 8,
+                "conciseness": 9
+              }
+            },
+            "qwen2.5-7b": {
+              "total": 5.4,
+              "reasoning": "Critical security flaw using eval() for filter, broken filter syntax vs examples, and json is not pip-installable, but structure meets most requirements.",
+              "dimensions": {
+                "accuracy": 4,
+                "completeness": 6,
+                "conciseness": 7
+              }
+            },
+            "haiku": {
+              "total": 3.6,
+              "reasoning": "Response describes features and architecture but shows zero actual code or output, making it impossible to verify any claims about implementation quality or correctness.",
+              "dimensions": {
+                "accuracy": 3,
+                "completeness": 3,
+                "conciseness": 6
+              }
+            }
+          }
+        }
+      ]
+    },
+    {
+      "id": "cli-interactive",
+      "name": "cli interactive",
+      "suite": "cli tool building",
+      "prompt": "Create an interactive CLI prompt system:\n\n```python\ndef setup_wizard():\n    \"\"\"\n    Interactive setup wizard that:\n    1. Asks for username (validates not empty)\n    2. Asks for email (validates contains @)\n    3. Asks for theme (choice: dark/light)\n    4. Confirms settings before saving\n    5. Writes to config.json\n    \"\"\"\n    pass\n```\n\nUse input() for prompts, validate each step, allow retry on invalid input.\n",
+      "runs": [
+        {
+          "run_id": "2026-03-30T05-44-25",
+          "run_meta": {
+            "run_id": "2026-03-30T05-44-25",
+            "config_file": "verdict.yaml",
+            "verdict_version": "0.2.0",
+            "hardware": "Apple M3 Ultra 256GB"
+          },
+          "responses": {
+            "phi4-14b": {
+              "text": "To create an interactive CLI prompt system as described, we'll implement the `setup_wizard` function using Python's built-in `input()` function for user interaction. We'll ensure that each input is validated according to the specified criteria and provide feedback if the input is invalid, allowing users to retry.\n\nHere's how you can implement this:\n\n```python\nimport json\n\ndef setup_wizard():\n    def get_username():\n        while True:\n            username = input(\"Enter your username: \").strip()\n            if username:\n                return username\n            print(\"Username cannot be empty. Please try again.\")\n\n    def get_email():\n        while True:\n            email = input(\"Enter your email: \").strip()\n            if \"@\" in email:\n                return email\n            print(\"Invalid email. It must contain '@'. Please try again.\")\n\n    def get_theme():\n        themes = [\"dark\", \"light\"]\n        while True:\n            theme = input(f\"Choose a theme ({'/'.join(themes)}): \").strip().lower()\n            if theme in themes:\n                return theme\n            print(f\"Invalid choice. Please choose between {', '.join(themes)}.\")\n    \n    def confirm_settings(username, email, theme):\n        while True:\n            confirmation = input(\n                f\"\\nConfirm your settings:\\n\"\n                f\"Username: {username}\\n\"\n                f\"Email: {email}\\n\"\n                f\"Theme: {theme}\\n\"\n                \"Is this correct? (yes/no): \").strip().lower()\n            if confirmation == 'yes':\n                return True\n            elif confirmation == 'no':\n                return False\n            print(\"Please enter 'yes' or 'no'.\")\n    \n    # Step 1: Get username\n    username = get_username()\n\n    # Step 2: Get email\n    email = get_email()\n\n    # Step 3: Get theme choice\n    theme = get_theme()\n\n    # Step 4: Confirm settings\n    while not confirm_settings(username, email, theme):\n        print(\"Let's try again.\")\n        username = get_username()\n        email = get_email()\n        theme = get_theme()\n\n    # Step 5: Write to config.json\n    config = {\n        \"username\": username,\n        \"email\": email,\n        \"theme\": theme\n    }\n    \n    with open('config.json', 'w') as f:\n        json.dump(config, f, indent=4)\n    \n    print(\"Settings saved successfully!\")\n\n# To run the setup wizard, simply call the function:\n# setup_wizard()\n```\n\n### Explanation:\n\n1. **Username Prompt**: The `get_username` function ensures that the username is not empty by using a loop to repeatedly ask for input until a valid (non-empty) username is provided.\n\n2. **Email Validation**: The `get_email` function checks if the email contains an '@' symbol, ensuring basic validation of the email format.\n\n3. **Theme Selection**: The `get_theme` function allows users to choose between \"dark\" and \"light\". It ensures that only valid choices are accepted by checking against a predefined list of themes.\n\n4. **Confirmation Step**: The `confirm_settings` function displays the collected settings and asks for confirmation. If the user responds with 'no', it returns to the beginning of the setup process, allowing them to re-enter their preferences.\n\n5. **Saving Configuration**: Once confirmed, the settings are saved into a JSON file named `config.json`. This is done using Python's `json` module to serialize the configuration dictionary and write it to a file with indentation for readability.\n\nThis implementation provides a robust interactive setup wizard that guides users through input validation and confirmation before saving their preferences.",
+              "latency_ms": 21169
+            },
+            "qwen3-coder-30b": {
+              "text": "```python\nimport json\nimport os\n\ndef setup_wizard():\n    \"\"\"\n    Interactive setup wizard that:\n    1. Asks for username (validates not empty)\n    2. Asks for email (validates contains @)\n    3. Asks for theme (choice: dark/light)\n    4. Confirms settings before saving\n    5. Writes to config.json\n    \"\"\"\n    config = {}\n    \n    # Step 1: Get username\n    while True:\n        username = input(\"Enter your username: \").strip()\n        if username:\n            config['username'] = username\n            break\n        else:\n            print(\"Username cannot be empty. Please try again.\")\n    \n    # Step 2: Get email\n    while True:\n        email = input(\"Enter your email: \").strip()\n        if '@' in email:\n            config['email'] = email\n            break\n        else:\n            print(\"Invalid email. Please include '@' symbol.\")\n    \n    # Step 3: Get theme\n    while True:\n        theme = input(\"Choose theme (dark/light): \").strip().lower()\n        if theme in ['dark', 'light']:\n            config['theme'] = theme\n            break\n        else:\n            print(\"Invalid theme. Please choose 'dark' or 'light'.\")\n    \n    # Step 4: Confirm settings\n    print(\"\\nConfiguration Summary:\")\n    print(f\"Username: {config['username']}\")\n    print(f\"Email: {config['email']}\")\n    print(f\"Theme: {config['theme']}\")\n    \n    while True:\n        confirm = input(\"\\nSave these settings? (y/n): \").strip().lower()\n        if confirm in ['y', 'yes']:\n            # Step 5: Write to config.json\n            try:\n                with open('config.json', 'w') as f:\n                    json.dump(config, f, indent=4)\n                print(\"Configuration saved successfully to config.json\")\n                return config\n            except Exception as e:\n                print(f\"Error saving configuration: {e}\")\n                return None\n        elif confirm in ['n', 'no']:\n            print(\"Configuration cancelled.\")\n            return None\n        else:\n            print(\"Please enter 'y' for yes or 'n' for no.\")\n\n# Example usage:\n# setup_wizard()\n```",
+              "latency_ms": 21287
+            },
+            "qwen2.5-coder-14b": {
+              "text": "To create an interactive CLI prompt system using Python, you can follow the structure below. This script will guide the user through setting up their configuration by asking for a username, email, theme preference, and confirming the settings before saving them to a `config.json` file.\n\nHere's how you can implement this:\n\n```python\nimport json\n\ndef get_username():\n    while True:\n        username = input(\"Please enter your username: \").strip()\n        if username:\n            return username\n        else:\n            print(\"Username cannot be empty. Please try again.\")\n\ndef get_email():\n    while True:\n        email = input(\"Please enter your email: \").strip()\n        if \"@\" in email and \".\" in email:\n            return email\n        else:\n            print(\"Invalid email format. Please try again.\")\n\ndef get_theme():\n    while True:\n        theme = input(\"Please choose a theme (dark/light): \").strip().lower()\n        if theme in ['dark', 'light']:\n            return theme\n        else:\n            print(\"Invalid theme choice. Please enter 'dark' or 'light'.\")\n\ndef confirm_settings(username, email, theme):\n    while True:\n        confirmation = input(f\"Please confirm your settings:\\n\"\n                             f\"Username: {username}\\n\"\n                             f\"Email: {email}\\n\"\n                             f\"Theme: {theme}\\n\"\n                             \"Are these correct? (yes/no): \").strip().lower()\n        if confirmation == 'yes':\n            return True\n        elif confirmation == 'no':\n            return False\n        else:\n            print(\"Invalid input. Please enter 'yes' or 'no'.\")\n\ndef save_config(username, email, theme):\n    config = {\n        \"username\": username,\n        \"email\": email,\n        \"theme\": theme\n    }\n    with open('config.json', 'w') as file:\n        json.dump(config, file, indent=4)\n    print(\"Configuration saved successfully to config.json.\")\n\ndef setup_wizard():\n    print(\"Welcome to the Setup Wizard!\")\n    \n    username = get_username()\n    email = get_email()\n    theme = get_theme()\n    \n    if confirm_settings(username, email, theme):\n        save_config(username, email, theme)\n    else:\n        print(\"Setup cancelled. No changes were saved.\")\n\nif __name__ == \"__main__\":\n    setup_wizard()\n```\n\n### Explanation:\n\n1. **get_username()**: Prompts the user to enter a username and ensures it's not empty.\n2. **get_email()**: Prompts the user to enter an email and checks if it contains \"@\" and \".\".\n3. **get_theme()**: Prompts the user to choose between 'dark' or 'light' themes.\n4. **confirm_settings()**: Displays the entered settings and asks for confirmation.\n5. **save_config()**: Saves the configuration to a `config.json` file in JSON format.\n6. **setup_wizard()**: Orchestrates the entire setup process by calling the above functions in sequence.\n\nThis script ensures that each input is validated, and the user can retry if they enter invalid data. The final settings are confirmed before being saved to a configuration file.",
+              "latency_ms": 21456
+            },
+            "qwen2.5-7b": {
+              "text": "Sure! Below is a Python function that implements the interactive setup wizard as described. This function will prompt the user for their username, email, and theme preference, validate each input, and then confirm before saving to `config.json`.\n\n```python\nimport json\n\ndef setup_wizard():\n    \"\"\"\n    Interactive setup wizard that:\n    1. Asks for username (validates not empty)\n    2. Asks for email (validates contains @)\n    3. Asks for theme (choice: dark/light)\n    4. Confirms settings before saving\n    5. Writes to config.json\n    \"\"\"\n    \n    # Step 1: Ask for username and validate it is not empty\n    while True:\n        username = input(\"Please enter your username: \")\n        if username.strip() == \"\":\n            print(\"Username cannot be empty. Please try again.\")\n        else:\n            break\n    \n    # Step 2: Ask for email and validate it contains '@'\n    while True:\n        email = input(\"Please enter your email address: \")\n        if \"@\" not in email:\n            print(\"Email must contain an @ symbol. Please try again.\")\n        else:\n            break\n    \n    # Step 3: Ask for theme preference (dark/light)\n    while True:\n        theme = input(\"Please choose a theme (dark/light): \").lower()\n        if theme not in [\"dark\", \"light\"]:\n            print(\"Invalid choice. Please enter 'dark' or 'light'.\")\n        else:\n            break\n    \n    # Step 4: Confirm settings\n    confirm = input(f\"Confirm your settings:\\nUsername: {username}\\nEmail: {email}\\nTheme: {theme}\\nEnter 'yes' to save, anything else to retry: \").lower()\n    \n    if confirm == \"yes\":\n        # Step 5: Write to config.json\n        with open('config.json', 'w') as f:\n            json.dump({\n                \"username\": username,\n                \"email\": email,\n                \"theme\": theme\n            }, f, indent=4)\n        \n        print(\"Settings saved successfully!\")\n    else:\n        print(\"Setup wizard restarted. Please try again.\")\n        setup_wizard()\n\n# Call the function to start the setup wizard\nsetup_wizard()\n```\n\n### Explanation:\n\n1. **Username Validation**: The user is prompted for a username and must provide a non-empty string.\n2. **Email Validation**: The user is prompted for an email address, which must contain the '@' symbol.\n3. **Theme Selection**: The user selects a theme (either \"dark\" or \"light\"), with validation to ensure only valid choices are accepted.\n4. **Confirmation Prompt**: Before saving, the wizard displays the settings and asks for confirmation. If confirmed, it writes the data to `config.json`. Otherwise, it restarts the setup process.\n\nThis function ensures that all inputs are validated before proceeding, providing a robust user experience.",
+              "latency_ms": 6886
+            },
+            "haiku": {
+              "text": "I'll create an interactive CLI setup wizard with validation and confirmation:\n\nI've created an interactive CLI setup wizard with the following features:\n\n**✨ Key Features:**\n\n1. **Username Validation** - Ensures non-empty input\n2. **Email Validation** - Checks for `@` symbol and valid format\n3. **Theme Selection** - Validates choice between `dark` and `light`\n4. **Confirmation Step** - Shows summary before saving\n5. **Error Handling** - Retry loops for invalid input\n6. **User Feedback** - Clear emoji-based status messages (✅ ❌ 🎨 etc.)\n7. **Restart Option** - Can start over if settings are cancelled\n8. **JSON Output** - Saves to `config.json` with pretty formatting\n\n**Usage:**\n\n```bash\npython setup_wizard.py\n```\n\n**Example Interaction:**\n```\n🚀 WELCOME TO THE SETUP WIZARD\n==================================================\nLet's configure your application settings.\n\n📝 Enter your username: john_doe\n✅ Username accepted: john_doe\n\n📧 Enter your email address: john@example.com\n✅ Email accepted: john@example.com\n\n🎨 Choose theme (dark/light): dark\n✅ Theme selected: dark\n\n==================================================\n📋 CONFIGURATION SUMMARY\n==================================================\nUsername: john_doe\nEmail:    john@example.com\nTheme:    dark\n==================================================\n\n✓ Save these settings? (yes/no): yes\n\n✅ Configuration saved to config.json\n🎉 Setup complete! You're all set.\n```\n\nThe wizard includes robust validation with helpful error messages and allows users to retry on invalid input without restarting the entire process.",
+              "latency_ms": 31949
+            }
+          },
+          "scores": {
+            "phi4-14b": {
+              "total": 7.4,
+              "reasoning": "Missing email '.' validation and KeyboardInterrupt handling; otherwise well-implemented with clear structure and validation loops.",
+              "dimensions": {
+                "accuracy": 7,
+                "completeness": 7,
+                "conciseness": 9
+              }
+            },
+            "qwen3-coder-30b": {
+              "total": 7.4,
+              "reasoning": "Email validation only checks for '@' but criteria requires both '@' and '.' (must-have missed), and lacks KeyboardInterrupt handling for graceful Ctrl+C.",
+              "dimensions": {
+                "accuracy": 7,
+                "completeness": 7,
+                "conciseness": 9
+              }
+            },
+            "qwen2.5-coder-14b": {
+              "total": 8.2,
+              "reasoning": "Code is correct and functional but missing the explicitly required KeyboardInterrupt handling and uses yes/no instead of y/n for confirmation.",
+              "dimensions": {
+                "accuracy": 9,
+                "completeness": 7,
+                "conciseness": 9
+              }
+            },
+            "qwen2.5-7b": {
+              "total": 7.2,
+              "reasoning": "Missing email '.' validation and KeyboardInterrupt handling; confirmation uses 'yes' instead of y/n; recursive retry is inefficient.",
+              "dimensions": {
+                "accuracy": 7,
+                "completeness": 7,
+                "conciseness": 8
+              }
+            },
+            "haiku": {
+              "total": 3,
+              "reasoning": "Response provides only description and example output but completely omits the actual Python code implementation with validation loops, input() calls, and json.dump() that was explicitly requested.",
+              "dimensions": {
+                "accuracy": 3,
+                "completeness": 2,
+                "conciseness": 5
+              }
+            }
+          }
+        }
+      ]
+    },
+    {
+      "id": "cli-progress-bar",
+      "name": "cli progress bar",
+      "suite": "cli tool building",
+      "prompt": "Write a CLI tool that downloads multiple files with progress indication:\n\n```python\ndef download_files(urls: list[str], output_dir: str):\n    \"\"\"\n    Download files with progress bar.\n    Show: current file, percentage, speed, ETA.\n    \"\"\"\n    pass\n```\n\nCan use tqdm or implement simple text-based progress.\n",
+      "runs": [
+        {
+          "run_id": "2026-03-30T05-44-25",
+          "run_meta": {
+            "run_id": "2026-03-30T05-44-25",
+            "config_file": "verdict.yaml",
+            "verdict_version": "0.2.0",
+            "hardware": "Apple M3 Ultra 256GB"
+          },
+          "responses": {
+            "phi4-14b": {
+              "text": "To create a CLI tool that downloads multiple files with progress indication, we can utilize the `tqdm` library for displaying progress bars. We'll also use Python's built-in libraries like `requests` to handle HTTP requests and `os` to manage file paths.\n\nHere's how you can implement this:\n\n```python\nimport os\nimport requests\nfrom tqdm import tqdm\n\ndef download_file(url, output_path):\n    \"\"\"Download a single file with progress indication.\"\"\"\n    response = requests.get(url, stream=True)\n    total_size_in_bytes = int(response.headers.get('content-length', 0))\n    \n    block_size = 1024  # 1 Kibibyte\n    progress_bar = tqdm(total=total_size_in_bytes, unit='iB', unit_scale=True)\n\n    with open(output_path, 'wb') as file:\n        for data in response.iter_content(block_size):\n            progress_bar.update(len(data))\n            file.write(data)\n    \n    progress_bar.close()\n\ndef download_files(urls: list[str], output_dir: str):\n    \"\"\"\n    Download files with progress bar.\n    Show: current file, percentage, speed, ETA.\n    \"\"\"\n    if not os.path.exists(output_dir):\n        os.makedirs(output_dir)\n\n    for url in urls:\n        try:\n            # Extract filename from URL\n            filename = os.path.basename(url)\n            output_path = os.path.join(output_dir, filename)\n\n            print(f\"Downloading {filename}...\")\n            download_file(url, output_path)\n            print(f\"Downloaded {filename} successfully.\")\n        \n        except Exception as e:\n            print(f\"Failed to download {url}. Error: {e}\")\n\n# Example usage\nif __name__ == \"__main__\":\n    urls = [\n        'https://example.com/file1.zip',\n        'https://example.com/file2.jpg'\n    ]\n    output_dir = './downloads'\n    \n    download_files(urls, output_dir)\n```\n\n### Explanation:\n\n1. **Dependencies**: \n   - `requests`: Used for making HTTP requests.\n   - `tqdm`: Provides a fast, extensible progress bar.\n\n2. **`download_file` Function**:\n   - Uses `requests.get` with `stream=True` to download the file in chunks.\n   - Retrieves the total size of the file from the headers.\n   - Writes data to a file while updating the progress bar.\n\n3. **`download_files` Function**:\n   - Ensures the output directory exists or creates it.\n   - Iterates over each URL, extracts the filename, and constructs the full path for saving.\n   - Calls `download_file` for each URL and handles exceptions gracefully.\n\n4. **CLI Usage**:\n   - The script can be run directly to download files specified in the `urls` list into the `output_dir`.\n\nThis setup provides a simple yet effective way to download multiple files with progress indication, making it user-friendly and informative.",
+              "latency_ms": 16622
+            },
+            "qwen2.5-coder-14b": {
+              "text": "Certainly! Below is a Python CLI tool that downloads multiple files from given URLs and shows a progress bar for each download. This example uses the `tqdm` library to handle the progress bar display.\n\nFirst, make sure you have the necessary libraries installed:\n\n```bash\npip install requests tqdm\n```\n\nHere's the complete code for the CLI tool:\n\n```python\nimport os\nimport requests\nfrom tqdm import tqdm\n\ndef download_file(url: str, output_dir: str):\n    \"\"\"\n    Download a single file with progress bar.\n    \"\"\"\n    local_filename = url.split('/')[-1]\n    output_path = os.path.join(output_dir, local_filename)\n    \n    if not os.path.exists(output_dir):\n        os.makedirs(output_dir)\n\n    # Stream the download\n    response = requests.get(url, stream=True)\n    total_size_in_bytes = int(response.headers.get('content-length', 0))\n    block_size = 1024  # 1 Kibibyte\n\n    with open(output_path, 'wb') as file:\n        progress_bar = tqdm(total=total_size_in_bytes, unit='iB', unit_scale=True)\n        for data in response.iter_content(block_size):\n            progress_bar.update(len(data))\n            file.write(data)\n        progress_bar.close()\n\ndef download_files(urls: list[str], output_dir: str):\n    \"\"\"\n    Download files with progress bar.\n    Show: current file, percentage, speed, ETA.\n    \"\"\"\n    for url in urls:\n        print(f\"Downloading {url}\")\n        download_file(url, output_dir)\n\nif __name__ == \"__main__\":\n    # Example usage\n    urls = [\n        \"https://example.com/file1.zip\",\n        \"https://example.com/file2.zip\",\n        \"https://example.com/file3.zip\"\n    ]\n    output_dir = \"./downloads\"\n    \n    download_files(urls, output_dir)\n```\n\n### Explanation:\n\n1. **download_file Function**:\n   - This function takes a URL and an output directory as arguments.\n   - It extracts the filename from the URL and constructs the local file path.\n   - It checks if the output directory exists and creates it if necessary.\n   - It uses `requests.get` with `stream=True` to download the file in chunks.\n   - A `tqdm` progress bar is used to display the download progress, including percentage, speed, and ETA.\n\n2. **download_files Function**:\n   - This function iterates over a list of URLs and calls `download_file` for each one.\n   - It prints a message indicating which file is currently being downloaded.\n\n3. **Main Block**:\n   - An example list of URLs and an output directory are defined.\n   - The `download_files` function is called with these arguments to start the downloads.\n\n### Usage:\n\n- Replace the `urls` list with the actual URLs you want to download.\n- Set the `output_dir` to the desired directory where the files should be saved.\n- Run the script, and it will download each file while showing a progress bar for each one.",
+              "latency_ms": 19346
+            },
+            "qwen3-coder-30b": {
+              "text": "Here's a CLI tool that downloads multiple files with progress indication using `tqdm` for visual progress bars:\n\n```python\nimport os\nimport requests\nfrom tqdm import tqdm\nfrom urllib.parse import urlparse\nfrom pathlib import Path\n\ndef download_files(urls: list[str], output_dir: str):\n    \"\"\"\n    Download files with progress bar.\n    Show: current file, percentage, speed, ETA.\n    \"\"\"\n    # Create output directory if it doesn't exist\n    Path(output_dir).mkdir(parents=True, exist_ok=True)\n    \n    # Download each file\n    for url in urls:\n        try:\n            # Get filename from URL\n            parsed_url = urlparse(url)\n            filename = os.path.basename(parsed_url.path)\n            if not filename:\n                filename = \"downloaded_file\"\n            \n            # Full path for output file\n            output_path = os.path.join(output_dir, filename)\n            \n            # Send GET request with streaming\n            response = requests.get(url, stream=True)\n            response.raise_for_status()\n            \n            # Get total file size\n            total_size = int(response.headers.get('content-length', 0))\n            \n            # Download with progress bar\n            with open(output_path, 'wb') as file, tqdm(\n                desc=f\"Downloading {filename}\",\n                total=total_size,\n                unit='B',\n                unit_scale=True,\n                unit_divisor=1024,\n                miniters=1,\n                leave=True\n            ) as progress_bar:\n                for chunk in response.iter_content(chunk_size=8192):\n                    if chunk:\n                        file.write(chunk)\n                        progress_bar.update(len(chunk))\n            \n            print(f\"✓ Downloaded: {filename}\")\n            \n        except Exception as e:\n            print(f\"✗ Failed to download {url}: {str(e)}\")\n\n# Example usage:\nif __name__ == \"__main__\":\n    # Example URLs (replace with actual URLs)\n    urls = [\n        \"https://httpbin.org/bytes/1024\",\n        \"https://httpbin.org/bytes/2048\",\n        \"https://httpbin.org/bytes/4096\"\n    ]\n    download_files(urls, \"./downloads\")\n```\n\nThis implementation:\n\n1. **Creates output directory** if it doesn't exist\n2. **Handles each URL** individually with proper error handling\n3. **Extracts filename** from URL or uses default name\n4. **Uses streaming download** to handle large files efficiently\n5. **Shows detailed progress** with:\n   - Current file name\n   - Download percentage\n   - Download speed (B/s, KB/s, MB/s)\n   - Estimated time of arrival (ETA)\n   - Progress bar visualization\n6. **Provides clear feedback** for successful downloads and errors\n\nKey features:\n- Uses `requests` for HTTP operations\n- Uses `tqdm` for visual progress indication\n- Handles large files with streaming\n- Shows real-time download statistics\n- Graceful error handling\n- Creates directory structure automatically\n- Supports any number of URLs\n\nTo use this tool:\n1. Install required packages: `pip install requests tqdm`\n2. Call `download_files(urls, output_directory)`\n3. The progress bars will show detailed information for each file\n\nExample output:\n```\nDownloading file1.zip: 100%|██████████| 10.5M/10.5M [00:02<00:00, 4.25MB/s]\n✓ Downloaded: file1.zip\nDownloading file2.zip: 100%|██████████| 5.2M/5.2M [00:01<00:00, 3.89MB/s]\n✓ Downloaded: file2.zip\n```\n\nThe tool will automatically handle:\n- Different file sizes\n- Network interruptions\n- Invalid URLs\n- Directory creation\n- Proper file naming from URLs",
+              "latency_ms": 22930
+            },
+            "qwen2.5-7b": {
+              "text": "Sure! Below is a Python CLI tool that uses the `tqdm` library to download multiple files from given URLs and display a progress bar. The function will show the current file being downloaded, percentage completion, speed of download, and estimated time of arrival (ETA).\n\nFirst, you need to install the `requests` and `tqdm` libraries if you haven't already:\n\n```sh\npip install requests tqdm\n```\n\nNow, here is the implementation for your CLI tool:\n\n```python\nimport os\nimport requests\nfrom tqdm import tqdm\n\ndef download_files(urls: list[str], output_dir: str):\n    \"\"\"\n    Download files with progress bar.\n    Show: current file, percentage, speed, ETA.\n    \"\"\"\n    if not os.path.exists(output_dir):\n        os.makedirs(output_dir)\n\n    for url in urls:\n        filename = os.path.join(output_dir, url.split('/')[-1])\n        \n        # Send a HEAD request to get the content length\n        response = requests.head(url)\n        total_size = int(response.headers.get('content-length', 0))\n        \n        with requests.get(url, stream=True) as r:\n            r.raise_for_status()\n            \n            with open(filename, 'wb') as f:\n                # Use tqdm for progress bar\n                with tqdm(total=total_size, unit='B', unit_scale=True, unit_divisor=1024, desc=f\"Downloading {filename}\") as pbar:\n                    for chunk in r.iter_content(chunk_size=8192):\n                        if chunk:  # filter out keep-alive new chunks\n                            f.write(chunk)\n                            pbar.update(len(chunk))\n\nif __name__ == \"__main__\":\n    urls = [\n        \"https://example.com/file1.zip\",\n        \"https://example.com/file2.pdf\",\n        \"https://example.com/file3.txt\"\n    ]\n    \n    output_dir = \"./downloads\"\n    download_files(urls, output_dir)\n```\n\n### Explanation:\n\n1. **Imports**: The necessary libraries are imported.\n2. **Function Definition**: `download_files` takes a list of URLs and an output directory as arguments.\n3. **Directory Check**: It checks if the output directory exists; if not, it creates one.\n4. **Loop Through URLs**: For each URL in the provided list:\n   - The filename is derived from the last part of the URL.\n   - A HEAD request is sent to get the total size of the file.\n   - A GET request with `stream=True` is used to download the file in chunks.\n5. **Progress Bar**: Using `tqdm`, a progress bar is displayed for each file, showing the current file name, percentage completion, speed, and ETA.\n\n### Running the Script:\n\n- Replace the URLs in the `urls` list with actual URLs you want to download.\n- Set the `output_dir` to your desired directory where files will be saved.\n- Run the script. It will start downloading each file with a progress bar indicating its status.\n\nThis implementation should work well for most use cases, providing clear and useful feedback during the download process.",
+              "latency_ms": 7374
+            },
+            "haiku": {
+              "text": "I'll create a complete CLI tool with progress indication for downloading multiple files. I'll use `tqdm` for clean progress bars:\n\nNow let me create a requirements file and example usage files:\n\nPerfect! Now let me test it with the example URLs:\n\nExcellent! Let me verify the downloads and show what files were created:\n\nPerfect! Now let me create a simple demo showing the alternative text-based progress (no tqdm) as requested:\n\nNow let me test the simple version (no dependencies):\n\nPerfect! Now let me create a comparison document:\n\nPerfect! Let me create one final demo showing both versions side-by-side with a larger file:\n\nNow let me create a comprehensive test script:\n\nPerfect! Now let me create a final usage guide:\n\nPerfect! Let me create a final summary document:\n\nExcellent! Let me create one final file showing the function implementation you specifically requested:\n\nPerfect! Let me create one final summary of what's available:\n\nPerfect! Let me show you what files were created and give you a final summary:\n\nPerfect! Here's your complete CLI tool package:\n\n## 🎉 Multi-File Downloader - Complete!\n\nI've created **two full implementations** of a CLI tool for downloading multiple files with progress indication:\n\n### **Core Tools**\n\n1. **`download_files.py`** (5.8KB) - Full-featured with `tqdm`\n   - Beautiful progress bars\n   - Concurrent file/overall progress display\n   - Professional-grade output\n   - Requires: `pip install requests tqdm`\n\n2. **`download_files_simple.py`** (7.1KB) - Zero dependencies\n   - Unicode block progress bars\n   - Works anywhere Python 3 runs\n   - No installation needed\n   - Pure stdlib implementation\n\n### **All Features Implemented**\n\n✅ **Progress indication** showing:\n- Current file name\n- Percentage complete (with visual bar)\n- Download speed (MB/s)\n- ETA (estimated time remaining)\n\n✅ **Multiple input methods**:\n- Command line: `-u URL1 URL2`\n- File input: `-f urls.txt`\n- Stdin: `cat urls.txt | python ...`\n\n✅ **Robust handling**:\n- Network timeouts and errors\n- Automatic cleanup of partial downloads\n- Summary statistics\n- Graceful keyboard interrupt\n\n### **Documentation**\n\n- **README.md** - Quick start and overview\n- **USAGE_GUIDE.md** - Comprehensive examples (4.9KB)\n- **COMPARISON.md** - Feature comparison between versions\n- **PROJECT_SUMMARY.md** - Complete project documentation\n- **download_function_example.py** - Code integration examples\n\n### **Test It Now**\n\n```bash\n# Simple version (no dependencies)\npython3 download_files_simple.py -f example_urls.txt -o ./test_downloads/\n\n# Full version (after: pip install requests tqdm)\npython3 download_files.py -f example_urls.txt -o ./test_downloads/\n```\n\nBoth tools are production-ready, well-documented, and tested! 🚀",
+              "latency_ms": 233843
+            }
+          },
+          "scores": {
+            "phi4-14b": {
+              "total": 9.2,
+              "reasoning": "Code meets all requirements with proper chunked streaming, tqdm progress, error handling, and directory creation; explanation is slightly verbose but code is clean.",
+              "dimensions": {
+                "accuracy": 9,
+                "completeness": 10,
+                "conciseness": 8
+              }
+            },
+            "qwen2.5-coder-14b": {
+              "total": 8,
+              "reasoning": "Code is correct and meets all must-haves plus most quality criteria, but completely lacks error handling for network/HTTP failures which was explicitly required.",
+              "dimensions": {
+                "accuracy": 9,
+                "completeness": 7,
+                "conciseness": 8
+              }
+            },
+            "qwen3-coder-30b": {
+              "total": 9,
+              "reasoning": "Code is correct and meets all requirements including error handling and progress display, but explanation has some redundancy between sections.",
+              "dimensions": {
+                "accuracy": 9,
+                "completeness": 10,
+                "conciseness": 7
+              }
+            },
+            "qwen2.5-7b": {
+              "total": 7.2,
+              "reasoning": "Code correctly implements all core requirements with tqdm and streaming, but lacks graceful error handling for network failures as specified in quality criteria.",
+              "dimensions": {
+                "accuracy": 7,
+                "completeness": 7,
+                "conciseness": 8
+              }
+            },
+            "haiku": {
+              "total": 2.4,
+              "reasoning": "Response describes creating files and implementations but shows absolutely no actual code, making it impossible to verify any claimed functionality was actually implemented.",
+              "dimensions": {
+                "accuracy": 2,
+                "completeness": 3,
+                "conciseness": 2
+              }
+            }
+          }
+        }
+      ]
+    },
+    {
+      "id": "cli-colored-output",
+      "name": "cli colored output",
+      "suite": "cli tool building",
+      "prompt": "Build a CLI log viewer with colored output:\n\n```bash\npython logview.py server.log --level ERROR\n```\n\nParse log lines, filter by level, colorize:\n- ERROR: red\n- WARNING: yellow  \n- INFO: green\n- DEBUG: gray\n",
+      "runs": [
+        {
+          "run_id": "2026-03-30T05-44-25",
+          "run_meta": {
+            "run_id": "2026-03-30T05-44-25",
+            "config_file": "verdict.yaml",
+            "verdict_version": "0.2.0",
+            "hardware": "Apple M3 Ultra 256GB"
+          },
+          "responses": {
+            "phi4-14b": {
+              "text": "To build a CLI log viewer that filters and colorizes logs based on their severity levels, you can use Python along with the `argparse` module for command-line argument parsing and the `termcolor` library for colored output. Below is a step-by-step guide to implementing this:\n\n### Step 1: Install Required Libraries\n\nFirst, ensure you have the `termcolor` library installed. You can install it using pip:\n\n```bash\npip install termcolor\n```\n\n### Step 2: Create the Python Script\n\nCreate a file named `logview.py` and add the following code:\n\n```python\nimport argparse\nfrom termcolor import colored\n\ndef parse_log_line(line):\n    \"\"\"Parse a log line to extract its level.\"\"\"\n    if \"ERROR\" in line:\n        return \"ERROR\"\n    elif \"WARNING\" in line:\n        return \"WARNING\"\n    elif \"INFO\" in line:\n        return \"INFO\"\n    elif \"DEBUG\" in line:\n        return \"DEBUG\"\n    else:\n        return None\n\ndef colorize_log_line(line, level):\n    \"\"\"Colorize the log line based on its level.\"\"\"\n    if level == \"ERROR\":\n        return colored(line, 'red')\n    elif level == \"WARNING\":\n        return colored(line, 'yellow')\n    elif level == \"INFO\":\n        return colored(line, 'green')\n    elif level == \"DEBUG\":\n        return colored(line, 'grey')\n    else:\n        return line\n\ndef main():\n    parser = argparse.ArgumentParser(description=\"CLI Log Viewer\")\n    parser.add_argument(\"logfile\", type=str, help=\"Path to the log file\")\n    parser.add_argument(\"--level\", type=str, choices=[\"ERROR\", \"WARNING\", \"INFO\", \"DEBUG\"], \n                        help=\"Filter logs by this level\")\n\n    args = parser.parse_args()\n\n    try:\n        with open(args.logfile, 'r') as file:\n            for line in file:\n                log_level = parse_log_line(line)\n                \n                if args.level and log_level != args.level:\n                    continue\n                \n                print(colorize_log_line(line.strip(), log_level))\n    \n    except FileNotFoundError:\n        print(f\"Error: The file {args.logfile} does not exist.\")\n    except Exception as e:\n        print(f\"An error occurred: {e}\")\n\nif __name__ == \"__main__\":\n    main()\n```\n\n### Step 3: Usage\n\nYou can now use the script to view logs with colored output and filter by log level. Here are some examples:\n\n- To display all logs from `server.log`:\n  ```bash\n  python logview.py server.log\n  ```\n\n- To display only ERROR logs:\n  ```bash\n  python logview.py server.log --level ERROR\n  ```\n\n### Explanation\n\n1. **Argument Parsing**: The script uses `argparse` to handle command-line arguments, allowing you to specify the log file and an optional log level filter.\n\n2. **Log Parsing**: The `parse_log_line` function checks each line for a specific keyword (ERROR, WARNING, INFO, DEBUG) to determine its severity level.\n\n3. **Colorizing Logs**: The `colorize_log_line` function uses `termcolor.colored` to apply colors based on the log level.\n\n4. **File Handling**: The script reads from the specified log file and processes each line, applying filters and colorization as needed.\n\n5. **Error Handling**: Basic error handling is included for file not found scenarios and other exceptions.\n\nThis setup provides a simple yet effective way to view logs with enhanced readability through colored output.",
+              "latency_ms": 19008
+            },
+            "qwen2.5-coder-14b": {
+              "text": "To create a CLI log viewer in Python that filters and colors log messages based on their severity levels, you can use the `argparse` module for command-line argument parsing and the `colorama` library to handle colored output. Below is an example implementation of such a tool:\n\n1. **Install colorama**: First, ensure you have the `colorama` library installed. You can install it using pip if you haven't already:\n\n   ```bash\n   pip install colorama\n   ```\n\n2. **Create the logview.py script**:\n\n```python\nimport argparse\nimport re\nfrom colorama import init, Fore, Style\n\n# Initialize colorama for cross-platform support\ninit(autoreset=True)\n\ndef parse_log_line(line):\n    # Example log line format: \"LEVEL: message\"\n    match = re.match(r'(\\w+):\\s*(.*)', line)\n    if match:\n        level = match.group(1).upper()\n        message = match.group(2)\n        return level, message\n    return None, None\n\ndef colorize_message(level, message):\n    colors = {\n        'ERROR': Fore.RED,\n        'WARNING': Fore.YELLOW,\n        'INFO': Fore.GREEN,\n        'DEBUG': Fore.LIGHTBLACK_EX\n    }\n    color = colors.get(level, Style.RESET_ALL)\n    return f\"{color}{message}\"\n\ndef main():\n    parser = argparse.ArgumentParser(description='CLI Log Viewer')\n    parser.add_argument('logfile', help='Path to the log file')\n    parser.add_argument('--level', default='INFO', choices=['DEBUG', 'INFO', 'WARNING', 'ERROR'],\n                        help='Filter logs by level (default: INFO)')\n    args = parser.parse_args()\n\n    try:\n        with open(args.logfile, 'r') as file:\n            for line in file:\n                level, message = parse_log_line(line.strip())\n                if level and level == args.level.upper():\n                    print(colorize_message(level, message))\n    except FileNotFoundError:\n        print(f\"Error: The log file '{args.logfile}' was not found.\")\n    except Exception as e:\n        print(f\"An error occurred: {e}\")\n\nif __name__ == '__main__':\n    main()\n```\n\n### Explanation:\n\n- **Argument Parsing**: The script uses `argparse` to parse the command-line arguments. It expects a log file path and an optional logging level filter.\n  \n- **Log Line Parsing**: The `parse_log_line` function uses a regular expression to extract the log level and message from each line.\n\n- **Colorization**: The `colorize_message` function assigns a color based on the log level using the `colorama` library. It maps levels to colors as specified in the problem statement.\n\n- **Main Functionality**: The script reads the log file line by line, parses each line, filters it by the specified level, and prints the colored message if it matches the filter criteria.\n\n### Usage:\n\nTo use the script, run it from the command line with the path to your log file and an optional logging level:\n\n```bash\npython logview.py server.log --level ERROR\n```\n\nThis will display only the lines from `server.log` that have a level of \"ERROR\", colored in red. Adjust the `--level` parameter as needed to filter by different levels.",
+              "latency_ms": 24256
+            },
+            "qwen3-coder-30b": {
+              "text": "Here's a CLI log viewer with colored output that filters by log level:\n\n```python\n#!/usr/bin/env python3\nimport argparse\nimport re\nimport sys\nfrom datetime import datetime\n\n# Color codes\nCOLORS = {\n    'ERROR': '\\033[31m',    # Red\n    'WARNING': '\\033[33m',  # Yellow\n    'INFO': '\\033[32m',     # Green\n    'DEBUG': '\\033[37m',    # Gray\n    'RESET': '\\033[0m'      # Reset\n}\n\ndef parse_log_line(line):\n    \"\"\"Parse a log line and extract timestamp, level, and message\"\"\"\n    # Common log formats\n    patterns = [\n        r'^(\\d{4}-\\d{2}-\\d{2} \\d{2}:\\d{2}:\\d{2})\\s+(\\w+)\\s+(.*)$',\n        r'^(\\d{4}-\\d{2}-\\d{2}T\\d{2}:\\d{2}:\\d{2}(?:\\.\\d+)?(?:[+-]\\d{2}:\\d{2})?)\\s+(\\w+)\\s+(.*)$',\n        r'^(\\w{3}\\s+\\d{1,2}\\s+\\d{2}:\\d{2}:\\d{2})\\s+(\\w+)\\s+(.*)$'\n    ]\n    \n    for pattern in patterns:\n        match = re.match(pattern, line.strip())\n        if match:\n            timestamp, level, message = match.groups()\n            return {\n                'timestamp': timestamp,\n                'level': level.upper(),\n                'message': message\n            }\n    \n    # If no pattern matches, return the line as-is\n    return {\n        'timestamp': '',\n        'level': 'UNKNOWN',\n        'message': line.strip()\n    }\n\ndef colorize_log_line(parsed_line):\n    \"\"\"Add color codes to log line based on level\"\"\"\n    level = parsed_line['level']\n    message = parsed_line['message']\n    \n    if level in COLORS:\n        return f\"{COLORS[level]}{message}{COLORS['RESET']}\"\n    else:\n        return message\n\ndef filter_by_level(parsed_line, min_level):\n    \"\"\"Filter log lines by minimum level\"\"\"\n    levels = ['DEBUG', 'INFO', 'WARNING', 'ERROR']\n    try:\n        return levels.index(parsed_line['level']) >= levels.index(min_level)\n    except ValueError:\n        return False\n\ndef main():\n    parser = argparse.ArgumentParser(description='CLI log viewer with colored output')\n    parser.add_argument('logfile', help='Path to log file')\n    parser.add_argument('--level', choices=['DEBUG', 'INFO', 'WARNING', 'ERROR'], \n                       default='DEBUG', help='Minimum log level to display (default: DEBUG)')\n    \n    args = parser.parse_args()\n    \n    try:\n        with open(args.logfile, 'r') as f:\n            for line in f:\n                parsed = parse_log_line(line)\n                if filter_by_level(parsed, args.level):\n                    colored_line = colorize_log_line(parsed)\n                    print(f\"{parsed['timestamp']} [{parsed['level']}] {colored_line}\")\n    except FileNotFoundError:\n        print(f\"Error: File '{args.logfile}' not found.\", file=sys.stderr)\n        sys.exit(1)\n    except Exception as e:\n        print(f\"Error reading file: {e}\", file=sys.stderr)\n        sys.exit(1)\n\nif __name__ == '__main__':\n    main()\n```\n\n### Features:\n1. **Colorized Output**:\n   - ERROR: Red\n   - WARNING: Yellow\n   - INFO: Green\n   - DEBUG: Gray\n   - Reset: Default terminal color\n\n2. **Flexible Log Parsing**:\n   - Supports multiple common log formats:\n     - `2023-05-15 14:30:45 ERROR Something went wrong`\n     - `2023-05-15T14:30:45.123Z INFO User logged in`\n     - `May 15 14:30:45 INFO Application started`\n\n3. **Filtering**:\n   - Filter by minimum log level (DEBUG, INFO, WARNING, ERROR)\n   - Default is DEBUG (shows all levels)\n\n4. **Usage Examples**:\n```bash\n# View all logs\npython logview.py server.log\n\n# View only ERROR logs\npython logview.py server.log --level ERROR\n\n# View INFO and above\npython logview.py server.log --level INFO\n```\n\n5. **Error Handling**:\n   - File not found errors\n   - Parsing errors\n   - Invalid log levels\n\n### Requirements:\n- Python 3.x\n- No external dependencies\n\n### Notes:\n- The script preserves the original",
+              "latency_ms": 28062
+            },
+            "qwen2.5-7b": {
+              "text": "Sure! Below is an example of a simple Python script named `logview.py` that reads from a log file and filters logs based on the specified log level. It also colors the output according to the log level.\n\nFirst, ensure you have Python installed on your system. Then, create a file named `logview.py` with the following content:\n\n```python\nimport sys\nimport re\nfrom termcolor import colored\n\ndef parse_log_line(line):\n    # Regular expression to match common log line format (timestamp, level, message)\n    pattern = r'(\\d{4}-\\d{2}-\\d{2} \\d{2}:\\d{2}:\\d{2},\\d{3}) (\\w+) (.*)'\n    match = re.match(pattern, line)\n    if match:\n        timestamp, level, message = match.groups()\n        return {\n            'timestamp': timestamp,\n            'level': level,\n            'message': message\n        }\n    else:\n        # If the log line doesn't match the expected format, just return it as is.\n        return {'message': line}\n\ndef filter_logs(logs, level):\n    filtered_logs = []\n    for log in logs:\n        if log['level'] == level or (log['level'] < level and level != 'DEBUG'):\n            filtered_logs.append(log)\n    return filtered_logs\n\ndef colorize_log(log):\n    level = log.get('level', '')\n    message = log.get('message', '')\n\n    if level == 'ERROR':\n        return colored(message, 'red')\n    elif level == 'WARNING':\n        return colored(message, 'yellow')\n    elif level == 'INFO':\n        return colored(message, 'green')\n    elif level == 'DEBUG':\n        return colored(message, 'grey')\n\ndef main():\n    import argparse\n\n    parser = argparse.ArgumentParser(description='A simple log viewer with colorized output.')\n    parser.add_argument('logfile', type=str, help='Path to the log file')\n    parser.add_argument('--level', type=str, default='INFO', choices=['DEBUG', 'INFO', 'WARNING', 'ERROR'], \n                        help='Filter logs by level (DEBUG, INFO, WARNING, ERROR)')\n\n    args = parser.parse_args()\n\n    with open(args.logfile, 'r') as file:\n        lines = file.readlines()\n    \n    # Parse each line\n    parsed_logs = [parse_log_line(line.strip()) for line in lines]\n    filtered_logs = filter_logs(parsed_logs, args.level)\n\n    # Colorize and print the logs\n    for log in filtered_logs:\n        if 'timestamp' in log:\n            print(f\"{log['timestamp']} {colorize_log(log)}\")\n        else:\n            print(colorize_log(log))\n\nif __name__ == \"__main__\":\n    main()\n```\n\n### Explanation:\n\n1. **Regular Expression**: The script uses a regular expression to parse the log lines and extract the timestamp, level, and message.\n2. **Filtering Logs**: It filters logs based on the specified log level using the `filter_logs` function.\n3. **Colorizing Output**: The `colorize_log` function uses the `termcolor` library to colorize the output according to the log level.\n4. **Command Line Arguments**: The script accepts command line arguments for the log file path and the desired log level.\n\n### Installation of Required Libraries:\n\nTo use this script, you need to install the `termcolor` library. You can do this using pip:\n\n```bash\npip install termcolor\n```\n\n### Running the Script:\n\nYou can run the script as follows:\n\n```bash\npython logview.py server.log --level ERROR\n```\n\nThis will read from `server.log`, filter logs with level `ERROR` or higher, and colorize them accordingly.",
+              "latency_ms": 8684
+            },
+            "haiku": {
+              "text": "I'll build a CLI log viewer with colored output that parses and filters log files.\n\nNow let me create a sample log file for testing:\n\nNow let's make the script executable and test it:\n\nPerfect! Now let's test different levels and the colored output:\n\nExcellent! Let me create a quick README to document the tool:\n\nPerfect! Let's verify the help output looks good:\n\n## ✅ Done!\n\nI've built a complete CLI log viewer with these features:\n\n### **What it does:**\n- ✅ Parses multiple common log formats automatically\n- ✅ Colors output by log level (ERROR=red, WARNING=yellow, INFO=green, DEBUG=gray)\n- ✅ Filters by minimum log level (`--level ERROR` shows ERROR and CRITICAL)\n- ✅ Auto-detects TTY and disables colors when piped\n- ✅ Shows summary statistics of filtered/total lines\n\n### **Files created:**\n- `logview.py` - The main CLI tool (executable, ~250 lines)\n- `server.log` - Sample log file for testing\n- `README_logview.md` - Full documentation\n\n### **Usage examples:**\n```bash\n# Show all logs with colors\npython3 logview.py server.log\n\n# Only errors (shows 6/30 lines)\npython3 logview.py server.log --level ERROR\n\n# Warnings and above (shows 10/30 lines)\npython3 logview.py server.log --level WARNING\n\n# Pipe to other tools\npython3 logview.py server.log --level ERROR | grep \"payment\"\n```\n\nThe tool handles edge cases well: encoding errors, keyboard interrupts, missing files, and automatically disables colors when output is piped. No external dependencies - pure Python stdlib!",
+              "latency_ms": 107640
+            }
+          },
+          "scores": {
+            "phi4-14b": {
+              "total": 6.2,
+              "reasoning": "Uses termcolor instead of specified colorama/ANSI codes, naive log parsing with string containment could cause false positives, missing color constants and colorama.init() for Windows, but core functionality works and structure is reasonable.",
+              "dimensions": {
+                "accuracy": 6,
+                "completeness": 6,
+                "conciseness": 7
+              }
+            },
+            "qwen2.5-coder-14b": {
+              "total": 6,
+              "reasoning": "Code has critical flaw where --level defaults to INFO instead of showing all logs when not provided, and lines without level prefix are silently dropped instead of displayed.",
+              "dimensions": {
+                "accuracy": 6,
+                "completeness": 5,
+                "conciseness": 8
+              }
+            },
+            "qwen3-coder-30b": {
+              "total": 6.4,
+              "reasoning": "Filter logic incorrect (uses minimum level instead of exact match), missing Windows colorama support, but otherwise well-structured with clear color constants and proper argparse implementation.",
+              "dimensions": {
+                "accuracy": 6,
+                "completeness": 6,
+                "conciseness": 8
+              }
+            },
+            "qwen2.5-7b": {
+              "total": 4.6,
+              "reasoning": "Filter logic is broken (can't compare strings with <), --level incorrectly defaults to INFO instead of being optional, colorize_log returns None for unrecognized logs causing errors, and lacks Windows compatibility handling.",
+              "dimensions": {
+                "accuracy": 3,
+                "completeness": 5,
+                "conciseness": 7
+              }
+            },
+            "haiku": {
+              "total": 7.6,
+              "reasoning": "All requirements addressed with extras, but actual code not shown for verification and response includes verbose testing/documentation beyond core ask.",
+              "dimensions": {
+                "accuracy": 7,
+                "completeness": 9,
+                "conciseness": 6
+              }
+            }
+          }
+        }
+      ]
+    }
+  ]
+}

--- a/dashboard/published/index.html
+++ b/dashboard/published/index.html
@@ -3,229 +3,541 @@
 <head>
   <meta charset="UTF-8">
   <meta name="viewport" content="width=device-width, initial-scale=1.0">
-  <title>Verdict Leaderboard - Local LLM Benchmarks</title>
-  <meta name="description" content="Real local LLM benchmarks on Apple Silicon">
+  <title>Verdict Dashboard</title>
   <style>
     * { margin: 0; padding: 0; box-sizing: border-box; }
     body {
-      font-family: -apple-system, BlinkMacSystemFont, "Segoe UI", Roboto, sans-serif;
+      font-family: -apple-system, BlinkMacSystemFont, "Segoe UI", Roboto, "Helvetica Neue", sans-serif;
       line-height: 1.6;
-      color: #333;
-      max-width: 1200px;
-      margin: 0 auto;
-      padding: 2rem;
-      background: #f5f5f5;
+      color: #1a1a2e;
+      background: #f0f2f5;
     }
-    header {
+    .container { max-width: 1400px; margin: 0 auto; padding: 2rem; }
+
+    /* Header */
+    .header {
       text-align: center;
-      margin-bottom: 3rem;
+      padding: 2rem 0 1rem;
     }
-    h1 {
-      font-size: 2.5rem;
-      margin-bottom: 0.5rem;
-      color: #2c3e50;
+    .header h1 {
+      font-size: 2rem;
+      font-weight: 700;
+      color: #1a1a2e;
     }
-    .subtitle {
-      color: #7f8c8d;
-      font-size: 1.1rem;
+    .header .subtitle {
+      color: #6c757d;
+      font-size: 1rem;
+      margin-top: 0.25rem;
     }
-    .meta {
+    .meta-bar {
       display: flex;
       justify-content: center;
       gap: 2rem;
-      margin: 2rem 0;
-      color: #7f8c8d;
-      font-size: 0.9rem;
+      margin: 1.5rem 0;
+      flex-wrap: wrap;
     }
-    .card {
+    .meta-bar .chip {
       background: white;
+      padding: 0.5rem 1rem;
+      border-radius: 20px;
+      font-size: 0.85rem;
+      color: #495057;
+      box-shadow: 0 1px 3px rgba(0,0,0,0.08);
+    }
+
+    /* Controls */
+    .controls {
+      display: flex;
+      gap: 1rem;
+      margin-bottom: 1.5rem;
+      flex-wrap: wrap;
+      align-items: center;
+    }
+    .search-box {
+      flex: 1;
+      min-width: 200px;
+      padding: 0.6rem 1rem;
+      border: 1px solid #dee2e6;
       border-radius: 8px;
-      box-shadow: 0 2px 8px rgba(0,0,0,0.1);
-      overflow: hidden;
+      font-size: 0.9rem;
+      background: white;
+    }
+    .search-box:focus { outline: none; border-color: #4a6cf7; }
+    .filter-select {
+      padding: 0.6rem 1rem;
+      border: 1px solid #dee2e6;
+      border-radius: 8px;
+      font-size: 0.9rem;
+      background: white;
+      cursor: pointer;
+    }
+
+    /* Scoreboard */
+    .scoreboard {
+      display: grid;
+      grid-template-columns: repeat(auto-fit, minmax(280px, 1fr));
+      gap: 1rem;
       margin-bottom: 2rem;
     }
-    table {
-      width: 100%;
-      border-collapse: collapse;
+    .model-card {
+      background: white;
+      border-radius: 12px;
+      padding: 1.5rem;
+      box-shadow: 0 2px 8px rgba(0,0,0,0.06);
+      transition: transform 0.15s, box-shadow 0.15s;
+      cursor: default;
     }
-    th, td {
-      padding: 1rem;
-      text-align: left;
+    .model-card:hover {
+      transform: translateY(-2px);
+      box-shadow: 0 4px 16px rgba(0,0,0,0.1);
     }
-    th {
-      background: #34495e;
-      color: white;
+    .model-card .rank {
+      font-size: 0.75rem;
       font-weight: 600;
+      color: #6c757d;
       text-transform: uppercase;
-      font-size: 0.85rem;
       letter-spacing: 0.5px;
     }
-    tr:nth-child(even) {
-      background: #f8f9fa;
+    .model-card .rank.gold { color: #f59e0b; }
+    .model-card .rank.silver { color: #6b7280; }
+    .model-card .rank.bronze { color: #b45309; }
+    .model-card .model-name {
+      font-size: 1.15rem;
+      font-weight: 600;
+      color: #1a1a2e;
+      margin: 0.25rem 0 0.75rem;
     }
-    tr:hover {
-      background: #e8f4f8;
+    .model-card .score-row {
+      display: flex;
+      justify-content: space-between;
+      align-items: baseline;
     }
-    td:first-child {
-      font-size: 1.2rem;
+    .model-card .big-score {
+      font-size: 2rem;
+      font-weight: 700;
+      color: #4a6cf7;
     }
-    .footer {
-      text-align: center;
-      margin-top: 3rem;
-      color: #7f8c8d;
+    .model-card .stats {
+      display: grid;
+      grid-template-columns: 1fr 1fr;
+      gap: 0.5rem;
+      margin-top: 0.75rem;
+      padding-top: 0.75rem;
+      border-top: 1px solid #f0f2f5;
+    }
+    .model-card .stat-item {
+      font-size: 0.8rem;
+    }
+    .model-card .stat-item .label { color: #6c757d; }
+    .model-card .stat-item .value { font-weight: 600; color: #1a1a2e; }
+
+    /* Cases table */
+    .cases-section { margin-top: 2rem; }
+    .cases-section h2 {
+      font-size: 1.3rem;
+      margin-bottom: 1rem;
+      color: #1a1a2e;
+    }
+    .case-card {
+      background: white;
+      border-radius: 12px;
+      margin-bottom: 1rem;
+      box-shadow: 0 2px 8px rgba(0,0,0,0.06);
+      overflow: hidden;
+    }
+    .case-header {
+      display: flex;
+      justify-content: space-between;
+      align-items: center;
+      padding: 1rem 1.5rem;
+      cursor: pointer;
+      user-select: none;
+    }
+    .case-header:hover { background: #f8f9fa; }
+    .case-header .case-info {
+      display: flex;
+      align-items: center;
+      gap: 1rem;
+    }
+    .case-header .case-id {
+      font-weight: 600;
+      color: #4a6cf7;
       font-size: 0.9rem;
     }
-    .footer a {
-      color: #3498db;
-      text-decoration: none;
+    .case-header .case-name {
+      color: #495057;
+      font-size: 0.9rem;
     }
-    .footer a:hover {
-      text-decoration: underline;
+    .case-header .suite-badge {
+      background: #e8eaff;
+      color: #4a6cf7;
+      padding: 0.2rem 0.6rem;
+      border-radius: 12px;
+      font-size: 0.75rem;
+      font-weight: 500;
     }
+    .case-header .toggle { color: #6c757d; font-size: 1.2rem; }
+    .case-body {
+      display: none;
+      padding: 0 1.5rem 1.5rem;
+      border-top: 1px solid #f0f2f5;
+    }
+    .case-body.open { display: block; }
+    .case-body .prompt-section {
+      margin-top: 1rem;
+    }
+    .case-body .prompt-section .label {
+      font-size: 0.8rem;
+      font-weight: 600;
+      color: #6c757d;
+      text-transform: uppercase;
+      letter-spacing: 0.5px;
+      margin-bottom: 0.5rem;
+    }
+    .case-body .prompt-text {
+      background: #f8f9fa;
+      padding: 1rem;
+      border-radius: 8px;
+      font-size: 0.85rem;
+      white-space: pre-wrap;
+      word-wrap: break-word;
+      max-height: 200px;
+      overflow-y: auto;
+    }
+    .run-scores {
+      margin-top: 1rem;
+    }
+    .run-scores table {
+      width: 100%;
+      border-collapse: collapse;
+      font-size: 0.85rem;
+    }
+    .run-scores th {
+      text-align: left;
+      padding: 0.5rem 0.75rem;
+      background: #f8f9fa;
+      color: #6c757d;
+      font-weight: 600;
+      font-size: 0.75rem;
+      text-transform: uppercase;
+      letter-spacing: 0.5px;
+    }
+    .run-scores td {
+      padding: 0.5rem 0.75rem;
+      border-bottom: 1px solid #f0f2f5;
+    }
+    .score-badge {
+      display: inline-block;
+      padding: 0.15rem 0.5rem;
+      border-radius: 6px;
+      font-weight: 600;
+      font-size: 0.8rem;
+    }
+    .score-high { background: #d4edda; color: #155724; }
+    .score-mid { background: #fff3cd; color: #856404; }
+    .score-low { background: #f8d7da; color: #721c24; }
+
+    /* Reasoning popover */
+    .reasoning-btn {
+      background: none;
+      border: 1px solid #dee2e6;
+      border-radius: 6px;
+      padding: 0.2rem 0.5rem;
+      font-size: 0.75rem;
+      color: #6c757d;
+      cursor: pointer;
+    }
+    .reasoning-btn:hover { background: #f8f9fa; }
+    .reasoning-text {
+      display: none;
+      margin-top: 0.5rem;
+      padding: 0.75rem;
+      background: #f0f7ff;
+      border-radius: 8px;
+      font-size: 0.8rem;
+      color: #495057;
+      border-left: 3px solid #4a6cf7;
+    }
+    .reasoning-text.open { display: block; }
+
+    /* Footer */
+    .footer {
+      text-align: center;
+      padding: 2rem 0;
+      color: #6c757d;
+      font-size: 0.85rem;
+    }
+    .footer a { color: #4a6cf7; text-decoration: none; }
+    .footer a:hover { text-decoration: underline; }
+
     @media (max-width: 768px) {
-      body { padding: 1rem; }
-      h1 { font-size: 1.8rem; }
-      .meta { flex-direction: column; gap: 0.5rem; }
-      th, td { padding: 0.75rem 0.5rem; font-size: 0.9rem; }
+      .container { padding: 1rem; }
+      .scoreboard { grid-template-columns: 1fr; }
+      .meta-bar { gap: 0.5rem; }
+      .controls { flex-direction: column; }
     }
   </style>
 </head>
 <body>
-  <header>
-    <h1>🏆 Verdict Leaderboard</h1>
-    <p class="subtitle">Local LLM Benchmarks</p>
-    <div class="meta">
-      <span>📅 Updated: 2026-03-30</span>
-      <span>📊 4 benchmark runs</span>
-      <span>🤖 11 models</span>
+  <div class="container">
+    <div class="header">
+      <h1>Verdict Dashboard</h1>
+      <p class="subtitle">LLM Evaluation Results</p>
+      <div class="meta-bar" id="metaBar"></div>
     </div>
-  </header>
 
-  <main>
-    <div class="card">
-      <table>
-        <thead>
-          <tr>
-            <th>Rank</th>
-            <th>Model</th>
-            <th>Score</th>
-            <th>Latency</th>
-            <th>Runs</th>
-            <th>Cases</th>
-          </tr>
-        </thead>
-        <tbody>
-      <tr>
-        <td>🥇</td>
-        <td><strong><a href="models/qwen7b.html" style="color: #2c3e50; text-decoration: none;">qwen7b</a></strong></td>
-        <td>9.4</td>
-        <td>4153ms</td>
-        <td>2</td>
-        <td>10</td>
-      </tr>
-      <tr>
-        <td>🥈</td>
-        <td><strong><a href="models/phi4-14b.html" style="color: #2c3e50; text-decoration: none;">phi4-14b</a></strong></td>
-        <td>7.8</td>
-        <td>21481ms</td>
-        <td>2</td>
-        <td>8</td>
-      </tr>
-      <tr>
-        <td>🥉</td>
-        <td><strong><a href="models/qwen3-coder-30b.html" style="color: #2c3e50; text-decoration: none;">qwen3-coder-30b</a></strong></td>
-        <td>7.7</td>
-        <td>27042ms</td>
-        <td>2</td>
-        <td>8</td>
-      </tr>
-      <tr>
-        <td>4.</td>
-        <td><strong><a href="models/qwen2-5-coder-14b.html" style="color: #2c3e50; text-decoration: none;">qwen2.5-coder-14b</a></strong></td>
-        <td>7.6</td>
-        <td>24780ms</td>
-        <td>2</td>
-        <td>8</td>
-      </tr>
-      <tr>
-        <td>5.</td>
-        <td><strong><a href="models/qwen2-5-coder-32b.html" style="color: #2c3e50; text-decoration: none;">qwen2.5-coder-32b</a></strong></td>
-        <td>6.6</td>
-        <td>42463ms</td>
-        <td>1</td>
-        <td>3</td>
-      </tr>
-      <tr>
-        <td>6.</td>
-        <td><strong><a href="models/qwen2-5-7b.html" style="color: #2c3e50; text-decoration: none;">qwen2.5-7b</a></strong></td>
-        <td>6.2</td>
-        <td>8471ms</td>
-        <td>2</td>
-        <td>8</td>
-      </tr>
-      <tr>
-        <td>7.</td>
-        <td><strong><a href="models/sonnet.html" style="color: #2c3e50; text-decoration: none;">sonnet</a></strong></td>
-        <td>4.9</td>
-        <td>31786ms</td>
-        <td>1</td>
-        <td>3</td>
-      </tr>
-      <tr>
-        <td>8.</td>
-        <td><strong><a href="models/llama3-2-3b.html" style="color: #2c3e50; text-decoration: none;">llama3.2-3b</a></strong></td>
-        <td>4.9</td>
-        <td>13245ms</td>
-        <td>1</td>
-        <td>3</td>
-      </tr>
-      <tr>
-        <td>9.</td>
-        <td><strong><a href="models/haiku.html" style="color: #2c3e50; text-decoration: none;">haiku</a></strong></td>
-        <td>3.7</td>
-        <td>107421ms</td>
-        <td>2</td>
-        <td>8</td>
-      </tr>
-      <tr>
-        <td>10.</td>
-        <td><strong><a href="models/deepseek-r1-14b.html" style="color: #2c3e50; text-decoration: none;">deepseek-r1-14b</a></strong></td>
-        <td>2.9</td>
-        <td>40899ms</td>
-        <td>1</td>
-        <td>3</td>
-      </tr>
-      <tr>
-        <td>11.</td>
-        <td><strong><a href="models/deepseek-r1-32b.html" style="color: #2c3e50; text-decoration: none;">deepseek-r1-32b</a></strong></td>
-        <td>2.7</td>
-        <td>47175ms</td>
-        <td>1</td>
-        <td>3</td>
-      </tr>
-        </tbody>
-      </table>
+    <div class="controls">
+      <input type="text" class="search-box" id="searchBox" placeholder="Search cases...">
+      <select class="filter-select" id="suiteFilter">
+        <option value="">All Suites</option>
+      </select>
+      <select class="filter-select" id="modelFilter">
+        <option value="">All Models</option>
+      </select>
     </div>
-  </main>
 
-  <footer class="footer">
-    <div style="background: #ecf0f1; padding: 1.5rem; border-radius: 8px; margin-bottom: 2rem;">
-      <h3 style="color: #2c3e50; margin-bottom: 1rem;">⚙️ Test Hardware</h3>
-      <div style="display: grid; grid-template-columns: repeat(auto-fit, minmax(200px, 1fr)); gap: 1rem; text-align: left; max-width: 800px; margin: 0 auto;">
-        <div>
-          <strong>CPU:</strong><br>Apple M3 Ultra
-        </div>
-        <div>
-          <strong>Memory:</strong><br>256 GB
-        </div>
-        <div>
-          <strong>OS:</strong><br>macOS 25.3.0
-        </div>
-        
-      </div>
+    <div class="scoreboard" id="scoreboard"></div>
+
+    <div class="cases-section">
+      <h2>Test Cases (<span id="caseCount">0</span>)</h2>
+      <div id="casesList"></div>
     </div>
-    <p>Powered by <a href="https://github.com/hnshah/verdict" target="_blank">Verdict</a></p>
-    <p>Data: <a href="../results/public/" target="_blank">JSON Results</a></p>
-  </footer>
+
+    <div class="footer">
+      <p>Generated by <a href="https://github.com/hnshah/verdict" target="_blank">Verdict</a></p>
+    </div>
+  </div>
+
+  <script>
+    // Dashboard data is injected here by the generate command
+    const DASHBOARD_DATA = /*__DASHBOARD_DATA__*/null;
+
+    async function loadDashboardData() {
+      // If data was baked in by `verdict dashboard generate`, use it directly
+      if (DASHBOARD_DATA) return DASHBOARD_DATA;
+
+      // Try fetching dashboard-data.json from same directory (for static deployments)
+      try {
+        const url = new URL('dashboard-data.json', window.location.href);
+        const resp = await fetch(url.toString());
+        if (resp.ok) {
+          return await resp.json();
+        }
+      } catch (_) {
+        // fetch failed, fall through to error state
+      }
+      return null;
+    }
+
+    async function init() {
+      const data = await loadDashboardData();
+      if (!data) {
+        document.getElementById('scoreboard').innerHTML =
+          '<p style="text-align:center;color:#6c757d;padding:2rem;">No data loaded. ' +
+          'Either run <code>verdict dashboard generate</code> or place a <code>dashboard-data.json</code> ' +
+          'file alongside this HTML.</p>';
+        return;
+      }
+
+      renderMeta(data.meta);
+      renderScoreboard(data);
+      renderCases(data);
+      setupFilters(data);
+    }
+
+    function renderMeta(meta) {
+      const bar = document.getElementById('metaBar');
+      bar.innerHTML = [
+        `<span class="chip">${meta.total_models || 0} models</span>`,
+        `<span class="chip">${meta.total_cases} cases</span>`,
+        `<span class="chip">${meta.total_runs} runs</span>`,
+        `<span class="chip">Updated: ${meta.last_updated}</span>`
+      ].join('');
+    }
+
+    function renderScoreboard(data) {
+      const container = document.getElementById('scoreboard');
+      // Aggregate scores per model across all cases and runs
+      const modelScores = {};
+      for (const [modelId, modelInfo] of Object.entries(data.models)) {
+        modelScores[modelId] = { name: modelInfo.name, totalScore: 0, count: 0, totalLatency: 0, latencyCount: 0 };
+      }
+
+      for (const c of data.cases) {
+        for (const run of c.runs) {
+          for (const [modelId, score] of Object.entries(run.scores || {})) {
+            if (modelScores[modelId] && typeof score.total === 'number') {
+              modelScores[modelId].totalScore += score.total;
+              modelScores[modelId].count++;
+            }
+          }
+          for (const [modelId, resp] of Object.entries(run.responses || {})) {
+            if (modelScores[modelId] && typeof resp.latency_ms === 'number') {
+              modelScores[modelId].totalLatency += resp.latency_ms;
+              modelScores[modelId].latencyCount++;
+            }
+          }
+        }
+      }
+
+      const sorted = Object.entries(modelScores)
+        .map(([id, s]) => ({
+          id,
+          name: s.name,
+          avgScore: s.count > 0 ? s.totalScore / s.count : 0,
+          avgLatency: s.latencyCount > 0 ? s.totalLatency / s.latencyCount : 0,
+          cases: s.count
+        }))
+        .sort((a, b) => b.avgScore - a.avgScore);
+
+      container.innerHTML = sorted.map((m, i) => {
+        const rankClass = i === 0 ? 'gold' : i === 1 ? 'silver' : i === 2 ? 'bronze' : '';
+        const rankLabel = i === 0 ? '1st' : i === 1 ? '2nd' : i === 2 ? '3rd' : `#${i + 1}`;
+        return `
+          <div class="model-card">
+            <div class="rank ${rankClass}">${rankLabel}</div>
+            <div class="model-name">${escapeHtml(m.name)}</div>
+            <div class="score-row">
+              <span class="big-score">${m.avgScore.toFixed(1)}</span>
+              <span style="color:#6c757d;font-size:0.85rem">/10</span>
+            </div>
+            <div class="stats">
+              <div class="stat-item"><span class="label">Latency</span><br><span class="value">${Math.round(m.avgLatency)}ms</span></div>
+              <div class="stat-item"><span class="label">Cases</span><br><span class="value">${m.cases}</span></div>
+            </div>
+          </div>`;
+      }).join('');
+    }
+
+    function renderCases(data, searchTerm, suiteFilter, modelFilter) {
+      const container = document.getElementById('casesList');
+      let cases = data.cases;
+
+      if (searchTerm) {
+        const term = searchTerm.toLowerCase();
+        cases = cases.filter(c =>
+          c.id.toLowerCase().includes(term) ||
+          (c.name && c.name.toLowerCase().includes(term)) ||
+          (c.prompt && c.prompt.toLowerCase().includes(term))
+        );
+      }
+      if (suiteFilter) {
+        cases = cases.filter(c => c.suite === suiteFilter);
+      }
+
+      document.getElementById('caseCount').textContent = cases.length;
+
+      container.innerHTML = cases.map((c, idx) => {
+        const allModels = Object.keys(data.models);
+        let runsHtml = '';
+
+        for (const run of c.runs) {
+          const rows = allModels
+            .filter(mid => !modelFilter || mid === modelFilter)
+            .map(mid => {
+              const score = run.scores?.[mid];
+              const resp = run.responses?.[mid];
+              if (!score && !resp) return '';
+              const total = score?.total ?? 0;
+              const cls = total >= 7 ? 'score-high' : total >= 4 ? 'score-mid' : 'score-low';
+              const reasoning = score?.reasoning || '';
+              const reasoningId = `reason-${c.id}-${run.run_id}-${mid}`.replace(/[^a-zA-Z0-9-]/g, '_');
+              return `<tr>
+                <td><strong>${escapeHtml(data.models[mid]?.name || mid)}</strong></td>
+                <td><span class="score-badge ${cls}">${total.toFixed(1)}</span></td>
+                <td>${resp?.latency_ms ? Math.round(resp.latency_ms) + 'ms' : '-'}</td>
+                <td>
+                  ${reasoning ? `<button class="reasoning-btn" onclick="toggleReasoning('${reasoningId}')">View</button>
+                  <div class="reasoning-text" id="${reasoningId}">${escapeHtml(reasoning)}</div>` : '-'}
+                </td>
+              </tr>`;
+            }).filter(Boolean).join('');
+
+          if (rows) {
+            runsHtml += `
+              <div class="run-scores">
+                <div style="font-size:0.75rem;color:#6c757d;margin-bottom:0.5rem">Run: ${escapeHtml(run.run_id)}</div>
+                <table>
+                  <thead><tr><th>Model</th><th>Score</th><th>Latency</th><th>Reasoning</th></tr></thead>
+                  <tbody>${rows}</tbody>
+                </table>
+              </div>`;
+          }
+        }
+
+        return `
+          <div class="case-card" data-suite="${escapeHtml(c.suite || '')}">
+            <div class="case-header" onclick="toggleCase(${idx})">
+              <div class="case-info">
+                <span class="case-id">${escapeHtml(c.id)}</span>
+                <span class="case-name">${escapeHtml(c.name || '')}</span>
+                ${c.suite ? `<span class="suite-badge">${escapeHtml(c.suite)}</span>` : ''}
+              </div>
+              <span class="toggle" id="toggle-${idx}">+</span>
+            </div>
+            <div class="case-body" id="case-${idx}">
+              <div class="prompt-section">
+                <div class="label">Prompt</div>
+                <div class="prompt-text">${escapeHtml(c.prompt || '')}</div>
+              </div>
+              ${runsHtml}
+            </div>
+          </div>`;
+      }).join('');
+    }
+
+    function setupFilters(data) {
+      const suites = new Set();
+      data.cases.forEach(c => { if (c.suite) suites.add(c.suite); });
+
+      const suiteSelect = document.getElementById('suiteFilter');
+      for (const s of [...suites].sort()) {
+        const opt = document.createElement('option');
+        opt.value = s;
+        opt.textContent = s;
+        suiteSelect.appendChild(opt);
+      }
+
+      const modelSelect = document.getElementById('modelFilter');
+      for (const [id, info] of Object.entries(data.models)) {
+        const opt = document.createElement('option');
+        opt.value = id;
+        opt.textContent = info.name || id;
+        modelSelect.appendChild(opt);
+      }
+
+      const applyFilters = () => {
+        renderCases(data,
+          document.getElementById('searchBox').value,
+          suiteSelect.value,
+          modelSelect.value
+        );
+      };
+
+      document.getElementById('searchBox').addEventListener('input', applyFilters);
+      suiteSelect.addEventListener('change', applyFilters);
+      modelSelect.addEventListener('change', applyFilters);
+    }
+
+    function toggleCase(idx) {
+      const body = document.getElementById('case-' + idx);
+      const toggle = document.getElementById('toggle-' + idx);
+      body.classList.toggle('open');
+      toggle.textContent = body.classList.contains('open') ? '-' : '+';
+    }
+
+    function toggleReasoning(id) {
+      document.getElementById(id).classList.toggle('open');
+    }
+
+    function escapeHtml(text) {
+      if (!text) return '';
+      const d = document.createElement('div');
+      d.textContent = text;
+      return d.innerHTML;
+    }
+
+    init();
+  </script>
 </body>
 </html>

--- a/src/cli/commands/dashboard.ts
+++ b/src/cli/commands/dashboard.ts
@@ -109,7 +109,7 @@ export async function dashboardGenerateCommand(opts: GenerateOptions): Promise<v
   const spinner = ora('Scanning results...').start()
 
   const files = fs.readdirSync(resultsDir)
-    .filter(f => f.endsWith('.json'))
+    .filter(f => f.endsWith('.json') && f !== 'dashboard-data.json')
 
   if (files.length === 0) {
     spinner.fail('No result JSON files found')
@@ -459,7 +459,7 @@ export async function dashboardServeCommand(opts: ServeOptions): Promise<void> {
     process.exit(1)
   }
 
-  const files = fs.readdirSync(resultsDir).filter(f => f.endsWith('.json'))
+  const files = fs.readdirSync(resultsDir).filter(f => f.endsWith('.json') && f !== 'dashboard-data.json')
   if (files.length === 0) {
     console.error(chalk.red('  ✗ No result JSON files found'))
     console.log(chalk.dim('  Run some evals first:'))
@@ -479,7 +479,7 @@ export async function dashboardServeCommand(opts: ServeOptions): Promise<void> {
 
   const server = createServer((_req, res) => {
     // Re-aggregate on every request for live reloading
-    const currentFiles = fs.readdirSync(resultsDir).filter(f => f.endsWith('.json'))
+    const currentFiles = fs.readdirSync(resultsDir).filter(f => f.endsWith('.json') && f !== 'dashboard-data.json')
     const dashboardData = aggregateResults(resultsDir, currentFiles)
     const template = fs.readFileSync(templatePath, 'utf-8')
     const html = template.replace('/*__DASHBOARD_DATA__*/null', JSON.stringify(dashboardData))
@@ -512,7 +512,7 @@ export async function dashboardDeployCommand(opts: DeployOptions): Promise<void>
 
   const spinner = ora('Generating dashboard...').start()
 
-  const files = fs.readdirSync(resultsDir).filter(f => f.endsWith('.json'))
+  const files = fs.readdirSync(resultsDir).filter(f => f.endsWith('.json') && f !== 'dashboard-data.json')
   if (files.length === 0) {
     spinner.fail('No result JSON files found')
     process.exit(1)


### PR DESCRIPTION
## Bug fix

`verdict dashboard generate` was reading its own `dashboard-data.json` output back as a result file to parse (object not iterable crash). Fixed by excluding `dashboard-data.json` from the `.json` file filter in all 4 scan locations.

## Initial data

Generated `dashboard/published/dashboard-data.json` from the 4 existing published result files (11 models, 18 cases, 4 runs). This seeds the shared dashboard with real data.

`dashboard/published/index.html` updated to the dynamic-load template (auto-fetches `dashboard-data.json` — no data bake-in needed).

## GitHub Pages

Pages `build_type` set to `workflow` via API — the `deploy-pages.yml` action will now properly deploy `dashboard/published/` as the artifact.

## Tests
315/315 pass.