### PR TITLE
feat: verdict/vitest integration — describeEvals() runs evals as native Vitest tests

### DIFF
--- a/package.json
+++ b/package.json
@@ -9,6 +9,10 @@
     ".": {
       "import": "./dist/index.js",
       "types": "./dist/index.d.ts"
+    },
+    "./vitest": {
+      "import": "./dist/integrations.js",
+      "types": "./dist/integrations.d.ts"
     }
   },
   "bin": {

--- a/src/integrations/__tests__/vitest-integration.test.ts
+++ b/src/integrations/__tests__/vitest-integration.test.ts
@@ -1,0 +1,249 @@
+import { describe, it, expect, vi } from 'vitest'
+import {
+  toModelConfig,
+  toJudgeConfig,
+  scoreSingleCase,
+  type VitestModelConfig,
+  type VitestJudgeConfig,
+} from '../vitest.js'
+import type { EvalCase } from '../../types/index.js'
+
+// Mock callModel at top level so vitest hoisting works correctly
+vi.mock('../../providers/compat.js', () => ({
+  callModel: vi.fn().mockResolvedValue({
+    text: 'Paris',
+    model_id: 'test',
+    input_tokens: 10,
+    output_tokens: 5,
+    latency_ms: 100,
+  }),
+  clearClientCache: vi.fn(),
+}))
+
+// ─── toModelConfig ────────────────────────────────────────────────────────────
+
+describe('toModelConfig', () => {
+  const base: VitestModelConfig = {
+    id: 'test-model',
+    model: 'llama3.1:8b',
+    base_url: 'http://localhost:11434/v1',
+    api_key: 'none',
+  }
+
+  it('maps id and model correctly', () => {
+    const cfg = toModelConfig(base)
+    expect(cfg.id).toBe('test-model')
+    expect(cfg.model).toBe('llama3.1:8b')
+  })
+
+  it('maps base_url and api_key', () => {
+    const cfg = toModelConfig(base)
+    expect(cfg.base_url).toBe('http://localhost:11434/v1')
+    expect(cfg.api_key).toBe('none')
+  })
+
+  it('defaults api_key to "none" when omitted', () => {
+    const cfg = toModelConfig({ id: 'x', model: 'y' })
+    expect(cfg.api_key).toBe('none')
+  })
+
+  it('defaults timeout_ms to 30000', () => {
+    const cfg = toModelConfig(base)
+    expect(cfg.timeout_ms).toBe(30_000)
+  })
+
+  it('respects custom timeout_ms', () => {
+    const cfg = toModelConfig({ ...base, timeout_ms: 60_000 })
+    expect(cfg.timeout_ms).toBe(60_000)
+  })
+
+  it('defaults max_tokens to 1024', () => {
+    const cfg = toModelConfig(base)
+    expect(cfg.max_tokens).toBe(1024)
+  })
+
+  it('includes empty tags array', () => {
+    const cfg = toModelConfig(base)
+    expect(cfg.tags).toEqual([])
+  })
+})
+
+// ─── toJudgeConfig ────────────────────────────────────────────────────────────
+
+describe('toJudgeConfig', () => {
+  const base: VitestJudgeConfig = {
+    model: 'gpt-4o-mini',
+    base_url: 'https://api.openai.com/v1',
+    api_key: 'sk-test',
+  }
+
+  it('returns judgeConfig and judgeModel', () => {
+    const { judgeConfig, judgeModel } = toJudgeConfig(base)
+    expect(judgeConfig).toBeDefined()
+    expect(judgeModel).toBeDefined()
+  })
+
+  it('sets judge model name', () => {
+    const { judgeConfig, judgeModel } = toJudgeConfig(base)
+    expect(judgeConfig.model).toBe('gpt-4o-mini')
+    expect(judgeModel.model).toBe('gpt-4o-mini')
+  })
+
+  it('sets judge base_url', () => {
+    const { judgeModel } = toJudgeConfig(base)
+    expect(judgeModel.base_url).toBe('https://api.openai.com/v1')
+  })
+
+  it('defaults base_url to OpenAI when omitted', () => {
+    const { judgeModel } = toJudgeConfig({ model: 'gpt-4o-mini' })
+    expect(judgeModel.base_url).toBe('https://api.openai.com/v1')
+  })
+
+  it('uses default rubric weights', () => {
+    const { judgeConfig } = toJudgeConfig(base)
+    expect(judgeConfig.rubric.accuracy).toBe(0.4)
+    expect(judgeConfig.rubric.completeness).toBe(0.4)
+    expect(judgeConfig.rubric.conciseness).toBe(0.2)
+  })
+
+  it('respects custom rubric weights', () => {
+    const { judgeConfig } = toJudgeConfig({
+      ...base,
+      rubric: { accuracy: 0.5, completeness: 0.3, conciseness: 0.2 },
+    })
+    expect(judgeConfig.rubric.accuracy).toBe(0.5)
+    expect(judgeConfig.rubric.completeness).toBe(0.3)
+  })
+
+  it('sets judgeModel id to "vitest-judge"', () => {
+    const { judgeModel } = toJudgeConfig(base)
+    expect(judgeModel.id).toBe('vitest-judge')
+  })
+})
+
+// ─── scoreSingleCase — deterministic scorers ──────────────────────────────────
+
+describe('scoreSingleCase — deterministic', () => {
+  const modelConfig = toModelConfig({
+    id: 'test',
+    model: 'dummy',
+    base_url: 'http://localhost:1/v1',
+    api_key: 'none',
+  })
+
+  it('scores exact match (correct) → 10', async () => {
+    // callModel is mocked at module level to return 'Paris'
+    const evalCase: EvalCase = {
+      id: 'test-exact',
+      prompt: 'What is the capital of France?',
+      criteria: 'Must say Paris',
+      scorer: 'exact',
+      expected: 'Paris',
+      tags: [],
+      judge_type: 'llm',
+      judge_style: 'standard',
+    }
+
+    const score = await scoreSingleCase(evalCase, modelConfig)
+    expect(score).toBe(10)
+  })
+
+  it('scores exact match (wrong answer) → 0', async () => {
+    const { callModel } = await import('../../providers/compat.js')
+    vi.mocked(callModel).mockResolvedValue({
+      text: 'London',
+      model_id: 'test',
+      input_tokens: 10,
+      output_tokens: 5,
+      latency_ms: 100,
+    })
+
+    const evalCase: EvalCase = {
+      id: 'test-exact-wrong',
+      prompt: 'What is the capital of France?',
+      criteria: 'Must say Paris',
+      scorer: 'exact',
+      expected: 'Paris',
+      tags: [],
+      judge_type: 'llm',
+      judge_style: 'standard',
+    }
+
+    const score = await scoreSingleCase(evalCase, modelConfig)
+    expect(score).toBe(0)
+  })
+
+  it('scores contains match (present) → 10', async () => {
+    const { callModel } = await import('../../providers/compat.js')
+    vi.mocked(callModel).mockResolvedValue({
+      text: 'The capital of France is Paris, a beautiful city.',
+      model_id: 'test',
+      input_tokens: 10,
+      output_tokens: 20,
+      latency_ms: 150,
+    })
+
+    const evalCase: EvalCase = {
+      id: 'test-contains',
+      prompt: 'Tell me about the capital of France',
+      criteria: 'Must mention Paris',
+      scorer: 'contains',
+      expected: 'Paris',
+      tags: [],
+      judge_type: 'llm',
+      judge_style: 'standard',
+    }
+
+    const score = await scoreSingleCase(evalCase, modelConfig)
+    expect(score).toBe(10)
+  })
+
+  it('throws when LLM scorer used without judge config', async () => {
+    const { callModel } = await import('../../providers/compat.js')
+    vi.mocked(callModel).mockResolvedValue({
+      text: 'Some answer',
+      model_id: 'test',
+      input_tokens: 10,
+      output_tokens: 10,
+      latency_ms: 100,
+    })
+
+    const evalCase: EvalCase = {
+      id: 'test-llm-no-judge',
+      prompt: 'Explain quantum entanglement',
+      criteria: 'Clear and accurate explanation',
+      scorer: 'llm',
+      tags: [],
+      judge_type: 'llm',
+      judge_style: 'standard',
+    }
+
+    await expect(scoreSingleCase(evalCase, modelConfig)).rejects.toThrow(
+      /requires LLM judge.*no judge config/
+    )
+  })
+})
+
+// ─── describeEvals shape ──────────────────────────────────────────────────────
+
+describe('describeEvals — export shape', () => {
+  it('exports describeEvals as a function', async () => {
+    const mod = await import('../vitest.js')
+    expect(typeof mod.describeEvals).toBe('function')
+  })
+
+  it('exports toModelConfig', async () => {
+    const mod = await import('../vitest.js')
+    expect(typeof mod.toModelConfig).toBe('function')
+  })
+
+  it('exports toJudgeConfig', async () => {
+    const mod = await import('../vitest.js')
+    expect(typeof mod.toJudgeConfig).toBe('function')
+  })
+
+  it('exports scoreSingleCase', async () => {
+    const mod = await import('../vitest.js')
+    expect(typeof mod.scoreSingleCase).toBe('function')
+  })
+})

--- a/src/integrations/index.ts
+++ b/src/integrations/index.ts
@@ -1,0 +1,8 @@
+/**
+ * verdict integrations — test runner adapters
+ *
+ * @module
+ */
+
+export { describeEvals } from './vitest.js'
+export type { DescribeEvalsOptions, VitestModelConfig, VitestJudgeConfig } from './vitest.js'

--- a/src/integrations/vitest.ts
+++ b/src/integrations/vitest.ts
@@ -1,0 +1,231 @@
+/**
+ * verdict/vitest — Vitest integration for verdict evals
+ *
+ * Registers eval cases as native Vitest test blocks so eval failures
+ * show up alongside your regular test failures.
+ *
+ * @example
+ * ```ts
+ * // model.test.ts
+ * import { describeEvals } from 'verdict/vitest'
+ *
+ * describeEvals('my-model quality', {
+ *   pack: './eval-packs/general.yaml',
+ *   model: {
+ *     id: 'local-llama',
+ *     base_url: 'http://localhost:11434/v1',
+ *     api_key: 'none',
+ *     model: 'llama3.1:8b',
+ *   },
+ *   threshold: 7.0,
+ *   judge: {
+ *     model: 'gpt-4o-mini',
+ *     base_url: 'https://api.openai.com/v1',
+ *     api_key: process.env.OPENAI_API_KEY,
+ *   },
+ * })
+ * ```
+ */
+
+import { describe, it, expect, afterAll } from 'vitest'
+import type { EvalCase, ModelConfig, JudgeConfig } from '../types/index.js'
+import { loadEvalPack } from '../core/config.js'
+import { callModel } from '../providers/compat.js'
+import { isDeterministic, scoreDeterministic } from '../judge/deterministic.js'
+import { judgeResponse } from '../judge/llm.js'
+
+// ─── Public types ─────────────────────────────────────────────────────────────
+
+export interface VitestModelConfig {
+  /** Unique identifier for this model */
+  id: string
+  /** OpenAI-compatible base URL (e.g. http://localhost:11434/v1) */
+  base_url?: string
+  /** API key — use 'none' for local models */
+  api_key?: string
+  /** Model name to use */
+  model: string
+  /** Provider shortcut ('ollama' | 'mlx') — alternative to base_url */
+  provider?: 'ollama' | 'mlx'
+  /** Max tokens for completions. Default: 1024 */
+  max_tokens?: number
+  /** Timeout in ms. Default: 30000 */
+  timeout_ms?: number
+}
+
+export interface VitestJudgeConfig {
+  /** Judge model name */
+  model: string
+  /** OpenAI-compatible base URL for the judge */
+  base_url?: string
+  /** Judge API key */
+  api_key?: string
+  /** Scoring rubric weights (must sum to 1.0) */
+  rubric?: {
+    accuracy?: number
+    completeness?: number
+    conciseness?: number
+  }
+}
+
+export interface DescribeEvalsOptions {
+  /** Path to eval pack YAML file, or inline eval cases array */
+  pack: string | EvalCase[]
+  /** Model configuration to test */
+  model: VitestModelConfig
+  /** Minimum average score (0-10) required to pass the suite. Default: 7.0 */
+  threshold?: number
+  /** Judge configuration (required for LLM-scored cases) */
+  judge?: VitestJudgeConfig
+  /** Maximum time for the entire eval run in ms. Default: 300000 (5 min) */
+  timeout?: number
+}
+
+// ─── Helpers ──────────────────────────────────────────────────────────────────
+
+/** Convert VitestModelConfig to internal ModelConfig */
+export function toModelConfig(m: VitestModelConfig): ModelConfig {
+  return {
+    id: m.id,
+    model: m.model,
+    base_url: m.base_url,
+    api_key: m.api_key ?? 'none',
+    provider: m.provider as ModelConfig['provider'],
+    tags: [],
+    timeout_ms: m.timeout_ms ?? 30_000,
+    max_tokens: m.max_tokens ?? 1024,
+    port: 8080,
+  }
+}
+
+/** Convert VitestJudgeConfig to internal JudgeConfig + judge ModelConfig */
+export function toJudgeConfig(j: VitestJudgeConfig): { judgeConfig: JudgeConfig; judgeModel: ModelConfig } {
+  const rubric = {
+    accuracy: j.rubric?.accuracy ?? 0.4,
+    completeness: j.rubric?.completeness ?? 0.4,
+    conciseness: j.rubric?.conciseness ?? 0.2,
+  }
+  const judgeConfig: JudgeConfig = {
+    model: j.model,
+    blind: true,
+    strategy: 'single',
+    rubric,
+  }
+  const judgeModel: ModelConfig = {
+    id: 'vitest-judge',
+    model: j.model,
+    base_url: j.base_url ?? 'https://api.openai.com/v1',
+    api_key: j.api_key ?? process.env.OPENAI_API_KEY ?? 'none',
+    tags: [],
+    timeout_ms: 30_000,
+    max_tokens: 256,
+    port: 8080,
+  }
+  return { judgeConfig, judgeModel }
+}
+
+/** Score a single eval case and return 0-10 */
+export async function scoreSingleCase(
+  evalCase: EvalCase,
+  modelConfig: ModelConfig,
+  judgeModel?: ModelConfig,
+  judgeConfig?: JudgeConfig,
+): Promise<number> {
+  const response = await callModel(modelConfig, evalCase.prompt, 0, undefined, evalCase.system_prompt)
+
+  // Use deterministic scorer when available
+  if (isDeterministic(evalCase.scorer)) {
+    const result = scoreDeterministic(
+      evalCase.scorer,
+      response.text ?? '',
+      evalCase.expected,
+      evalCase.schema,
+      evalCase.choices,
+      evalCase.scorer_code,
+    )
+    if (result !== null) return result.total
+  }
+
+  // Fall back to LLM judge
+  if (!judgeModel || !judgeConfig) {
+    throw new Error(
+      `Case '${evalCase.id}' requires LLM judge (scorer: '${evalCase.scorer}') but no judge config provided`
+    )
+  }
+
+  const score = await judgeResponse(judgeModel, judgeConfig, evalCase.prompt, evalCase.criteria, response.text ?? '')
+  return score.total
+}
+
+// ─── Main export ──────────────────────────────────────────────────────────────
+
+/**
+ * Register a verdict eval suite as Vitest tests.
+ *
+ * Runs all eval cases in a single `it()` block and reports per-case results.
+ * The suite fails if any case scores below `threshold`, or if the average
+ * score across all cases is below `threshold`.
+ */
+export function describeEvals(name: string, options: DescribeEvalsOptions): void {
+  const {
+    pack,
+    model,
+    threshold = 7.0,
+    judge,
+    timeout = 300_000,
+  } = options
+
+  const modelConfig = toModelConfig(model)
+  const judgeSetup = judge ? toJudgeConfig(judge) : undefined
+
+  describe(`verdict: ${name}`, () => {
+    const results: Array<{ id: string; score: number }> = []
+
+    it('eval cases', async () => {
+      // Load cases
+      let cases: EvalCase[]
+      if (Array.isArray(pack)) {
+        cases = pack
+      } else {
+        const loaded = await loadEvalPack(
+          pack,
+          // Minimal config stub required by loadEvalPack
+          { packs: [], models: [], judge: { model: 'none', blind: true, strategy: 'single', rubric: { accuracy: 0.4, completeness: 0.4, conciseness: 0.2 } }, name: '' } as never
+        )
+        cases = loaded.cases
+      }
+
+      expect(cases.length).toBeGreaterThan(0)
+
+      // Run each case
+      for (const c of cases) {
+        const score = await scoreSingleCase(
+          c,
+          modelConfig,
+          judgeSetup?.judgeModel,
+          judgeSetup?.judgeConfig,
+        )
+        results.push({ id: c.id, score })
+
+        // Per-case failure
+        if (score < threshold) {
+          throw new Error(
+            `eval: ${c.id} (${score.toFixed(1)}/10) — below threshold ${threshold}`
+          )
+        }
+      }
+    }, timeout)
+
+    afterAll(() => {
+      if (results.length === 0) return
+      const avg = results.reduce((s, r) => s + r.score, 0) / results.length
+      if (avg < threshold) {
+        const failing = results.filter(r => r.score < threshold)
+        throw new Error(
+          `eval suite "${name}": avg ${avg.toFixed(1)}/10 below threshold ${threshold} ` +
+          `(${failing.length}/${results.length} cases failed)`
+        )
+      }
+    })
+  })
+}

--- a/tsup.config.ts
+++ b/tsup.config.ts
@@ -29,4 +29,15 @@ export default defineConfig([
     shims: false,
     external: ['openai', 'better-sqlite3'],
   },
+  // Integrations bundle — `import { describeEvals } from 'verdict/vitest'`
+  {
+    entry: { integrations: 'src/integrations/index.ts' },
+    format: ['esm'],
+    target: 'node18',
+    outDir: 'dist',
+    clean: false,
+    dts: true,
+    shims: false,
+    external: ['openai', 'better-sqlite3', 'vitest'],
+  },
 ])


### PR DESCRIPTION
Closes #111

## What

Adds `verdict/vitest` integration so eval failures show up in your existing test suite alongside regular test failures.

## Usage

```ts
// model.test.ts
import { describeEvals } from 'verdict/vitest'

describeEvals('my-model quality', {
  pack: './eval-packs/general.yaml',
  model: {
    id: 'local-llama',
    base_url: 'http://localhost:11434/v1',
    api_key: 'none',
    model: 'llama3.1:8b',
  },
  threshold: 7.0,
  judge: {
    model: 'gpt-4o-mini',
    base_url: 'https://api.openai.com/v1',
    api_key: process.env.OPENAI_API_KEY,
  },
})
```

Output:
```
✓ verdict: my-model quality > eval cases
✗ verdict: my-model quality > eval cases — eval: factual-recall (5.1/10) below threshold 7.0
```

## Files added

- `src/integrations/vitest.ts` — `describeEvals()` + helpers (`toModelConfig`, `toJudgeConfig`, `scoreSingleCase`)
- `src/integrations/index.ts` — clean re-export
- `tsup.config.ts` — integrations bundle entry (external: vitest)
- `package.json` — `exports["./vitest"]` → `dist/integrations.js`

## Behavior

- Each eval pack runs in a single `it()` block (avoids test count explosion for large packs)
- Per-case failure with score and threshold in message
- `afterAll()` summary failure when avg < threshold
- Deterministic scorers (exact/contains/regex/etc.) run without LLM judge
- Clear error when LLM scorer used without judge config
- Works with inline `EvalCase[]` arrays as well as YAML paths

## Tests

22 tests: `toModelConfig` (7), `toJudgeConfig` (7), `scoreSingleCase` (4), export shape (4)
`pnpm typecheck` clean on all new files