### PR TITLE
fix(judge): always include confidence field in JudgeScore output

### DIFF
--- a/src/judge/llm.ts
+++ b/src/judge/llm.ts
@@ -159,7 +159,10 @@ export async function judgeResponse(
     conciseness * rubric.conciseness
   ).toFixed(1)
 
-  const confidence = parsed.confidence !== undefined ? clamp(parsed.confidence) : undefined
+  // Clamp confidence if present; default to null (not undefined) so it
+  // always appears in JSON output and consumers can distinguish "not asked"
+  // from "omitted by model"
+  const confidence = parsed.confidence !== undefined ? clamp(parsed.confidence) : null
 
   return {
     accuracy,
@@ -167,7 +170,7 @@ export async function judgeResponse(
     conciseness,
     total,
     reasoning: typeof parsed.reasoning === 'string' ? parsed.reasoning : '',
-    ...(confidence !== undefined ? { confidence } : {}),
+    confidence,
   }
 }
 

--- a/src/reporter/markdown.ts
+++ b/src/reporter/markdown.ts
@@ -64,11 +64,11 @@ export function generateMarkdownReport(result: RunResult): string {
   for (const c of result.cases) {
     lines.push(`### ${c.case_id}`, ``, `> ${c.prompt}`, ``)
     // Check if any score has confidence data
-    const hasConfidence = Object.values(c.scores).some(s => s.confidence !== undefined)
+    const hasConfidence = Object.values(c.scores).some(s => s.confidence != null)
     if (hasConfidence) {
       lines.push(`| Model | Score | Confidence | Reasoning |`, `|-------|-------|------------|-----------|`)
       for (const [id, score] of Object.entries(c.scores)) {
-        const confStr = score.confidence !== undefined
+        const confStr = score.confidence != null
           ? (score.confidence < 4 ? `⚠ ${score.confidence}/10` : `${score.confidence}/10`)
           : '—'
         lines.push(`| ${id} | ${score.total} | ${confStr} | ${score.reasoning} |`)

--- a/src/reporter/markdown.ts
+++ b/src/reporter/markdown.ts
@@ -63,9 +63,21 @@ export function generateMarkdownReport(result: RunResult): string {
   lines.push(``, `## Cases`, ``)
   for (const c of result.cases) {
     lines.push(`### ${c.case_id}`, ``, `> ${c.prompt}`, ``)
-    lines.push(`| Model | Score | Reasoning |`, `|-------|-------|-----------|`)
-    for (const [id, score] of Object.entries(c.scores)) {
-      lines.push(`| ${id} | ${score.total} | ${score.reasoning} |`)
+    // Check if any score has confidence data
+    const hasConfidence = Object.values(c.scores).some(s => s.confidence !== undefined)
+    if (hasConfidence) {
+      lines.push(`| Model | Score | Confidence | Reasoning |`, `|-------|-------|------------|-----------|`)
+      for (const [id, score] of Object.entries(c.scores)) {
+        const confStr = score.confidence !== undefined
+          ? (score.confidence < 4 ? `⚠ ${score.confidence}/10` : `${score.confidence}/10`)
+          : '—'
+        lines.push(`| ${id} | ${score.total} | ${confStr} | ${score.reasoning} |`)
+      }
+    } else {
+      lines.push(`| Model | Score | Reasoning |`, `|-------|-------|-----------|`)
+      for (const [id, score] of Object.entries(c.scores)) {
+        lines.push(`| ${id} | ${score.total} | ${score.reasoning} |`)
+      }
     }
     lines.push(``)
   }

--- a/src/reporter/terminal.ts
+++ b/src/reporter/terminal.ts
@@ -68,14 +68,14 @@ export function printSummary(result: RunResult): void {
 
 export function printCaseDetail(
   caseId: string, prompt: string,
-  scores: Record<string, { total: number; reasoning: string; confidence?: number }>
+  scores: Record<string, { total: number; reasoning: string; confidence?: number | null }>
 ): void {
   console.log(chalk.dim(`\n  [${caseId}] ${prompt.slice(0, 72)}${prompt.length > 72 ? '...' : ''}`))
   for (const [id, score] of Object.entries(scores)) {
     // Clamp score to 0-10 range to prevent negative repeat counts
     const scoreDisplay = Math.max(0, Math.min(10, Math.round(score.total)))
     const bar = '|'.repeat(scoreDisplay) + chalk.dim('.'.repeat(10 - scoreDisplay))
-    const lowConfidence = score.confidence !== undefined && score.confidence < 4
+    const lowConfidence = score.confidence != null && score.confidence < 4
       ? chalk.yellow(' ⚠ low confidence')
       : ''
     console.log(`    ${chalk.dim(id.padEnd(22))} ${bar} ${score.total.toFixed(1)}  ${chalk.dim(score.reasoning.slice(0, 60))}${lowConfidence}`)

--- a/src/types/index.ts
+++ b/src/types/index.ts
@@ -193,7 +193,8 @@ export interface JudgeScore {
   total: number
   reasoning: string
   structured_reasoning?: StructuredReasoning
-  confidence?: number  // 0-10, optional — how certain is the judge?
+  // 0-10 — how certain is the judge? null = LLM didn't return it; undefined = not an LLM judge
+  confidence?: number | null
 }
 
 export interface CaseResult {


### PR DESCRIPTION
Closes #102

## Root Cause

The `confidence` field was being omitted from JSON output when the judge model did not explicitly return it. This happened because:
1. `judgeResponse` returned `...(confidence !== undefined ? { confidence } : {})` — spreading nothing when undefined
2. `JSON.stringify` naturally omits `undefined` values
3. Result: `confidence` never appeared in `results/latest.json`

## Fix

- `judgeResponse` now always returns `confidence: null` when the judge does not provide it
- `JudgeScore` type updated: `confidence?: number | null`
- Terminal/markdown reporters updated to use `!= null` check (handles both null and undefined)

## Semantics

| Value | Meaning |
|-------|---------|
| `7` | Judge scored confidence 7/10 |
| `null` | LLM judge ran but model did not return confidence |
| `undefined`/missing | Not an LLM judge case (deterministic scorer) |

## Tests

- 19 judge tests pass
- 13 markdown reporter tests pass
- `pnpm typecheck` clean on all modified files