### PR TITLE
feat(cli): verdict share — generate self-contained HTML report (closes #117)

### DIFF
--- a/src/cli/commands/__tests__/share.test.ts
+++ b/src/cli/commands/__tests__/share.test.ts
@@ -1,0 +1,252 @@
+import { describe, it, expect, beforeEach, afterEach, vi } from 'vitest'
+import path from 'path'
+import fs from 'fs'
+import os from 'os'
+
+// Mock ora
+vi.mock('ora', () => ({
+  default: () => ({
+    start: vi.fn().mockReturnThis(),
+    succeed: vi.fn().mockReturnThis(),
+    fail: vi.fn().mockReturnThis(),
+    text: '',
+  }),
+}))
+
+// Mock chalk to return plain strings
+vi.mock('chalk', () => ({
+  default: {
+    bold: (s: string) => s,
+    dim: (s: string) => s,
+    green: (s: string) => s,
+    red: (s: string) => s,
+    cyan: (s: string) => s,
+  },
+}))
+
+// Mock report.ts to avoid complex HTML generation in unit tests
+vi.mock('../report.js', () => ({
+  generateDetailedReport: vi.fn(() => '<html><body>Mock Report</body></html>'),
+}))
+
+const mockResult = {
+  run_id: 'test-run-2026-04-03',
+  name: 'Test Eval Run',
+  timestamp: '2026-04-03T06:00:00Z',
+  models: ['model-a', 'model-b'],
+  cases: [
+    {
+      case_id: 'case-1',
+      prompt: 'What is 2+2?',
+      criteria: 'Correct arithmetic',
+      responses: {
+        'model-a': { text: '4', latency_ms: 100, tokens_used: 10, cost_usd: 0 },
+      },
+      scores: {
+        'model-a': { total: 9.5, accuracy: 10, completeness: 9, conciseness: 9, reasoning: 'Correct', confidence: 0.95 },
+      },
+    },
+  ],
+  summary: {
+    'model-a': {
+      model_id: 'model-a',
+      avg_total: 9.5,
+      avg_accuracy: 10,
+      avg_completeness: 9,
+      avg_conciseness: 9,
+      avg_latency_ms: 100,
+      total_cost_usd: 0,
+      win_rate: 100,
+    },
+  },
+}
+
+describe('share command', () => {
+  let tmpDir: string
+  let originalCwd: string
+
+  beforeEach(() => {
+    tmpDir = fs.mkdtempSync(path.join(os.tmpdir(), 'verdict-share-test-'))
+    originalCwd = process.cwd()
+    process.chdir(tmpDir)
+  })
+
+  afterEach(() => {
+    process.chdir(originalCwd)
+    fs.rmSync(tmpDir, { recursive: true, force: true })
+  })
+
+  it('generates HTML from latest result in results/ dir', async () => {
+    // Create a results dir with a mock result
+    const resultsDir = path.join(tmpDir, 'results')
+    fs.mkdirSync(resultsDir)
+    fs.writeFileSync(
+      path.join(resultsDir, `${mockResult.run_id}.json`),
+      JSON.stringify(mockResult)
+    )
+
+    const { shareCommand } = await import('../share.js')
+    await shareCommand({})
+
+    const shareDir = path.join(tmpDir, 'verdict-share')
+    expect(fs.existsSync(shareDir)).toBe(true)
+
+    const outputFile = path.join(shareDir, `${mockResult.run_id}.html`)
+    expect(fs.existsSync(outputFile)).toBe(true)
+
+    const content = fs.readFileSync(outputFile, 'utf-8')
+    expect(content).toContain('Mock Report')
+  })
+
+  it('generates HTML from results/private/ dir (preferred over results/)', async () => {
+    // Create both dirs but put a different result in private
+    const publicDir = path.join(tmpDir, 'results')
+    const privateDir = path.join(tmpDir, 'results', 'private')
+    fs.mkdirSync(privateDir, { recursive: true })
+
+    fs.writeFileSync(
+      path.join(publicDir, 'old-run.json'),
+      JSON.stringify({ ...mockResult, run_id: 'old-run' })
+    )
+    fs.writeFileSync(
+      path.join(privateDir, 'new-run-2026-04-03.json'),
+      JSON.stringify({ ...mockResult, run_id: 'new-run-2026-04-03' })
+    )
+
+    const { shareCommand } = await import('../share.js')
+    await shareCommand({})
+
+    const shareDir = path.join(tmpDir, 'verdict-share')
+    // Private dir is checked first — newest file there
+    const files = fs.readdirSync(shareDir)
+    expect(files.some(f => f.includes('new-run'))).toBe(true)
+  })
+
+  it('writes to --output path when specified', async () => {
+    const resultsDir = path.join(tmpDir, 'results')
+    fs.mkdirSync(resultsDir)
+    fs.writeFileSync(
+      path.join(resultsDir, `${mockResult.run_id}.json`),
+      JSON.stringify(mockResult)
+    )
+
+    const outputPath = path.join(tmpDir, 'my-report.html')
+    const { shareCommand } = await import('../share.js')
+    await shareCommand({ output: outputPath })
+
+    expect(fs.existsSync(outputPath)).toBe(true)
+    const content = fs.readFileSync(outputPath, 'utf-8')
+    expect(content).toContain('Mock Report')
+  })
+
+  it('finds result by --run id', async () => {
+    const resultsDir = path.join(tmpDir, 'results')
+    fs.mkdirSync(resultsDir)
+
+    // Write two results
+    fs.writeFileSync(
+      path.join(resultsDir, 'run-alpha.json'),
+      JSON.stringify({ ...mockResult, run_id: 'run-alpha' })
+    )
+    fs.writeFileSync(
+      path.join(resultsDir, 'run-beta.json'),
+      JSON.stringify({ ...mockResult, run_id: 'run-beta' })
+    )
+
+    const { shareCommand } = await import('../share.js')
+    const outputPath = path.join(tmpDir, 'specific.html')
+    await shareCommand({ run: 'run-alpha', output: outputPath })
+
+    expect(fs.existsSync(outputPath)).toBe(true)
+  })
+
+  it('exits with error when no results found', async () => {
+    const exitSpy = vi.spyOn(process, 'exit').mockImplementation((() => {
+      throw new Error('process.exit called')
+    }) as any)
+
+    const { shareCommand } = await import('../share.js')
+
+    await expect(shareCommand({})).rejects.toThrow('process.exit called')
+    expect(exitSpy).toHaveBeenCalledWith(1)
+
+    exitSpy.mockRestore()
+  })
+
+  it('exits with error when --run id not found', async () => {
+    const exitSpy = vi.spyOn(process, 'exit').mockImplementation((() => {
+      throw new Error('process.exit called')
+    }) as any)
+
+    const { shareCommand } = await import('../share.js')
+
+    await expect(shareCommand({ run: 'nonexistent-run-id' })).rejects.toThrow('process.exit called')
+    expect(exitSpy).toHaveBeenCalledWith(1)
+
+    exitSpy.mockRestore()
+  })
+
+  it('exits with error when --gist used without GITHUB_TOKEN', async () => {
+    const resultsDir = path.join(tmpDir, 'results')
+    fs.mkdirSync(resultsDir)
+    fs.writeFileSync(
+      path.join(resultsDir, `${mockResult.run_id}.json`),
+      JSON.stringify(mockResult)
+    )
+
+    delete process.env.GITHUB_TOKEN
+
+    const exitSpy = vi.spyOn(process, 'exit').mockImplementation((() => {
+      throw new Error('process.exit called')
+    }) as any)
+
+    const { shareCommand } = await import('../share.js')
+
+    await expect(shareCommand({ gist: true })).rejects.toThrow('process.exit called')
+    expect(exitSpy).toHaveBeenCalledWith(1)
+
+    exitSpy.mockRestore()
+  })
+
+  it('uploads to GitHub Gist when --gist and GITHUB_TOKEN provided', async () => {
+    const resultsDir = path.join(tmpDir, 'results')
+    fs.mkdirSync(resultsDir)
+    fs.writeFileSync(
+      path.join(resultsDir, `${mockResult.run_id}.json`),
+      JSON.stringify(mockResult)
+    )
+
+    process.env.GITHUB_TOKEN = 'mock-token'
+
+    // Mock fetch
+    const mockRawUrl = `https://gist.githubusercontent.com/raw/verdict-${mockResult.run_id}.html`
+    const mockFetch = vi.fn().mockResolvedValue({
+      ok: true,
+      json: async () => ({
+        html_url: 'https://gist.github.com/abc123',
+        id: 'abc123',
+        files: {
+          [`verdict-${mockResult.run_id}.html`]: { raw_url: mockRawUrl },
+        },
+      }),
+    })
+    vi.stubGlobal('fetch', mockFetch)
+
+    const { shareCommand } = await import('../share.js')
+    await shareCommand({ gist: true })
+
+    expect(mockFetch).toHaveBeenCalledOnce()
+    const [url, opts] = mockFetch.mock.calls[0]
+    expect(url).toBe('https://api.github.com/gists')
+    expect(opts.method).toBe('POST')
+    expect(opts.headers.Authorization).toBe('token mock-token')
+
+    const body = JSON.parse(opts.body)
+    expect(body.public).toBe(false)
+    expect(Object.keys(body.files)).toHaveLength(1)
+    expect(Object.keys(body.files)[0]).toContain('verdict-')
+
+    delete process.env.GITHUB_TOKEN
+    vi.unstubAllGlobals()
+  })
+})

--- a/src/cli/commands/report.ts
+++ b/src/cli/commands/report.ts
@@ -64,7 +64,7 @@ export async function reportCommand(opts: ReportOptions): Promise<void> {
 /**
  * Generate detailed HTML report
  */
-function generateDetailedReport(result: RunResult): string {
+export function generateDetailedReport(result: RunResult): string {
   const date = new Date(result.timestamp).toLocaleString()
   const duration = calculateDuration(result)
   

--- a/src/cli/commands/share.ts
+++ b/src/cli/commands/share.ts
@@ -1,0 +1,219 @@
+import path from 'path'
+import fs from 'fs'
+import os from 'os'
+import chalk from 'chalk'
+import ora from 'ora'
+import type { RunResult } from '../../types/index.js'
+import { generateDetailedReport } from './report.js'
+
+interface ShareOptions {
+  run?: string
+  output?: string
+  gist?: boolean
+  open?: boolean
+}
+
+function findResultFiles(dir: string): string[] {
+  if (!fs.existsSync(dir)) return []
+  return fs.readdirSync(dir)
+    .filter(f => f.endsWith('.json') && !f.startsWith('.') && !f.includes('baseline'))
+    .sort()
+    .reverse()
+    .map(f => path.join(dir, f))
+}
+
+function findLatestResult(): string | null {
+  // Check local results/ dir first (private, then public)
+  const dirs = [
+    path.resolve('results/private'),
+    path.resolve('results'),
+  ]
+
+  for (const dir of dirs) {
+    const files = findResultFiles(dir)
+    if (files.length > 0) return files[0]
+  }
+
+  return null
+}
+
+function findResultByRunId(runId: string): string | null {
+  const dirs = [
+    path.resolve('results/private'),
+    path.resolve('results'),
+  ]
+
+  for (const dir of dirs) {
+    if (!fs.existsSync(dir)) continue
+    const files = fs.readdirSync(dir)
+      .filter(f => f.endsWith('.json'))
+      .map(f => path.join(dir, f))
+    const match = files.find(f => path.basename(f, '.json') === runId || f.includes(runId))
+    if (match) return match
+  }
+
+  return null
+}
+
+async function uploadToGist(html: string, runId: string, token: string): Promise<string | null> {
+  const filename = `verdict-${runId}.html`
+  const body = JSON.stringify({
+    description: `verdict eval report — ${runId}`,
+    public: false,
+    files: {
+      [filename]: { content: html },
+    },
+  })
+
+  const resp = await fetch('https://api.github.com/gists', {
+    method: 'POST',
+    headers: {
+      Authorization: `token ${token}`,
+      'Content-Type': 'application/json',
+      'User-Agent': 'verdict-cli',
+    },
+    body,
+  })
+
+  if (!resp.ok) {
+    const text = await resp.text()
+    throw new Error(`GitHub Gist API error ${resp.status}: ${text}`)
+  }
+
+  const data = await resp.json() as { html_url: string; id: string; files: Record<string, { raw_url: string }> }
+  // Return the raw URL so the HTML renders directly
+  const rawUrl = data.files[filename]?.raw_url
+  return rawUrl ?? data.html_url
+}
+
+async function openInBrowser(filePath: string): Promise<void> {
+  const { exec } = await import('child_process')
+  const url = `file://${path.resolve(filePath)}`
+
+  const browserCmd =
+    process.env.BROWSER ||
+    (process.platform === 'darwin' ? `open "${url}"` :
+     process.platform === 'win32' ? `start "${url}"` :
+     `xdg-open "${url}"`)
+
+  exec(browserCmd, (err) => {
+    if (err) {
+      // Silently ignore — we already printed the path
+    }
+  })
+}
+
+/**
+ * verdict share — generate a self-contained HTML report and optionally share via GitHub Gist
+ */
+export async function shareCommand(opts: ShareOptions): Promise<void> {
+  console.log()
+  console.log(chalk.bold('  verdict') + chalk.dim(' share'))
+  console.log()
+
+  // 1. Find result file
+  let resultPath: string | null
+
+  if (opts.run) {
+    resultPath = findResultByRunId(opts.run)
+    if (!resultPath) {
+      console.error(chalk.red(`  ✗ No result found for run: ${opts.run}`))
+      process.exit(1)
+    }
+  } else {
+    resultPath = findLatestResult()
+    if (!resultPath) {
+      console.error(chalk.red('  ✗ No result files found.'))
+      console.error(chalk.dim('    Run `verdict run` first to generate results.'))
+      process.exit(1)
+    }
+  }
+
+  const spinner = ora('Loading result...').start()
+
+  // 2. Parse result
+  let result: RunResult
+  try {
+    const content = fs.readFileSync(resultPath, 'utf-8')
+    result = JSON.parse(content)
+  } catch (err) {
+    spinner.fail(`Failed to parse result: ${err}`)
+    process.exit(1)
+  }
+
+  spinner.text = 'Generating self-contained HTML report...'
+
+  // 3. Generate HTML
+  const html = generateDetailedReport(result)
+
+  // 4. Determine output path
+  let outputPath: string
+  let isTempFile = false
+
+  if (opts.output) {
+    outputPath = path.resolve(opts.output)
+  } else if (opts.gist) {
+    // Write to temp file, upload, then optionally clean up
+    outputPath = path.join(os.tmpdir(), `verdict-${result.run_id}.html`)
+    isTempFile = true
+  } else {
+    // Default: write to ./verdict-share/ directory
+    const shareDir = path.resolve('verdict-share')
+    if (!fs.existsSync(shareDir)) fs.mkdirSync(shareDir, { recursive: true })
+    outputPath = path.join(shareDir, `${result.run_id}.html`)
+  }
+
+  // Ensure output directory exists
+  const outputDir = path.dirname(outputPath)
+  if (!fs.existsSync(outputDir)) fs.mkdirSync(outputDir, { recursive: true })
+
+  // Write HTML
+  fs.writeFileSync(outputPath, html)
+  spinner.succeed(`Generated: ${chalk.cyan(path.relative(process.cwd(), outputPath))}`)
+
+  // 5. Upload to GitHub Gist if requested
+  if (opts.gist) {
+    const token = process.env.GITHUB_TOKEN
+    if (!token) {
+      console.error(chalk.red('\n  ✗ --gist requires GITHUB_TOKEN environment variable'))
+      process.exit(1)
+    }
+
+    const gistSpinner = ora('Uploading to GitHub Gist...').start()
+    try {
+      const gistUrl = await uploadToGist(html, result.run_id, token)
+      gistSpinner.succeed('Uploaded to GitHub Gist')
+      console.log()
+      console.log(chalk.green('  ✓ Shareable URL:'))
+      console.log(`    ${chalk.cyan(gistUrl)}`)
+
+      // Clean up temp file
+      if (isTempFile && fs.existsSync(outputPath)) {
+        fs.unlinkSync(outputPath)
+      }
+    } catch (err) {
+      gistSpinner.fail(`Gist upload failed: ${err}`)
+      // Still print the local file path
+      console.log(chalk.dim(`\n  Local file saved at: ${outputPath}`))
+    }
+  } else {
+    // Local output
+    const absPath = path.resolve(outputPath)
+    const fileUrl = `file://${absPath}`
+
+    console.log()
+    console.log(chalk.green('  ✓ Report ready!'))
+    console.log(`    Run: ${chalk.dim(result.run_id)}`)
+    console.log(`    Models: ${chalk.dim(result.models.join(', '))}`)
+    console.log(`    Cases: ${chalk.dim(result.cases.length)}`)
+    console.log()
+    console.log(`    Open: ${chalk.cyan(fileUrl)}`)
+    console.log()
+    console.log(chalk.dim('  Tip: Share via Gist with --gist (requires GITHUB_TOKEN)'))
+
+    // Auto-open if --open flag or $BROWSER is set
+    if (opts.open || process.env.BROWSER) {
+      await openInBrowser(outputPath)
+    }
+  }
+}

--- a/src/cli/index.ts
+++ b/src/cli/index.ts
@@ -14,6 +14,7 @@ import { validateCommand } from './commands/validate.js'
 import { publishCommand } from './commands/publish.js'
 import { leaderboardCommand } from './commands/leaderboard.js'
 import { reportCommand } from './commands/report.js'
+import { shareCommand } from './commands/share.js'
 import { evalAddCommand, evalRemoveCommand, evalListCommand, evalInitCommand } from './commands/eval.js'
 import { contributeCommand } from './commands/contribute.js'
 // Dashboard CLI removed - use custom build system in dashboard/build/ instead
@@ -180,6 +181,16 @@ program
   .option('--result <path>', 'Path to result JSON file', { required: true })
   .option('--output <path>', 'Output HTML file path (default: docs/runs/<run_id>.html)')
   .action((opts: any) => reportCommand({ result: opts.result, output: opts.output }))
+
+program
+  .command('share')
+  .description('Generate a self-contained HTML report from the latest (or specified) run')
+  .option('--run <id>', 'Run ID to share (default: latest)')
+  .option('--output <path>', 'Output file path (default: verdict-share/<run_id>.html)')
+  .option('--gist', 'Upload to GitHub Gist and return URL (requires GITHUB_TOKEN)')
+  .option('--open', 'Open the report in browser after generating')
+  .action((opts: any) => shareCommand({ run: opts.run, output: opts.output, gist: opts.gist, open: opts.open }))
+
 const evalCmd = program
   .command('eval')
   .description('Manage the named eval registry')


### PR DESCRIPTION
## What

Adds `verdict share` — generates a self-contained HTML report from your latest eval run and optionally uploads to GitHub Gist.

```bash
# Generate HTML from latest run
verdict share

# Save to specific path
verdict share --output report.html

# Share specific run
verdict share --run 2026-04-03T06-00-00

# Upload to GitHub Gist (returns URL)
GITHUB_TOKEN=ghp_xxx verdict share --gist

# Auto-open in browser
verdict share --open
```

## Implementation

- `src/cli/commands/share.ts` — new command
- Exported `generateDetailedReport()` from `report.ts` for reuse (was private)
- Registered in `src/cli/index.ts`
- Searches `results/private/` first, then `results/` (prefers private results)
- `--gist` uses `POST /gists` API — secret gist, returns raw URL for direct HTML render

## Tests

8 tests in `src/cli/commands/__tests__/share.test.ts`:
- Latest result discovery
- `results/private/` priority over `results/`
- `--output` path
- `--run` ID lookup
- Error on no results
- Error on missing run ID
- Error on `--gist` without `GITHUB_TOKEN`
- Gist upload flow (mock fetch)

All 8 passing. Pre-existing SQLite binding failures unaffected.

Closes #117