### PR TITLE
feat: verdict costs — summarize API spend across runs

### DIFF
--- a/src/cli/commands/__tests__/costs.test.ts
+++ b/src/cli/commands/__tests__/costs.test.ts
@@ -1,0 +1,197 @@
+import { describe, it, expect, beforeEach } from 'vitest'
+import Database from 'better-sqlite3'
+import { initSchema, saveRunResult, queryCosts } from '../../../db/client.js'
+import type { RunResult } from '../../../types/index.js'
+
+function createTestDb(): Database.Database {
+  const db = new Database(':memory:')
+  db.pragma('foreign_keys = ON')
+  initSchema(db)
+  return db
+}
+
+function makeRunResult(overrides: Partial<RunResult> = {}): RunResult {
+  return {
+    run_id: 'test-run-1',
+    name: 'Test Run',
+    timestamp: '2026-03-25T12:00:00Z',
+    models: ['gpt-4o', 'claude-haiku'],
+    cases: [
+      {
+        case_id: 'case-1',
+        prompt: 'What is 2+2?',
+        criteria: 'Correct answer',
+        responses: {
+          'gpt-4o': {
+            model_id: 'gpt-4o',
+            text: '4',
+            input_tokens: 100,
+            output_tokens: 50,
+            latency_ms: 450,
+            cost_usd: 0.005,
+          },
+          'claude-haiku': {
+            model_id: 'claude-haiku',
+            text: '4',
+            input_tokens: 100,
+            output_tokens: 50,
+            latency_ms: 300,
+            cost_usd: 0.001,
+          },
+        },
+        scores: {
+          'gpt-4o': { accuracy: 10, completeness: 10, conciseness: 10, total: 9.8, reasoning: 'Correct' },
+          'claude-haiku': { accuracy: 10, completeness: 9, conciseness: 10, total: 9.5, reasoning: 'Correct' },
+        },
+        winner: 'gpt-4o',
+      },
+    ],
+    summary: {
+      'gpt-4o': {
+        model_id: 'gpt-4o',
+        avg_total: 9.8,
+        avg_accuracy: 10,
+        avg_completeness: 10,
+        avg_conciseness: 10,
+        avg_latency_ms: 450,
+        avg_tokens_per_sec: 0,
+        total_cost_usd: 0.142,
+        win_rate: 100,
+        wins: 1,
+        cases_run: 15,
+        avg_solve_rate: 0,
+      },
+      'claude-haiku': {
+        model_id: 'claude-haiku',
+        avg_total: 9.5,
+        avg_accuracy: 10,
+        avg_completeness: 9,
+        avg_conciseness: 10,
+        avg_latency_ms: 300,
+        avg_tokens_per_sec: 0,
+        total_cost_usd: 0.0156,
+        win_rate: 0,
+        wins: 0,
+        cases_run: 15,
+        avg_solve_rate: 0,
+      },
+    },
+    ...overrides,
+  }
+}
+
+describe('queryCosts', () => {
+  let db: Database.Database
+
+  beforeEach(() => {
+    db = createTestDb()
+  })
+
+  it('returns aggregated costs grouped by model', () => {
+    saveRunResult(db, makeRunResult(), 'general')
+
+    const rows = queryCosts(db, {})
+    expect(rows.length).toBe(2)
+
+    const gpt = rows.find(r => r.model_id === 'gpt-4o')
+    expect(gpt).toBeDefined()
+    expect(gpt!.runs).toBe(1)
+    expect(gpt!.cases).toBe(15)
+    expect(gpt!.cost).toBeCloseTo(0.142, 3)
+
+    const claude = rows.find(r => r.model_id === 'claude-haiku')
+    expect(claude).toBeDefined()
+    expect(claude!.cost).toBeCloseTo(0.0156, 3)
+  })
+
+  it('aggregates across multiple runs', () => {
+    saveRunResult(db, makeRunResult(), 'general')
+    saveRunResult(db, makeRunResult({ run_id: 'test-run-2' }), 'reasoning')
+
+    const rows = queryCosts(db, {})
+    const gpt = rows.find(r => r.model_id === 'gpt-4o')
+    expect(gpt).toBeDefined()
+    expect(gpt!.runs).toBe(2)
+    expect(gpt!.cases).toBe(30)
+    expect(gpt!.cost).toBeCloseTo(0.284, 3)
+  })
+
+  it('sorts by cost descending', () => {
+    saveRunResult(db, makeRunResult(), 'general')
+
+    const rows = queryCosts(db, {})
+    expect(rows.length).toBe(2)
+    // gpt-4o costs more, should be first
+    expect(rows[0].model_id).toBe('gpt-4o')
+    expect(rows[1].model_id).toBe('claude-haiku')
+  })
+
+  it('filters by --since time range', () => {
+    // Recent run: 1 day ago (always within 7d)
+    const recentTs = new Date(Date.now() - 24 * 60 * 60 * 1000).toISOString()
+    saveRunResult(db, makeRunResult({ timestamp: recentTs }), 'general')
+    // Old run: far in the past
+    saveRunResult(db, makeRunResult({
+      run_id: 'old-run',
+      timestamp: '2020-01-01T00:00:00Z',
+    }), 'general')
+
+    const rows = queryCosts(db, { since: '7d' })
+    const gpt = rows.find(r => r.model_id === 'gpt-4o')
+    // Should only include the recent run, not the 2020 run
+    expect(gpt).toBeDefined()
+    expect(gpt!.runs).toBe(1)
+  })
+
+  it('returns empty array when no data', () => {
+    const rows = queryCosts(db, {})
+    expect(rows.length).toBe(0)
+  })
+
+  it('handles models with zero cost', () => {
+    saveRunResult(db, makeRunResult({
+      models: ['qwen2.5:32b'],
+      cases: [
+        {
+          case_id: 'case-1',
+          prompt: 'What is 2+2?',
+          criteria: 'Correct answer',
+          responses: {
+            'qwen2.5:32b': {
+              model_id: 'qwen2.5:32b',
+              text: '4',
+              input_tokens: 10,
+              output_tokens: 5,
+              latency_ms: 1200,
+              cost_usd: 0,
+            },
+          },
+          scores: {
+            'qwen2.5:32b': { accuracy: 10, completeness: 10, conciseness: 10, total: 9.2, reasoning: 'Correct' },
+          },
+          winner: 'qwen2.5:32b',
+        },
+      ],
+      summary: {
+        'qwen2.5:32b': {
+          model_id: 'qwen2.5:32b',
+          avg_total: 9.2,
+          avg_accuracy: 10,
+          avg_completeness: 10,
+          avg_conciseness: 10,
+          avg_latency_ms: 1200,
+          avg_tokens_per_sec: 0,
+          total_cost_usd: 0,
+          win_rate: 100,
+          wins: 1,
+          cases_run: 1,
+          avg_solve_rate: 0,
+        },
+      },
+    }), 'general')
+
+    const rows = queryCosts(db, {})
+    expect(rows.length).toBe(1)
+    expect(rows[0].cost).toBe(0)
+  })
+})

--- a/src/cli/commands/costs.ts
+++ b/src/cli/commands/costs.ts
@@ -1,0 +1,92 @@
+/**
+ * `verdict costs` command — summarize API spend across eval runs.
+ */
+
+import chalk from 'chalk'
+import { getDb, initSchema, queryCosts, parseSince } from '../../db/client.js'
+import type { CostSummaryRow } from '../../db/client.js'
+
+export interface CostsCommandOpts {
+  since?: string
+  by?: string
+}
+
+/** Pad/truncate a string to fixed width. */
+function col(s: string, w: number): string {
+  return s.slice(0, w).padEnd(w)
+}
+
+/** Format cost with 4 decimal places for precision. */
+function formatCost(cost: number): string {
+  if (cost === 0) return '$0.0000'
+  return `$${cost.toFixed(4)}`
+}
+
+export async function costsCommand(opts: CostsCommandOpts): Promise<void> {
+  // Validate --since if provided
+  if (opts.since) {
+    const parsed = parseSince(opts.since)
+    if (!parsed) {
+      console.error(chalk.red(`  Invalid --since value: ${opts.since} (use e.g. 7d, 24h, 1w)`))
+      process.exit(1)
+    }
+  }
+
+  let db
+  try {
+    db = getDb()
+    initSchema(db)
+  } catch (err) {
+    console.error(chalk.red(`  Failed to open database: ${err instanceof Error ? err.message : err}`))
+    process.exit(1)
+  }
+
+  let rows: CostSummaryRow[] = []
+  try {
+    rows = queryCosts(db, {
+      since: opts.since,
+      groupBy: opts.by === 'model' ? 'model' : undefined,
+    })
+  } catch (err) {
+    console.error(chalk.red(`  Query failed: ${err instanceof Error ? err.message : err}`))
+    process.exit(1)
+  } finally {
+    db.close()
+  }
+
+  // Compute totals
+  const totalRuns = rows.reduce((sum, r) => sum + r.runs, 0)
+  const totalCases = rows.reduce((sum, r) => sum + r.cases, 0)
+  const totalCost = rows.reduce((sum, r) => sum + r.cost, 0)
+
+  // Check for no data
+  if (rows.length === 0 || totalCost === 0) {
+    console.log()
+    const label = opts.since ? ` (last ${opts.since})` : ''
+    console.log(chalk.dim(`  No cost data found${label}. Local models report $0 cost.`))
+    console.log()
+    return
+  }
+
+  const label = opts.since ? ` (last ${opts.since})` : ''
+  console.log()
+  console.log(chalk.bold(`  Cost Summary${label}`))
+  console.log()
+
+  // Header
+  const header = `  ${col('Model', 25)}${col('Runs', 8)}${col('Cases', 8)}${'Cost'}`
+  console.log(chalk.dim(header))
+  console.log(chalk.dim('  ' + '─'.repeat(50)))
+
+  for (const row of rows) {
+    console.log(
+      `  ${col(row.model_id, 25)}${col(String(row.runs), 8)}${col(String(row.cases), 8)}${formatCost(row.cost)}`
+    )
+  }
+
+  console.log(chalk.dim('  ' + '─'.repeat(50)))
+  console.log(
+    chalk.bold(`  ${col('Total', 25)}${col(String(totalRuns), 8)}${col(String(totalCases), 8)}${formatCost(totalCost)}`)
+  )
+  console.log()
+}

--- a/src/cli/index.ts
+++ b/src/cli/index.ts
@@ -6,6 +6,7 @@ import { initCommand } from './commands/init.js'
 import { compareCommand } from './commands/compare.js'
 import { baselineSaveCommand, baselineListCommand, baselineCompareCommand } from './commands/baseline.js'
 import { historyCommand } from './commands/history.js'
+import { costsCommand } from './commands/costs.js'
 import { routeCommand } from './commands/route.js'
 import { serveCommand } from './commands/serve.js'
 import { daemonStartCommand, daemonStopCommand, daemonStatusCommand, daemonLogsCommand, daemonWorkerCommand } from './commands/daemon.js'
@@ -98,6 +99,13 @@ program
   .option('--sort <field>', 'Sort by: date (default), score')
   .option('--trend', 'Show sparkline score trends per model')
   .action(historyCommand)
+
+program
+  .command('costs')
+  .description('Summarize API spend across eval runs')
+  .option('--since <time>', 'Filter by time (e.g., 7d, 30d, 90d)')
+  .option('--by <field>', 'Group by field (model)')
+  .action(costsCommand)
 
 program
   .command('route <prompt>')

--- a/src/db/client.ts
+++ b/src/db/client.ts
@@ -35,6 +35,20 @@ export interface JobRow {
   metadata: string | null
 }
 
+/** A row returned from the cost summary aggregation query. */
+export interface CostSummaryRow {
+  model_id: string
+  runs: number
+  cases: number
+  cost: number
+}
+
+/** Options for querying cost summary. */
+export interface CostOpts {
+  since?: string
+  groupBy?: 'model'
+}
+
 /** Options for querying eval history. */
 export interface HistoryOpts {
   modelId?: string
@@ -217,6 +231,29 @@ export function queryHistory(db: Database.Database, opts: HistoryOpts): EvalHist
   params.limit = limit
 
   return db.prepare(sql).all(params) as EvalHistoryRow[]
+}
+
+/**
+ * Aggregate cost data from eval_results, grouped by model.
+ * Returns one row per model with total runs, cases, and cost.
+ */
+export function queryCosts(db: Database.Database, opts: CostOpts): CostSummaryRow[] {
+  const conditions: string[] = []
+  const params: Record<string, string | number> = {}
+
+  if (opts.since) {
+    const sinceDate = parseSince(opts.since)
+    if (sinceDate) {
+      conditions.push('run_at >= @since')
+      params.since = sinceDate.toISOString()
+    }
+  }
+
+  const where = conditions.length > 0 ? `WHERE ${conditions.join(' AND ')}` : ''
+
+  const sql = `SELECT model_id, COUNT(DISTINCT run_id) as runs, SUM(cases_run) as cases, SUM(COALESCE(total_cost_usd, 0)) as cost FROM eval_results ${where} GROUP BY model_id ORDER BY cost DESC`
+
+  return db.prepare(sql).all(params) as CostSummaryRow[]
 }
 
 /** Detect provider from model id conventions. */


### PR DESCRIPTION
Closes #116

## Summary

Adds a new `verdict costs` command that aggregates API spend across eval runs.

## New command

```bash
# All time
verdict costs

# Last 7 days
verdict costs --since 7d

# Last 30 days, grouped by model
verdict costs --since 30d --by model
```

## Output
```
Cost Summary (last 7d)

  Model                    Runs    Cases   Cost
  ──────────────────────────────────────────────────
  gpt-4o-mini              12      180     $0.8640
  claude-haiku             8       120     $0.1872
  qwen2.5:32b              15      225     $0.0000
  ──────────────────────────────────────────────────
  Total                    35      525     $1.0512
```

## Changes
- `src/cli/commands/costs.ts` — new command with table display
- `src/db/client.ts` — `queryCosts()`, `CostSummaryRow`, `CostOpts`
- `src/cli/index.ts` — registered `verdict costs` with `--since` and `--by` flags
- `src/cli/commands/__tests__/costs.test.ts` — 6 unit tests (all passing)

## Test coverage
- Aggregates costs grouped by model
- Aggregates across multiple runs
- Sorts by cost descending
- Filters by `--since` time range
- Returns empty array when no data
- Handles zero-cost models (local inference)