### PR TITLE
fix(runner): use random tiebreaker to eliminate first-model bias

### DIFF
--- a/src/core/__tests__/runner.test.ts
+++ b/src/core/__tests__/runner.test.ts
@@ -335,6 +335,33 @@ describe('runEvals', () => {
     expect(result.cases[0].scores['model-a'].total).toBe(6) // correct tool, no expected args
   })
 
+  it('uses random tiebreaker when models tie — no systematic first-model bias (#108)', async () => {
+    const config = makeConfig()
+    const pack = makePack([
+      { id: 'tie-case', prompt: 'Test', criteria: 'Test', scorer: 'exact', expected: 'answer', tags: [], judge_type: 'llm', max_tokens: undefined },
+    ])
+
+    // Both models return identical correct answers → tie
+    vi.mocked(callModel)
+      .mockResolvedValueOnce(makeModelResponse('model-a', 'answer'))
+      .mockResolvedValueOnce(makeModelResponse('model-b', 'answer'))
+
+    // Run 100 times and verify both models win at least once (random selection)
+    const winCounts: Record<string, number> = { 'model-a': 0, 'model-b': 0 }
+    for (let i = 0; i < 100; i++) {
+      vi.mocked(callModel)
+        .mockResolvedValueOnce(makeModelResponse('model-a', 'answer'))
+        .mockResolvedValueOnce(makeModelResponse('model-b', 'answer'))
+      const result = await runEvals(config, [pack])
+      const winner = result.cases[0].winner
+      if (winner) winCounts[winner] = (winCounts[winner] ?? 0) + 1
+    }
+
+    // Both models should win at least once in 100 trials (probability of all-same: 2^-100 ≈ 0)
+    expect(winCounts['model-a']).toBeGreaterThan(0)
+    expect(winCounts['model-b']).toBeGreaterThan(0)
+  })
+
   it('uses callModelMultiTurn for multi-turn cases', async () => {
     const config = makeConfig()
     const pack = makePack([

--- a/src/core/runner.ts
+++ b/src/core/runner.ts
@@ -387,11 +387,15 @@ export async function runEvals(
       }
     }
 
-    // Find winner
-    const winner = Object.entries(caseResult.scores)
-      .filter(([, s]) => s.total > 0)
-      .sort((a, b) => b[1].total - a[1].total)[0]
-    if (winner) { caseResult.winner = winner[0]; summary[winner[0]].wins++ }
+    // Find winner — random tiebreaker to avoid first-model bias (#108)
+    const validScores = Object.entries(caseResult.scores).filter(([, s]) => s.total > 0)
+    if (validScores.length > 0) {
+      const topScore = Math.max(...validScores.map(([, s]) => s.total))
+      const tied = validScores.filter(([, s]) => s.total === topScore)
+      const winner = tied[Math.floor(Math.random() * tied.length)]
+      caseResult.winner = winner[0]
+      summary[winner[0]].wins++
+    }
 
     cases.push(caseResult)
 


### PR DESCRIPTION
Closes #108

## Problem

When models score identically, `Object.entries()` insertion order + stable sort meant the first model in config always won ties. In Run 4 (HumanEval), 85/154 cases (55%) were ties — and model-a won 78% of them artificially.

## Fix

Replace sort-based winner selection with:
1. Find the top score across all models
2. Collect all models tied at that score
3. Pick randomly from the tied set

```typescript
// Before
const winner = Object.entries(caseResult.scores)
  .filter(([, s]) => s.total > 0)
  .sort((a, b) => b[1].total - a[1].total)[0]

// After
const topScore = Math.max(...validScores.map(([, s]) => s.total))
const tied = validScores.filter(([, s]) => s.total === topScore)
const winner = tied[Math.floor(Math.random() * tied.length)]
```

## Test

100-trial randomness test: with two models always tying, both must win at least once. Probability of all-same: 2^-100 ≈ 0.

15 runner tests pass.