### PR TITLE
fix(scorer): scoreJson parse failure returns 0/10 not 2/10

### DIFF
--- a/src/judge/__tests__/deterministic.test.ts
+++ b/src/judge/__tests__/deterministic.test.ts
@@ -29,9 +29,11 @@ describe('deterministic scorers', () => {
       expect(result.total).toBe(10)
     })
 
-    it('gives partial credit for malformed JSON-like output', () => {
+    it('gives 0/10 for malformed JSON-like output (no partial credit)', () => {
       const result = scoreJson('{key: value}')
-      expect(result.total).toBe(2)
+      expect(result.total).toBe(0)
+      expect(result.reasoning).toContain('JSON-like structure found but failed to parse')
+      expect(result.reasoning).toContain('{key: value}')
     })
 
     it('scores non-JSON as 0/10', () => {

--- a/src/judge/deterministic.ts
+++ b/src/judge/deterministic.ts
@@ -56,8 +56,8 @@ export function scoreJson(output: string): JudgeScore {
     }
   } catch (err) {
     return {
-      accuracy: 2, completeness: 2, conciseness: 2, total: 2,
-      reasoning: `JSON structure found but parse failed: ${err instanceof Error ? err.message : err}`,
+      accuracy: 0, completeness: 0, conciseness: 0, total: 0,
+      reasoning: `JSON-like structure found but failed to parse: ${err instanceof Error ? err.message : err}. Got: "${extracted.slice(0, 80)}"`,
     }
   }
 }


### PR DESCRIPTION
Fixes #88

## What Changed

### src/judge/deterministic.ts
- Changed catch block in scoreJson() to return 0/10 instead of 2/10
- Improved error message includes snippet of extracted content

### src/judge/__tests__/deterministic.test.ts
- Updated test expecting 0/10 for malformed JSON-like output
- Added reasoning message assertions

## Test Results
60/60 tests pass