### PR TITLE
feat(judge): add confidence/uncertainty score to judge output

### DIFF
--- a/src/reporter/markdown.ts
+++ b/src/reporter/markdown.ts
@@ -63,9 +63,21 @@ export function generateMarkdownReport(result: RunResult): string {
   lines.push(``, `## Cases`, ``)
   for (const c of result.cases) {
     lines.push(`### ${c.case_id}`, ``, `> ${c.prompt}`, ``)
-    lines.push(`| Model | Score | Reasoning |`, `|-------|-------|-----------|`)
-    for (const [id, score] of Object.entries(c.scores)) {
-      lines.push(`| ${id} | ${score.total} | ${score.reasoning} |`)
+    // Check if any score has confidence data
+    const hasConfidence = Object.values(c.scores).some(s => s.confidence !== undefined)
+    if (hasConfidence) {
+      lines.push(`| Model | Score | Confidence | Reasoning |`, `|-------|-------|------------|-----------|`)
+      for (const [id, score] of Object.entries(c.scores)) {
+        const confStr = score.confidence !== undefined
+          ? (score.confidence < 4 ? `⚠ ${score.confidence}/10` : `${score.confidence}/10`)
+          : '—'
+        lines.push(`| ${id} | ${score.total} | ${confStr} | ${score.reasoning} |`)
+      }
+    } else {
+      lines.push(`| Model | Score | Reasoning |`, `|-------|-------|-----------|`)
+      for (const [id, score] of Object.entries(c.scores)) {
+        lines.push(`| ${id} | ${score.total} | ${score.reasoning} |`)
+      }
     }
     lines.push(``)
   }


### PR DESCRIPTION
Closes #90

## What

Adds confidence/uncertainty scoring to the LLM judge output.

## Changes

### Already in main (from prior work)
- `src/types/index.ts`: `JudgeScore.confidence?: number` field added
- `src/judge/llm.ts`: Judge prompt requests `confidence` field (1-10), parsed and clamped
- `src/judge/llm.ts`: `judgeResponseCot` maps choice score to confidence (extreme→8, middle→4, other→6)
- `src/reporter/terminal.ts`: Shows `⚠ low confidence` when confidence < 4
- `src/judge/__tests__/llm.test.ts`: Tests for confidence parsing (present, missing, out-of-range clamping, string numbers)

### This PR
- `src/reporter/markdown.ts`: Adds confidence column to per-case scores table
  - Column only shown when at least one score has confidence data (backward compatible)
  - Flags low-confidence scores (< 4) with ⚠ prefix

## Test coverage
- 19 judge tests pass (confidence parsing: present, missing, OOB clamping, string number)
- 13 markdown reporter tests pass
- `pnpm typecheck` clean on all modified files