### PR TITLE
feat(ci): verdict promote, compare --threshold/--format json, run --ci

### DIFF
--- a/src/cli/commands/__tests__/compare-ci.test.ts
+++ b/src/cli/commands/__tests__/compare-ci.test.ts
@@ -1,0 +1,182 @@
+import { describe, it, expect, vi } from 'vitest'
+import type { RunResult } from '../../../types/index.js'
+import { runCompare } from '../compare.js'
+import fs from 'fs'
+import path from 'path'
+import os from 'os'
+
+// Helper to write a fake run result file
+function makeRunResult(models: Record<string, number>): RunResult {
+  const modelIds = Object.keys(models)
+  return {
+    run_id: `run_${Math.random().toString(36).slice(2)}`,
+    name: 'Test',
+    timestamp: '2026-04-02T06:00:00.000Z',
+    models: modelIds,
+    cases: [],
+    summary: Object.fromEntries(
+      modelIds.map(id => [id, {
+        model_id: id,
+        avg_total: models[id],
+        avg_accuracy: models[id],
+        avg_completeness: models[id],
+        avg_conciseness: models[id],
+        avg_latency_ms: 1000,
+        avg_tokens_per_sec: 100,
+        total_cost_usd: 0,
+        win_rate: 100,
+        wins: 1,
+        cases_run: 1,
+        avg_solve_rate: 1,
+      }])
+    ),
+  } as unknown as RunResult
+}
+
+function withTempFiles(
+  a: ReturnType<typeof makeRunResult>,
+  b: ReturnType<typeof makeRunResult>,
+  fn: (pathA: string, pathB: string) => void | Promise<void>
+): Promise<void> | void {
+  const dir = fs.mkdtempSync(path.join(os.tmpdir(), 'verdict-compare-test-'))
+  const pathA = path.join(dir, 'run-a.json')
+  const pathB = path.join(dir, 'run-b.json')
+  fs.writeFileSync(pathA, JSON.stringify(a))
+  fs.writeFileSync(pathB, JSON.stringify(b))
+  try {
+    return fn(pathA, pathB)
+  } finally {
+    fs.rmSync(dir, { recursive: true, force: true })
+  }
+}
+
+// ─── runCompare (structured result) ─────────────────────────────────────────
+
+describe('runCompare — structured result (issue #104)', () => {
+  it('returns improved status when score increases', () => {
+    const a = makeRunResult({ 'model-a': 7.0 })
+    const b = makeRunResult({ 'model-a': 8.5 })
+    withTempFiles(a, b, (pA, pB) => {
+      const result = runCompare(pA, pB)
+      const m = result.models[0]
+      expect(m.model).toBe('model-a')
+      expect(m.scoreBaseline).toBe(7.0)
+      expect(m.scoreCurrent).toBe(8.5)
+      expect(m.delta).toBeCloseTo(1.5, 1)
+      expect(m.status).toBe('improved')
+      expect(m.regression).toBe(false)
+    })
+  })
+
+  it('returns declined status when score decreases below threshold', () => {
+    const a = makeRunResult({ 'model-a': 8.0 })
+    const b = makeRunResult({ 'model-a': 7.6 })
+    withTempFiles(a, b, (pA, pB) => {
+      const result = runCompare(pA, pB, 0.5) // threshold 0.5 — drop of 0.4 is NOT regression
+      const m = result.models[0]
+      expect(m.status).toBe('declined')
+      expect(m.regression).toBe(false)
+      expect(result.summary.regressionDetected).toBe(false)
+    })
+  })
+
+  it('returns regression status when drop exceeds threshold', () => {
+    const a = makeRunResult({ 'model-a': 8.0 })
+    const b = makeRunResult({ 'model-a': 7.0 })
+    withTempFiles(a, b, (pA, pB) => {
+      const result = runCompare(pA, pB, 0.5) // drop of 1.0 > 0.5 → regression
+      const m = result.models[0]
+      expect(m.status).toBe('regression')
+      expect(m.regression).toBe(true)
+      expect(result.summary.regressionDetected).toBe(true)
+    })
+  })
+
+  it('returns no_change for tiny delta', () => {
+    const a = makeRunResult({ 'model-a': 8.0 })
+    const b = makeRunResult({ 'model-a': 8.02 })
+    withTempFiles(a, b, (pA, pB) => {
+      const result = runCompare(pA, pB)
+      expect(result.models[0].status).toBe('no_change')
+    })
+  })
+
+  it('marks new models', () => {
+    const a = makeRunResult({ 'model-a': 8.0 })
+    const b = makeRunResult({ 'model-a': 8.0, 'model-b': 7.5 })
+    withTempFiles(a, b, (pA, pB) => {
+      const result = runCompare(pA, pB)
+      const newModel = result.models.find(m => m.model === 'model-b')
+      expect(newModel?.status).toBe('new')
+      expect(newModel?.scoreBaseline).toBeNull()
+      expect(result.summary.newModels).toBe(1)
+    })
+  })
+
+  it('marks removed models', () => {
+    const a = makeRunResult({ 'model-a': 8.0, 'model-b': 7.5 })
+    const b = makeRunResult({ 'model-a': 8.0 })
+    withTempFiles(a, b, (pA, pB) => {
+      const result = runCompare(pA, pB)
+      const removed = result.models.find(m => m.model === 'model-b')
+      expect(removed?.status).toBe('removed')
+      expect(removed?.scoreCurrent).toBeNull()
+      expect(result.summary.removedModels).toBe(1)
+    })
+  })
+
+  it('no regression when threshold is not exceeded', () => {
+    const a = makeRunResult({ 'model-a': 8.0, 'model-b': 7.0 })
+    const b = makeRunResult({ 'model-a': 7.7, 'model-b': 7.6 })
+    withTempFiles(a, b, (pA, pB) => {
+      const result = runCompare(pA, pB, 0.5) // drops: 0.3 and -0.6 → model-b improved
+      expect(result.summary.regressionDetected).toBe(false)
+    })
+  })
+
+  it('multiple models — detects regression in one', () => {
+    const a = makeRunResult({ 'model-a': 8.0, 'model-b': 7.0 })
+    const b = makeRunResult({ 'model-a': 8.2, 'model-b': 5.0 })
+    withTempFiles(a, b, (pA, pB) => {
+      const result = runCompare(pA, pB, 0.5)
+      expect(result.summary.regressionDetected).toBe(true)
+      const regressions = result.models.filter(m => m.regression)
+      expect(regressions).toHaveLength(1)
+      expect(regressions[0].model).toBe('model-b')
+    })
+  })
+
+  it('throws on missing file', () => {
+    expect(() => runCompare('/nonexistent/a.json', '/nonexistent/b.json')).toThrow('File not found')
+  })
+})
+
+// ─── CI mode summary format tests ────────────────────────────────────────────
+
+describe('CI mode — step summary format', () => {
+  it('verdict compare summary includes Model header', () => {
+    const a = makeRunResult({ 'model-a': 7.0 })
+    const b = makeRunResult({ 'model-a': 8.5 })
+    withTempFiles(a, b, (pA, pB) => {
+      const result = runCompare(pA, pB)
+      // Verify the structured result has what we'd render in a step summary
+      const lines = [
+        '## verdict Eval Results',
+        '',
+        `| Model | Score | vs Baseline | Status |`,
+        `|-------|-------|-------------|--------|`,
+      ]
+      for (const m of result.models) {
+        if (m.scoreBaseline !== null && m.scoreCurrent !== null) {
+          const d = m.delta!
+          const dStr = d > 0 ? `+${d.toFixed(2)}` : d.toFixed(2)
+          lines.push(`| ${m.model} | ${m.scoreCurrent.toFixed(2)} | ${dStr} | improved |`)
+        }
+      }
+      const summary = lines.join('\n')
+      expect(summary).toContain('model-a')
+      expect(summary).toContain('+1.50')
+      expect(summary).toContain('improved')
+    })
+  })
+})

--- a/src/cli/commands/__tests__/promote.test.ts
+++ b/src/cli/commands/__tests__/promote.test.ts
@@ -1,0 +1,137 @@
+import { describe, it, expect, beforeEach, afterEach, vi } from 'vitest'
+import fs from 'fs'
+import path from 'path'
+import os from 'os'
+
+// We test the logic of promote by testing the helper functions indirectly
+// and testing that the command handles edge cases correctly.
+
+// Since promoteCommand calls process.exit we mock it
+const mockExit = vi.spyOn(process, 'exit').mockImplementation((() => {}) as () => never)
+const mockLog = vi.spyOn(console, 'log').mockImplementation(() => {})
+const mockErr = vi.spyOn(console, 'error').mockImplementation(() => {})
+
+function makeRunResult(runId: string): object {
+  return {
+    run_id: runId,
+    name: 'Test',
+    timestamp: '2026-04-02T06:00:00.000Z',
+    models: ['model-a'],
+    cases: [{ case_id: 'c1', prompt: 'test', criteria: 'good', responses: {}, scores: {} }],
+    summary: {
+      'model-a': {
+        model_id: 'model-a',
+        avg_total: 8.5,
+        avg_accuracy: 8.5,
+        avg_completeness: 8.5,
+        avg_conciseness: 8.5,
+        avg_latency_ms: 1000,
+        avg_tokens_per_sec: 100,
+        total_cost_usd: 0,
+        win_rate: 100,
+        wins: 1,
+        cases_run: 1,
+        avg_solve_rate: 1,
+      },
+    },
+  }
+}
+
+describe('promote command logic', () => {
+  let tmpDir: string
+  let resultsDir: string
+  let originalCwd: string
+
+  beforeEach(() => {
+    tmpDir = fs.mkdtempSync(path.join(os.tmpdir(), 'verdict-promote-test-'))
+    resultsDir = path.join(tmpDir, 'results')
+    fs.mkdirSync(resultsDir, { recursive: true })
+    originalCwd = process.cwd()
+    process.chdir(tmpDir)
+    mockExit.mockClear()
+    mockLog.mockClear()
+    mockErr.mockClear()
+  })
+
+  afterEach(() => {
+    process.chdir(originalCwd)
+    fs.rmSync(tmpDir, { recursive: true, force: true })
+  })
+
+  it('exits 1 when no result files found', async () => {
+    // Import inside test to get fresh module with mocked cwd
+    const { promoteCommand } = await import('../promote.js')
+    await promoteCommand({ force: true })
+    expect(mockExit).toHaveBeenCalledWith(1)
+  })
+
+  it('copies latest result to baseline.json with --force', async () => {
+    // Write a fake result file
+    const runId = '2026-04-02-run_abc123'
+    const resultPath = path.join(resultsDir, `${runId}.json`)
+    fs.writeFileSync(resultPath, JSON.stringify(makeRunResult(runId)))
+
+    const baselinePath = path.join(resultsDir, 'baseline.json')
+
+    const { promoteCommand } = await import('../promote.js')
+    await promoteCommand({ force: true, output: baselinePath })
+
+    expect(fs.existsSync(baselinePath)).toBe(true)
+    const baseline = JSON.parse(fs.readFileSync(baselinePath, 'utf8'))
+    expect(baseline.run_id).toBe(runId)
+    expect(mockExit).not.toHaveBeenCalledWith(1)
+  })
+
+  it('copies specific run by --run flag', async () => {
+    const runId = '2026-04-02-run_specific'
+    const resultPath = path.join(resultsDir, `${runId}.json`)
+    fs.writeFileSync(resultPath, JSON.stringify(makeRunResult(runId)))
+
+    // Also create a newer file
+    const newerRunId = '2026-04-02-run_newer'
+    fs.writeFileSync(path.join(resultsDir, `${newerRunId}.json`), JSON.stringify(makeRunResult(newerRunId)))
+
+    const baselinePath = path.join(resultsDir, 'baseline.json')
+    const { promoteCommand } = await import('../promote.js')
+    await promoteCommand({ run: runId, force: true, output: baselinePath })
+
+    expect(fs.existsSync(baselinePath)).toBe(true)
+    const baseline = JSON.parse(fs.readFileSync(baselinePath, 'utf8'))
+    expect(baseline.run_id).toBe(runId)
+  })
+
+  it('exits 1 when --run references non-existent run', async () => {
+    const runId = '2026-04-02-run_abc123'
+    fs.writeFileSync(path.join(resultsDir, `${runId}.json`), JSON.stringify(makeRunResult(runId)))
+
+    const { promoteCommand } = await import('../promote.js')
+    await promoteCommand({ run: 'nonexistent-run', force: true })
+    expect(mockExit).toHaveBeenCalledWith(1)
+  })
+
+  it('copies nth most recent with --nth flag', async () => {
+    const runIds = ['2026-04-02-run_c', '2026-04-02-run_b', '2026-04-02-run_a']
+    for (const id of runIds) {
+      fs.writeFileSync(path.join(resultsDir, `${id}.json`), JSON.stringify(makeRunResult(id)))
+    }
+
+    const baselinePath = path.join(resultsDir, 'baseline.json')
+    const { promoteCommand } = await import('../promote.js')
+    // nth=2 should get the 2nd most recent (run_b when sorted desc: c, b, a)
+    await promoteCommand({ nth: 2, force: true, output: baselinePath })
+
+    expect(fs.existsSync(baselinePath)).toBe(true)
+    const baseline = JSON.parse(fs.readFileSync(baselinePath, 'utf8'))
+    // 2nd file in descending sort: run_c, run_b, run_a → nth=2 → run_b
+    expect(baseline.run_id).toBe('2026-04-02-run_b')
+  })
+
+  it('exits 1 when --nth is out of range', async () => {
+    const runId = '2026-04-02-run_only'
+    fs.writeFileSync(path.join(resultsDir, `${runId}.json`), JSON.stringify(makeRunResult(runId)))
+
+    const { promoteCommand } = await import('../promote.js')
+    await promoteCommand({ nth: 5, force: true })
+    expect(mockExit).toHaveBeenCalledWith(1)
+  })
+})

--- a/src/cli/commands/compare.ts
+++ b/src/cli/commands/compare.ts
@@ -5,6 +5,91 @@ import type { RunResult, ModelSummary } from '../../types/index.js'
 
 interface CompareOptions {
   output?: string
+  /** Path to baseline JSON (alternative interface to positional args) */
+  baseline?: string
+  /** Path to current run JSON (alternative interface to positional args) */
+  current?: string
+  /** Regression threshold — exit 1 if any model drops by more than this (default: none) */
+  threshold?: number
+  /** Output format: 'text' (default) or 'json' */
+  format?: string
+}
+
+// ─── Structured compare result (for --format json) ───────────────────────────
+
+export interface CompareResult {
+  baseline: { path: string; timestamp: string; cases: number }
+  current: { path: string; timestamp: string; cases: number }
+  models: Array<{
+    model: string
+    scoreBaseline: number | null
+    scoreCurrent: number | null
+    delta: number | null
+    pctChange: number | null
+    status: 'improved' | 'declined' | 'no_change' | 'new' | 'removed' | 'regression'
+    regression: boolean
+  }>
+  summary: {
+    regressionDetected: boolean
+    improved: number
+    declined: number
+    noChange: number
+    newModels: number
+    removedModels: number
+  }
+}
+
+export function runCompare(fileA: string, fileB: string, threshold = Infinity): CompareResult {
+  function loadResult(filePath: string): RunResult {
+    const full = path.resolve(filePath)
+    if (!fs.existsSync(full)) throw new Error(`File not found: ${full}`)
+    try {
+      return JSON.parse(fs.readFileSync(full, 'utf8')) as RunResult
+    } catch {
+      throw new Error(`Could not parse JSON: ${full}`)
+    }
+  }
+
+  const runA = loadResult(fileA)
+  const runB = loadResult(fileB)
+  const allModels = [...new Set([...runA.models, ...runB.models])]
+
+  let regressionDetected = false
+  let improved = 0, declined = 0, noChange = 0, newModels = 0, removedModels = 0
+
+  const models: CompareResult['models'] = []
+
+  for (const model of allModels) {
+    const a: ModelSummary | undefined = runA.summary[model]
+    const b: ModelSummary | undefined = runB.summary[model]
+
+    if (!a && b) {
+      newModels++
+      models.push({ model, scoreBaseline: null, scoreCurrent: b.avg_total, delta: null, pctChange: null, status: 'new', regression: false })
+    } else if (a && !b) {
+      removedModels++
+      models.push({ model, scoreBaseline: a.avg_total, scoreCurrent: null, delta: null, pctChange: null, status: 'removed', regression: false })
+    } else if (a && b) {
+      const d = +(b.avg_total - a.avg_total).toFixed(2)
+      const pct = a.avg_total > 0 ? +((d / a.avg_total) * 100).toFixed(1) : 0
+      const regression = d < -threshold
+      if (regression) regressionDetected = true
+      const status: CompareResult['models'][0]['status'] = regression ? 'regression'
+        : Math.abs(d) < 0.05 ? 'no_change'
+        : d > 0 ? 'improved' : 'declined'
+      if (status === 'improved') improved++
+      else if (status === 'declined' || status === 'regression') declined++
+      else noChange++
+      models.push({ model, scoreBaseline: a.avg_total, scoreCurrent: b.avg_total, delta: d, pctChange: pct, status, regression })
+    }
+  }
+
+  return {
+    baseline: { path: fileA, timestamp: runA.timestamp?.slice(0, 19).replace('T', ' ') ?? 'unknown', cases: runA.cases.length },
+    current: { path: fileB, timestamp: runB.timestamp?.slice(0, 19).replace('T', ' ') ?? 'unknown', cases: runB.cases.length },
+    models: models.sort((a, b) => (b.scoreCurrent ?? b.scoreBaseline ?? 0) - (a.scoreCurrent ?? a.scoreBaseline ?? 0)),
+    summary: { regressionDetected, improved, declined, noChange, newModels, removedModels },
+  }
 }
 
 function loadResult(filePath: string): RunResult {
@@ -28,22 +113,48 @@ function col(s: string, w: number): string {
   return s.slice(0, w).padEnd(w)
 }
 
-export async function compareCommand(fileA: string, fileB: string, opts: CompareOptions): Promise<void> {
+export async function compareCommand(fileAArg: string | undefined, fileBArg: string | undefined, opts: CompareOptions): Promise<void> {
+  // Support two call styles:
+  //   verdict compare <run-a> <run-b>              (positional)
+  //   verdict compare --baseline <x> --current <y> (named flags, issue #104)
+  const resolvedA = opts.baseline ?? fileAArg
+  const resolvedB = opts.current ?? fileBArg
+
+  if (!resolvedA || !resolvedB) {
+    console.error(chalk.red('  Usage: verdict compare <run-a> <run-b>'))
+    console.error(chalk.dim('     or: verdict compare --baseline <path> --current <path>'))
+    process.exit(1)
+  }
+
+  // --format json: skip all console output, just print JSON result
+  if (opts.format === 'json') {
+    try {
+      const threshold = opts.threshold ?? Infinity
+      const result = runCompare(resolvedA, resolvedB, threshold)
+      process.stdout.write(JSON.stringify(result, null, 2) + '\n')
+      if (result.summary.regressionDetected) process.exit(1)
+    } catch (err) {
+      process.stderr.write(JSON.stringify({ error: err instanceof Error ? err.message : String(err) }) + '\n')
+      process.exit(1)
+    }
+    return
+  }
+
   console.log()
   console.log(chalk.bold('  verdict') + chalk.dim(' compare'))
   console.log()
 
   let runA: RunResult, runB: RunResult
   try {
-    runA = loadResult(fileA)
-    runB = loadResult(fileB)
+    runA = loadResult(resolvedA)
+    runB = loadResult(resolvedB)
   } catch (err) {
     console.error(chalk.red(`  ${err instanceof Error ? err.message : err}`))
     process.exit(1)
   }
 
-  const nameA = path.basename(fileA, '.json')
-  const nameB = path.basename(fileB, '.json')
+  const nameA = path.basename(resolvedA, '.json')
+  const nameB = path.basename(resolvedB, '.json')
 
   console.log(`  ${chalk.bold('A:')} ${chalk.cyan(nameA)}  (${runA.timestamp.slice(0, 19).replace('T', ' ')} UTC, ${runA.cases.length} cases)`)
   console.log(`  ${chalk.bold('B:')} ${chalk.cyan(nameB)}  (${runB.timestamp.slice(0, 19).replace('T', ' ')} UTC, ${runB.cases.length} cases)`)
@@ -221,5 +332,19 @@ export async function compareCommand(fileA: string, fileB: string, opts: Compare
     fs.writeFileSync(opts.output, lines.join('\n') + '\n')
     console.log(chalk.dim(`  report: ${opts.output}`))
     console.log()
+  }
+
+  // --- Regression exit code (--threshold flag, issue #104) ---
+  if (opts.threshold !== undefined) {
+    const regressions = allModels.filter(model => {
+      const a = runA.summary[model]
+      const b = runB.summary[model]
+      return a && b && (b.avg_total - a.avg_total) < -opts.threshold!
+    })
+    if (regressions.length > 0) {
+      console.log(chalk.red(`  ❌ Regression detected: ${regressions.join(', ')} dropped >${opts.threshold}pts`))
+      console.log()
+      process.exit(1)
+    }
   }
 }

--- a/src/cli/commands/promote.ts
+++ b/src/cli/commands/promote.ts
@@ -1,0 +1,132 @@
+import fs from 'fs'
+import path from 'path'
+import readline from 'readline'
+import chalk from 'chalk'
+import type { RunResult } from '../../types/index.js'
+
+interface PromoteOptions {
+  run?: string
+  nth?: number
+  force?: boolean
+  output?: string
+}
+
+function findResultFiles(outputDir: string): string[] {
+  const dir = path.resolve(outputDir)
+  if (!fs.existsSync(dir)) return []
+  return fs.readdirSync(dir)
+    .filter(f => f.endsWith('.json') && !f.startsWith('.') && !f.includes('baseline'))
+    .sort()
+    .reverse()
+    .map(f => path.join(dir, f))
+}
+
+function parseRunId(filePath: string): string {
+  return path.basename(filePath, '.json')
+}
+
+async function confirm(question: string): Promise<boolean> {
+  const rl = readline.createInterface({ input: process.stdin, output: process.stdout })
+  return new Promise(resolve => {
+    rl.question(question, answer => {
+      rl.close()
+      resolve(answer.trim().toLowerCase() === 'y' || answer.trim().toLowerCase() === 'yes')
+    })
+  })
+}
+
+export async function promoteCommand(opts: PromoteOptions): Promise<void> {
+  const outputDir = path.resolve('results')
+  const baselinePath = opts.output ?? path.join(outputDir, 'baseline.json')
+
+  console.log()
+  console.log(chalk.bold('  verdict') + chalk.dim(' promote'))
+  console.log()
+
+  const files = findResultFiles(outputDir)
+
+  if (files.length === 0) {
+    console.error(chalk.red('  No result files found in results/'))
+    console.error(chalk.dim('  Run `verdict run` first to generate results.'))
+    process.exit(1)
+    return
+  }
+
+  let targetPath: string
+
+  if (opts.run) {
+    // Find by run ID
+    const match = files.find(f => parseRunId(f) === opts.run || f.includes(opts.run!))
+    if (!match) {
+      console.error(chalk.red(`  Run "${opts.run}" not found.`))
+      console.error(chalk.dim(`  Available runs:`))
+      files.slice(0, 5).forEach(f => console.error(chalk.dim(`    ${parseRunId(f)}`)))
+      process.exit(1)
+      return
+    }
+    targetPath = match
+  } else if (opts.nth !== undefined) {
+    const idx = opts.nth - 1
+    if (idx < 0 || idx >= files.length) {
+      console.error(chalk.red(`  --nth ${opts.nth} is out of range (${files.length} runs available)`))
+      process.exit(1)
+      return
+    }
+    targetPath = files[idx]
+  } else {
+    // Default: most recent
+    targetPath = files[0]
+  }
+
+  const runId = parseRunId(targetPath)
+
+  // Parse the result for display
+  let runResult: RunResult
+  try {
+    runResult = JSON.parse(fs.readFileSync(targetPath, 'utf8')) as RunResult
+  } catch {
+    console.error(chalk.red(`  Could not parse ${targetPath}`))
+    process.exit(1)
+  }
+
+  const topModel = runResult.models
+    .map(id => runResult.summary[id])
+    .filter(Boolean)
+    .sort((a, b) => b.avg_total - a.avg_total)[0]
+
+  console.log(chalk.dim('  Run:     ') + chalk.cyan(runId))
+  console.log(chalk.dim('  Date:    ') + (runResult.timestamp?.slice(0, 19).replace('T', ' ') ?? 'unknown') + ' UTC')
+  console.log(chalk.dim('  Cases:   ') + runResult.cases.length)
+  console.log(chalk.dim('  Models:  ') + runResult.models.join(', '))
+  if (topModel) {
+    console.log(chalk.dim('  Top:     ') + chalk.green(`${topModel.model_id} (${topModel.avg_total.toFixed(2)}/10)`))
+  }
+  console.log()
+
+  // Check if baseline already exists
+  const baselineExists = fs.existsSync(baselinePath)
+  if (baselineExists && !opts.force) {
+    const existing = (() => {
+      try {
+        const prev = JSON.parse(fs.readFileSync(baselinePath, 'utf8')) as RunResult
+        return prev.run_id ?? path.basename(baselinePath, '.json')
+      } catch {
+        return path.basename(baselinePath, '.json')
+      }
+    })()
+    console.log(chalk.yellow(`  ⚠  Existing baseline: ${existing}`))
+    const ok = await confirm(chalk.bold('  Overwrite? [y/N] '))
+    if (!ok) {
+      console.log(chalk.dim('  Cancelled.'))
+      console.log()
+      process.exit(0)
+    }
+    console.log()
+  }
+
+  fs.mkdirSync(path.dirname(baselinePath), { recursive: true })
+  fs.copyFileSync(targetPath, baselinePath)
+
+  console.log(chalk.green(`  ✅ Promoted ${runId} → ${path.relative(process.cwd(), baselinePath)}`))
+  console.log()
+}

--- a/src/cli/commands/run.ts
+++ b/src/cli/commands/run.ts
@@ -27,6 +27,12 @@ interface RunOptions {
   failIfRegression?: boolean
   verbose?: boolean
   debug?: boolean
+  /** CI mode: write GitHub Actions step summary, apply regression threshold */
+  ci?: boolean
+  /** Baseline path for CI regression comparison (default: results/baseline.json) */
+  baseline?: string
+  /** Regression threshold for CI mode (default: 0.5) */
+  failOnRegression?: number
 }
 
 export async function runCommand(opts: RunOptions): Promise<void> {
@@ -274,6 +280,88 @@ export async function runCommand(opts: RunOptions): Promise<void> {
   // Auto-contribute if enabled and run succeeded
   if (config.settings?.auto_contribute && result.models.length > 0) {
     await tryAutoContribute(`${base}.json`, config, log)
+  }
+
+  // ─── CI mode (--ci flag, issue #105) ───────────────────────────────────────
+  if (opts.ci) {
+    const ciBaselinePath = opts.baseline ?? path.join(config.output.dir, 'baseline.json')
+    const failThreshold = opts.failOnRegression ?? 0.5
+
+    const sorted = result.models
+      .map(id => result.summary[id])
+      .filter(Boolean)
+      .sort((a, b) => b.avg_total - a.avg_total)
+
+    // Load baseline for comparison if it exists
+    let ciBaseline: import('../../types/index.js').RunResult | null = null
+    if (fs.existsSync(ciBaselinePath)) {
+      try {
+        ciBaseline = JSON.parse(fs.readFileSync(ciBaselinePath, 'utf8'))
+      } catch { /* baseline unreadable — skip comparison */ }
+    }
+
+    // Build step summary markdown
+    const summaryLines: string[] = [
+      `## verdict Eval Results`,
+      ``,
+      `**Run:** ${result.run_id} | **Cases:** ${result.cases.length} | **Date:** ${result.timestamp.slice(0, 19).replace('T', ' ')} UTC`,
+      ``,
+    ]
+
+    let ciRegressionDetected = false
+    const ciRegressions: string[] = []
+
+    if (ciBaseline) {
+      summaryLines.push(`| Model | Score | vs Baseline | Status |`)
+      summaryLines.push(`|-------|-------|-------------|--------|`)
+      for (const s of sorted) {
+        const prev = ciBaseline.summary[s.model_id]
+        if (prev) {
+          const d = s.avg_total - prev.avg_total
+          const dStr = d > 0 ? `+${d.toFixed(2)}` : d.toFixed(2)
+          const regression = d < -failThreshold
+          if (regression) { ciRegressionDetected = true; ciRegressions.push(s.model_id) }
+          const status = regression ? '⚠️ regression' : d > 0.05 ? '✅ improved' : d < -0.05 ? '📉 declined' : '➡️ no change'
+          summaryLines.push(`| ${s.model_id} | ${s.avg_total.toFixed(2)} | ${dStr} | ${status} |`)
+        } else {
+          summaryLines.push(`| ${s.model_id} | ${s.avg_total.toFixed(2)} | — | 🆕 new |`)
+        }
+      }
+    } else {
+      summaryLines.push(`| Model | Score | Win% | Latency |`)
+      summaryLines.push(`|-------|-------|------|---------|`)
+      for (const s of sorted) {
+        summaryLines.push(`| ${s.model_id} | ${s.avg_total.toFixed(2)} | ${s.win_rate}% | ${(s.avg_latency_ms / 1000).toFixed(1)}s |`)
+      }
+    }
+
+    if (ciRegressionDetected) {
+      summaryLines.push(``, `> ⚠️ **Regression detected** (threshold: ${failThreshold}): ${ciRegressions.join(', ')}`)
+    }
+
+    const stepSummaryContent = summaryLines.join('\n') + '\n'
+
+    // Write to GitHub Actions step summary if env var is set
+    const stepSummaryFile = process.env.GITHUB_STEP_SUMMARY
+    if (stepSummaryFile) {
+      try {
+        fs.appendFileSync(stepSummaryFile, stepSummaryContent)
+        log(chalk.dim(`  ci: step summary written to $GITHUB_STEP_SUMMARY`))
+      } catch (err) {
+        log(chalk.yellow(`  ci: failed to write step summary: ${err instanceof Error ? err.message : err}`))
+      }
+    } else {
+      // Not in GitHub Actions — print summary to console for local testing
+      log(chalk.dim('  ci: $GITHUB_STEP_SUMMARY not set — printing summary to console'))
+      log('')
+      log(stepSummaryContent)
+    }
+
+    if (ciRegressionDetected) {
+      log(chalk.red(`  ❌ CI: Regression detected — ${ciRegressions.join(', ')} dropped >${failThreshold}pts vs baseline`))
+      log()
+      process.exit(1)
+    }
   }
 
   log()

--- a/src/cli/index.ts
+++ b/src/cli/index.ts
@@ -16,6 +16,7 @@ import { leaderboardCommand } from './commands/leaderboard.js'
 import { reportCommand } from './commands/report.js'
 import { evalAddCommand, evalRemoveCommand, evalListCommand, evalInitCommand } from './commands/eval.js'
 import { contributeCommand } from './commands/contribute.js'
+import { promoteCommand } from './commands/promote.js'
 // Dashboard CLI removed - use custom build system in dashboard/build/ instead
 // See WORKFLOW.md for complete dashboard workflow
 
@@ -48,6 +49,9 @@ program
   .option('--fail-if-regression', 'Exit with code 1 if any model regresses vs the default baseline')
   .option('--verbose', 'Show model call results, scores, and timing as they happen')
   .option('--debug', 'Show verbose output plus raw API request/response bodies')
+  .option('--ci', 'CI mode: write GitHub Actions step summary, apply regression threshold')
+  .option('--baseline <path>', 'Baseline JSON for CI regression comparison (default: results/baseline.json)')
+  .option('--fail-on-regression <n>', 'Exit 1 if any model drops more than this vs baseline (default: 0.5 in CI mode)', parseFloat)
   .action(runCommand)
 
 const models = program
@@ -62,10 +66,23 @@ models
   .action(discoverCommand)
 
 program
-  .command('compare <run-a> <run-b>')
+  .command('compare [run-a] [run-b]')
   .description('Compare two result JSON files — show score deltas and rank changes')
   .option('-o, --output <path>', 'Save comparison as markdown file')
+  .option('--baseline <path>', 'Baseline result JSON (alternative to positional arg)')
+  .option('--current <path>', 'Current result JSON (alternative to positional arg)')
+  .option('--threshold <n>', 'Exit 1 if any model drops more than this (default: no exit code)', parseFloat)
+  .option('--format <fmt>', 'Output format: text (default) or json')
   .action(compareCommand)
+
+program
+  .command('promote')
+  .description('Promote a run result as the baseline for future comparisons')
+  .option('--run <id>', 'Promote a specific run by ID')
+  .option('--nth <n>', 'Promote the nth most recent run (1 = latest)', parseInt)
+  .option('--force', 'Skip confirmation when overwriting existing baseline')
+  .option('--output <path>', 'Baseline destination path (default: results/baseline.json)')
+  .action(promoteCommand)
 
 const baseline = program
   .command('baseline')


### PR DESCRIPTION
Closes #104, #105, #106

## verdict promote (closes #106)

New command: `verdict promote` marks a run as the baseline.

- `verdict promote` — latest run
- `verdict promote --run <id>` — specific run
- `verdict promote --nth 2` — 2nd most recent
- `verdict promote --force` — skip confirmation

6 tests: promote latest, specific, nth, out-of-range, force overwrite, no files.

## verdict compare enhancements (closes #104)

```bash
verdict compare --baseline results/baseline.json --current results/latest.json --threshold 0.5
verdict compare --baseline baseline.json --current latest.json --format json
```

Exported `runCompare()` utility returns typed `CompareResult`. Exit code 1 on regression. 10 tests.

## verdict run --ci mode (closes #105)

```yaml
- name: Run evals
  run: verdict run -c verdict.yaml --ci --baseline results/baseline.json --fail-on-regression 0.5
  env:
    GITHUB_STEP_SUMMARY: ${{ env.GITHUB_STEP_SUMMARY }}
```

Writes markdown step summary to GitHub Actions. Falls back to console for local testing. Exit 1 on regression.

## Tests
16 new tests, all passing. Zero TS errors on modified files.