### PR TITLE
feat(cli): verdict import --hf — import HuggingFace datasets as eval packs (closes #115)

### DIFF
--- a/src/cli/commands/__tests__/import.test.ts
+++ b/src/cli/commands/__tests__/import.test.ts
@@ -1,0 +1,311 @@
+import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest'
+import fs from 'fs'
+import path from 'path'
+import os from 'os'
+import { detectFields, importCommand } from '../import.js'
+
+// ─── detectFields tests ───────────────────────────────────────────────────────
+
+describe('detectFields', () => {
+  it('detects question/answer (GSM8K pattern)', () => {
+    const row = { question: 'What is 2+2?', answer: '#### 4' }
+    const { inputField, outputField } = detectFields(row)
+    expect(inputField).toBe('question')
+    expect(outputField).toBe('answer')
+  })
+
+  it('detects prompt/completion pattern', () => {
+    const row = { prompt: 'Tell me about AI', completion: 'AI is...' }
+    const { inputField, outputField } = detectFields(row)
+    expect(inputField).toBe('prompt')
+    expect(outputField).toBe('completion')
+  })
+
+  it('detects input/output pattern', () => {
+    const row = { input: 'Sort this list', output: '[1,2,3]', metadata: {} }
+    const { inputField, outputField } = detectFields(row)
+    expect(inputField).toBe('input')
+    expect(outputField).toBe('output')
+  })
+
+  it('detects instruction/response pattern', () => {
+    const row = { instruction: 'Translate to French', response: 'Bonjour' }
+    const { inputField, outputField } = detectFields(row)
+    expect(inputField).toBe('instruction')
+    expect(outputField).toBe('response')
+  })
+
+  it('returns null for unknown fields', () => {
+    const row = { foo: 'bar', baz: 'qux' }
+    const { inputField, outputField } = detectFields(row)
+    expect(inputField).toBeNull()
+    expect(outputField).toBeNull()
+  })
+
+  it('handles empty row', () => {
+    const { inputField, outputField } = detectFields({})
+    expect(inputField).toBeNull()
+    expect(outputField).toBeNull()
+  })
+
+  it('prioritizes question over text', () => {
+    const row = { text: 'some text', question: 'a question', answer: 'yes' }
+    const { inputField } = detectFields(row)
+    expect(inputField).toBe('question')
+  })
+
+  it('detects query field', () => {
+    const row = { query: 'Find me X', label: 'relevant' }
+    const { inputField, outputField } = detectFields(row)
+    expect(inputField).toBe('query')
+    expect(outputField).toBe('label')
+  })
+})
+
+// ─── importCommand tests ──────────────────────────────────────────────────────
+
+// Mock fetch globally
+const mockFetch = vi.fn()
+vi.stubGlobal('fetch', mockFetch)
+
+// Mock ora
+vi.mock('ora', () => ({
+  default: () => ({
+    start: () => ({ succeed: vi.fn(), fail: vi.fn(), stop: vi.fn() }),
+    succeed: vi.fn(),
+    fail: vi.fn(),
+    stop: vi.fn(),
+  }),
+}))
+
+function makeSplitsResponse(dataset: string) {
+  return {
+    splits: [
+      { dataset, config: 'main', split: 'train' },
+      { dataset, config: 'main', split: 'test' },
+    ],
+  }
+}
+
+function makeRowsResponse(rows: Record<string, unknown>[]) {
+  return {
+    rows: rows.map((row, idx) => ({ row_idx: idx, row, truncated_cells: [] })),
+    num_rows_total: rows.length,
+  }
+}
+
+const GSM8K_ROWS = [
+  { question: "Janet's ducks lay 16 eggs per day. She eats 3. How much does she make selling the rest at $2 each?", answer: 'She sells 13 eggs.\n#### 26' },
+  { question: 'A robe takes 2 bolts. Half as much white. Total?', answer: '3 bolts.\n#### 3' },
+  { question: 'James has 3 children. Each needs 4 sets of clothes. Each costs $6. Total?', answer: '#### 72' },
+]
+
+beforeEach(() => {
+  mockFetch.mockReset()
+})
+
+afterEach(() => {
+  vi.restoreAllMocks()
+})
+
+describe('importCommand', () => {
+  it('exits with error when --hf is missing', async () => {
+    const mockExit = vi.spyOn(process, 'exit').mockImplementation((_code?: string | number | null) => { throw new Error('exit') })
+    const mockError = vi.spyOn(console, 'error').mockImplementation(() => {})
+
+    await expect(importCommand({ dryRun: true })).rejects.toThrow('exit')
+    expect(mockExit).toHaveBeenCalledWith(1)
+
+    mockExit.mockRestore()
+    mockError.mockRestore()
+  })
+
+  it('dry run — does not write files', async () => {
+    mockFetch
+      .mockResolvedValueOnce({ ok: true, json: async () => makeSplitsResponse('openai/gsm8k') })
+      .mockResolvedValueOnce({ ok: true, json: async () => makeRowsResponse(GSM8K_ROWS) })
+
+    const tmpDir = fs.mkdtempSync(path.join(os.tmpdir(), 'verdict-import-test-'))
+    const outputPath = path.join(tmpDir, 'gsm8k-out.yaml')
+
+    const mockExit = vi.spyOn(process, 'exit').mockImplementation((_code?: string | number | null) => { throw new Error('exit') })
+    vi.spyOn(console, 'log').mockImplementation(() => {})
+    vi.spyOn(console, 'error').mockImplementation(() => {})
+
+    await expect(importCommand({
+      hf: 'openai/gsm8k',
+      split: 'test',
+      max: 3,
+      output: outputPath,
+      dryRun: true,
+    })).rejects.toThrow('exit')
+
+    expect(fs.existsSync(outputPath)).toBe(false)
+    mockExit.mockRestore()
+  })
+
+  it('writes yaml with correct structure for GSM8K', async () => {
+    mockFetch
+      .mockResolvedValueOnce({ ok: true, json: async () => makeSplitsResponse('openai/gsm8k') })
+      .mockResolvedValueOnce({ ok: true, json: async () => makeRowsResponse(GSM8K_ROWS) })
+
+    const tmpDir = fs.mkdtempSync(path.join(os.tmpdir(), 'verdict-import-test-'))
+    const outputPath = path.join(tmpDir, 'gsm8k.yaml')
+
+    vi.spyOn(console, 'log').mockImplementation(() => {})
+    vi.spyOn(console, 'error').mockImplementation(() => {})
+
+    await importCommand({
+      hf: 'openai/gsm8k',
+      split: 'test',
+      max: 3,
+      output: outputPath,
+    })
+
+    expect(fs.existsSync(outputPath)).toBe(true)
+    const content = fs.readFileSync(outputPath, 'utf8')
+    expect(content).toContain('name:')
+    expect(content).toContain('cases:')
+    expect(content).toContain('gsm8k-test-0001')
+    expect(content).toContain('prompt:')
+  })
+
+  it('strips #### markers from GSM8K answers', async () => {
+    mockFetch
+      .mockResolvedValueOnce({ ok: true, json: async () => makeSplitsResponse('openai/gsm8k') })
+      .mockResolvedValueOnce({ ok: true, json: async () => makeRowsResponse([GSM8K_ROWS[2]]) })
+
+    const tmpDir = fs.mkdtempSync(path.join(os.tmpdir(), 'verdict-import-test-'))
+    const outputPath = path.join(tmpDir, 'gsm8k-answer.yaml')
+
+    vi.spyOn(console, 'log').mockImplementation(() => {})
+
+    await importCommand({
+      hf: 'openai/gsm8k',
+      split: 'test',
+      max: 1,
+      output: outputPath,
+    })
+
+    const content = fs.readFileSync(outputPath, 'utf8')
+    // Should have extracted just '72' from '#### 72'
+    expect(content).toContain('72')
+    expect(content).not.toContain('####')
+  })
+
+  it('uses --config to pick non-default HF config', async () => {
+    const socialSplits = {
+      splits: [
+        { dataset: 'openai/gsm8k', config: 'socratic', split: 'train' },
+        { dataset: 'openai/gsm8k', config: 'socratic', split: 'test' },
+      ],
+    }
+    mockFetch
+      .mockResolvedValueOnce({ ok: true, json: async () => socialSplits })
+      .mockResolvedValueOnce({ ok: true, json: async () => makeRowsResponse(GSM8K_ROWS.slice(0, 1)) })
+
+    const tmpDir = fs.mkdtempSync(path.join(os.tmpdir(), 'verdict-import-test-'))
+    const outputPath = path.join(tmpDir, 'gsm8k-socratic.yaml')
+
+    vi.spyOn(console, 'log').mockImplementation(() => {})
+
+    await importCommand({
+      hf: 'openai/gsm8k',
+      config: 'socratic',
+      split: 'test',
+      max: 1,
+      output: outputPath,
+    })
+
+    // Check that the second fetch used the correct config
+    const secondCallUrl = mockFetch.mock.calls[1][0] as string
+    expect(secondCallUrl).toContain('config=socratic')
+    expect(secondCallUrl).toContain('split=test')
+  })
+
+  it('exits gracefully when split not found in config', async () => {
+    mockFetch.mockResolvedValueOnce({
+      ok: true,
+      json: async () => makeSplitsResponse('openai/gsm8k'),
+    })
+
+    const mockExit = vi.spyOn(process, 'exit').mockImplementation((_code?: string | number | null) => { throw new Error('exit') })
+    vi.spyOn(console, 'log').mockImplementation(() => {})
+    vi.spyOn(console, 'error').mockImplementation(() => {})
+
+    await expect(importCommand({
+      hf: 'openai/gsm8k',
+      split: 'validation',  // doesn't exist
+      max: 5,
+    })).rejects.toThrow('exit')
+
+    expect(mockExit).toHaveBeenCalledWith(1)
+    mockExit.mockRestore()
+  })
+
+  it('handles HuggingFace API error gracefully', async () => {
+    mockFetch.mockResolvedValueOnce({
+      ok: false,
+      status: 404,
+      text: async () => '{"error": "Not Found"}',
+    })
+
+    const mockExit = vi.spyOn(process, 'exit').mockImplementation((_code?: string | number | null) => { throw new Error('exit') })
+    vi.spyOn(console, 'log').mockImplementation(() => {})
+    vi.spyOn(console, 'error').mockImplementation(() => {})
+
+    await expect(importCommand({
+      hf: 'nonexistent/dataset',
+      split: 'test',
+      max: 5,
+    })).rejects.toThrow('exit')
+
+    expect(mockExit).toHaveBeenCalledWith(1)
+    mockExit.mockRestore()
+  })
+
+  it('uses custom --criteria when provided', async () => {
+    mockFetch
+      .mockResolvedValueOnce({ ok: true, json: async () => makeSplitsResponse('openai/gsm8k') })
+      .mockResolvedValueOnce({ ok: true, json: async () => makeRowsResponse(GSM8K_ROWS.slice(0, 1)) })
+
+    const tmpDir = fs.mkdtempSync(path.join(os.tmpdir(), 'verdict-import-test-'))
+    const outputPath = path.join(tmpDir, 'custom-criteria.yaml')
+
+    vi.spyOn(console, 'log').mockImplementation(() => {})
+
+    await importCommand({
+      hf: 'openai/gsm8k',
+      split: 'test',
+      max: 1,
+      output: outputPath,
+      criteria: 'Must show step-by-step reasoning',
+    })
+
+    const content = fs.readFileSync(outputPath, 'utf8')
+    expect(content).toContain('Must show step-by-step reasoning')
+  })
+
+  it('includes source tags in cases', async () => {
+    mockFetch
+      .mockResolvedValueOnce({ ok: true, json: async () => makeSplitsResponse('openai/gsm8k') })
+      .mockResolvedValueOnce({ ok: true, json: async () => makeRowsResponse(GSM8K_ROWS.slice(0, 1)) })
+
+    const tmpDir = fs.mkdtempSync(path.join(os.tmpdir(), 'verdict-import-test-'))
+    const outputPath = path.join(tmpDir, 'tagged.yaml')
+
+    vi.spyOn(console, 'log').mockImplementation(() => {})
+
+    await importCommand({
+      hf: 'openai/gsm8k',
+      split: 'test',
+      max: 1,
+      output: outputPath,
+    })
+
+    const content = fs.readFileSync(outputPath, 'utf8')
+    expect(content).toContain('source:huggingface')
+    expect(content).toContain('dataset:openai/gsm8k')
+    expect(content).toContain('split:test')
+  })
+})

--- a/src/cli/commands/import.ts
+++ b/src/cli/commands/import.ts
@@ -1,0 +1,299 @@
+import fs from 'fs'
+import path from 'path'
+import chalk from 'chalk'
+import ora from 'ora'
+import yaml from 'js-yaml'
+
+// ─── HuggingFace API types ────────────────────────────────────────────────────
+
+interface HFSplitsResponse {
+  splits: Array<{ dataset: string; config: string; split: string }>
+}
+
+interface HFRowsResponse {
+  rows: Array<{ row_idx: number; row: Record<string, unknown> }>
+  num_rows_total?: number
+}
+
+// ─── Field detection ──────────────────────────────────────────────────────────
+
+/**
+ * Common field name patterns across popular HuggingFace datasets.
+ * Priority order matters — first match wins.
+ */
+const INPUT_FIELD_CANDIDATES = [
+  'question', 'prompt', 'input', 'instruction', 'query', 'text',
+  'premise', 'sentence', 'context', 'problem',
+]
+
+const OUTPUT_FIELD_CANDIDATES = [
+  'answer', 'output', 'completion', 'response', 'label', 'solution',
+  'target', 'gold', 'hypothesis', 'choices',
+]
+
+export function detectFields(row: Record<string, unknown>): {
+  inputField: string | null
+  outputField: string | null
+} {
+  const keys = Object.keys(row)
+
+  const inputField = INPUT_FIELD_CANDIDATES.find(f => keys.includes(f)) ?? null
+  const outputField = OUTPUT_FIELD_CANDIDATES.find(f => keys.includes(f)) ?? null
+
+  return { inputField, outputField }
+}
+
+/**
+ * Extract the final numeric answer from GSM8K-style "#### 18" answers.
+ * Returns the clean expected value (just the number) or the full text if no marker.
+ */
+function extractExpected(raw: unknown): string {
+  if (typeof raw !== 'string') return String(raw)
+  const markerMatch = raw.match(/####\s*(.+)$/)
+  if (markerMatch) return markerMatch[1].trim()
+  return raw.trim()
+}
+
+// ─── HuggingFace API helpers ──────────────────────────────────────────────────
+
+const HF_API_BASE = 'https://datasets-server.huggingface.co'
+
+async function fetchJSON<T>(url: string): Promise<T> {
+  const resp = await fetch(url)
+  if (!resp.ok) {
+    const body = await resp.text().catch(() => '')
+    throw new Error(`HuggingFace API error ${resp.status}: ${body.slice(0, 200)}`)
+  }
+  return resp.json() as Promise<T>
+}
+
+/**
+ * Get available splits for a dataset. Returns the first config's splits
+ * (most datasets have a single 'main' config).
+ */
+async function fetchSplits(dataset: string): Promise<Array<{ config: string; split: string }>> {
+  const url = `${HF_API_BASE}/splits?dataset=${encodeURIComponent(dataset)}`
+  const data = await fetchJSON<HFSplitsResponse>(url)
+  return data.splits.map(s => ({ config: s.config, split: s.split }))
+}
+
+/**
+ * Fetch rows from the HuggingFace Datasets Server API.
+ * Handles pagination for datasets that require --max > 100.
+ */
+async function fetchRows(
+  dataset: string,
+  config: string,
+  split: string,
+  max: number,
+): Promise<Array<Record<string, unknown>>> {
+  const PAGE_SIZE = 100
+  const rows: Array<Record<string, unknown>> = []
+  let offset = 0
+
+  while (rows.length < max) {
+    const batchSize = Math.min(PAGE_SIZE, max - rows.length)
+    const url = `${HF_API_BASE}/rows?dataset=${encodeURIComponent(dataset)}&config=${encodeURIComponent(config)}&split=${encodeURIComponent(split)}&offset=${offset}&length=${batchSize}`
+    const data = await fetchJSON<HFRowsResponse>(url)
+
+    if (!data.rows || data.rows.length === 0) break
+    rows.push(...data.rows.map(r => r.row))
+    offset += data.rows.length
+
+    // If we got fewer rows than requested, we've hit the end
+    if (data.rows.length < batchSize) break
+  }
+
+  return rows
+}
+
+// ─── Import command ───────────────────────────────────────────────────────────
+
+export interface ImportOptions {
+  hf?: string
+  split?: string
+  config?: string   // HF dataset config (e.g., 'main', 'socratic')
+  max?: number
+  output?: string
+  inputField?: string
+  outputField?: string
+  criteria?: string
+  scorer?: string
+  dryRun?: boolean
+}
+
+export async function importCommand(opts: ImportOptions): Promise<void> {
+  console.log()
+  console.log(chalk.bold('  verdict') + chalk.dim(' import'))
+  console.log()
+
+  if (!opts.hf) {
+    console.error(chalk.red('  ✗ --hf <dataset-name> is required'))
+    console.log()
+    console.log('  ' + chalk.dim('Example:'))
+    console.log(`    ${chalk.cyan('verdict import --hf openai/gsm8k --split test --max 50 --output eval-packs/gsm8k.yaml')}`)
+    process.exit(1)
+  }
+
+  const max = opts.max ?? 100
+  const split = opts.split ?? 'test'
+  const outputPath = opts.output
+    ? path.resolve(opts.output)
+    : path.resolve(`eval-packs/${opts.hf.replace('/', '-')}-${split}.yaml`)
+
+  // ── 1. Discover configs ───────────────────────────────────────────────────
+  const spinner = ora(`  Discovering dataset splits for ${chalk.bold(opts.hf)}…`).start()
+  let splits: Array<{ config: string; split: string }> = []
+
+  try {
+    splits = await fetchSplits(opts.hf)
+    spinner.succeed(`  Found ${splits.length} split(s)`)
+  } catch (err) {
+    spinner.fail(`  Failed to fetch dataset info`)
+    console.error(chalk.red(`  ✗ ${(err as Error).message}`))
+    console.log()
+    console.log(chalk.dim('  Is this dataset public and available via the HuggingFace Datasets Server?'))
+    console.log(chalk.dim('  Check: https://datasets-server.huggingface.co/splits?dataset=' + encodeURIComponent(opts.hf)))
+    process.exit(1)
+  }
+
+  // Pick config: prefer user-supplied, then 'main', then first available
+  let hfConfig = opts.config
+  if (!hfConfig) {
+    const mainConfig = splits.find(s => s.config === 'main')
+    hfConfig = mainConfig?.config ?? splits[0]?.config
+  }
+  if (!hfConfig) {
+    console.error(chalk.red('  ✗ No configs found for this dataset'))
+    process.exit(1)
+  }
+
+  // Validate split exists in chosen config
+  const validSplits = splits.filter(s => s.config === hfConfig).map(s => s.split)
+  if (!validSplits.includes(split)) {
+    console.error(chalk.red(`  ✗ Split '${split}' not found in config '${hfConfig}'`))
+    console.log(chalk.dim(`  Available splits: ${validSplits.join(', ')}`))
+    process.exit(1)
+  }
+
+  console.log(chalk.dim(`  Config: ${hfConfig} | Split: ${split} | Max: ${max}`))
+  console.log()
+
+  // ── 2. Fetch rows ─────────────────────────────────────────────────────────
+  const fetchSpinner = ora(`  Fetching up to ${max} rows…`).start()
+  let rawRows: Array<Record<string, unknown>> = []
+
+  try {
+    rawRows = await fetchRows(opts.hf, hfConfig, split, max)
+    fetchSpinner.succeed(`  Fetched ${rawRows.length} rows`)
+  } catch (err) {
+    fetchSpinner.fail('  Failed to fetch rows')
+    console.error(chalk.red(`  ✗ ${(err as Error).message}`))
+    process.exit(1)
+  }
+
+  if (rawRows.length === 0) {
+    console.error(chalk.red('  ✗ No rows returned from HuggingFace API'))
+    process.exit(1)
+  }
+
+  // ── 3. Detect fields ──────────────────────────────────────────────────────
+  const sampleRow = rawRows[0]
+  const detected = detectFields(sampleRow)
+
+  const inputField = opts.inputField ?? detected.inputField
+  const outputField = opts.outputField ?? detected.outputField
+
+  console.log()
+  console.log('  ' + chalk.bold('Field mapping'))
+  if (inputField) {
+    console.log(`  ${chalk.green('✓')} Input field:  ${chalk.cyan(inputField)}`)
+  } else {
+    console.log(`  ${chalk.yellow('⚠')} Input field:  ${chalk.yellow('not detected')} — use --input-field to specify`)
+  }
+  if (outputField) {
+    console.log(`  ${chalk.green('✓')} Output field: ${chalk.cyan(outputField)}`)
+  } else {
+    console.log(`  ${chalk.dim('–')} Output field: ${chalk.dim('not detected')} — evals will use LLM judge only`)
+  }
+  console.log()
+  console.log('  ' + chalk.dim('Available fields: ' + Object.keys(sampleRow).join(', ')))
+
+  if (!inputField) {
+    console.error(chalk.red('\n  ✗ Cannot determine input field. Use --input-field <name> to specify.'))
+    process.exit(1)
+  }
+
+  // ── 4. Convert rows to eval cases ─────────────────────────────────────────
+  const datasetShortName = opts.hf.split('/').pop() ?? opts.hf
+  const defaultCriteria = opts.criteria
+    ?? `Accurate, correct response to the question. Judge on factual correctness and completeness.`
+  const scorer = opts.scorer ?? (outputField ? 'llm' : 'llm')
+
+  interface EvalCaseYaml {
+    id: string
+    prompt: string
+    criteria: string
+    expected?: string
+    scorer: string
+    tags: string[]
+  }
+
+  const cases: EvalCaseYaml[] = rawRows.map((row, idx) => {
+    const prompt = String(row[inputField] ?? '').trim()
+    const rawExpected = outputField ? row[outputField] : undefined
+    const expected = rawExpected !== undefined ? extractExpected(rawExpected) : undefined
+
+    const c: EvalCaseYaml = {
+      id: `${datasetShortName}-${split}-${String(idx + 1).padStart(4, '0')}`,
+      prompt,
+      criteria: defaultCriteria,
+      scorer,
+      tags: [`source:huggingface`, `dataset:${opts.hf}`, `split:${split}`],
+    }
+    if (expected !== undefined) {
+      c.expected = expected
+    }
+    return c
+  })
+
+  // ── 5. Preview (dry run or sample) ────────────────────────────────────────
+  console.log('  ' + chalk.bold('Sample case'))
+  const sample = cases[0]
+  console.log(chalk.dim('  id:       ') + sample.id)
+  console.log(chalk.dim('  prompt:   ') + sample.prompt.slice(0, 80) + (sample.prompt.length > 80 ? '…' : ''))
+  if (sample.expected) {
+    console.log(chalk.dim('  expected: ') + sample.expected.slice(0, 60) + (sample.expected.length > 60 ? '…' : ''))
+  }
+  console.log(chalk.dim('  scorer:   ') + sample.scorer)
+  console.log()
+
+  if (opts.dryRun) {
+    console.log(chalk.yellow('  Dry run — no file written.'))
+    console.log(chalk.dim(`  Would write ${cases.length} cases to: ${outputPath}`))
+    process.exit(0)
+  }
+
+  // ── 6. Write YAML ─────────────────────────────────────────────────────────
+  const packName = `${opts.hf} (${split}, ${cases.length} cases)`
+  const pack = {
+    name: packName,
+    version: '1.0.0',
+    description: `Imported from HuggingFace: ${opts.hf} — ${split} split, ${cases.length} cases. Auto-generated by verdict import.`,
+    cases,
+  }
+
+  const outputDir = path.dirname(outputPath)
+  if (!fs.existsSync(outputDir)) {
+    fs.mkdirSync(outputDir, { recursive: true })
+  }
+
+  fs.writeFileSync(outputPath, yaml.dump(pack, { lineWidth: 120, noRefs: true }), 'utf8')
+
+  console.log(chalk.green(`  ✓ Written ${cases.length} cases → ${outputPath}`))
+  console.log()
+  console.log('  ' + chalk.bold('Next steps'))
+  console.log(`    ${chalk.cyan('verdict validate ' + path.relative(process.cwd(), outputPath))}`)
+  console.log(`    ${chalk.cyan('verdict run --pack ' + path.relative(process.cwd(), outputPath))}`)
+  console.log()
+}

--- a/src/cli/index.ts
+++ b/src/cli/index.ts
@@ -16,6 +16,7 @@ import { leaderboardCommand } from './commands/leaderboard.js'
 import { reportCommand } from './commands/report.js'
 import { evalAddCommand, evalRemoveCommand, evalListCommand, evalInitCommand } from './commands/eval.js'
 import { contributeCommand } from './commands/contribute.js'
+import { importCommand } from './commands/import.js'
 // Dashboard CLI removed - use custom build system in dashboard/build/ instead
 // See WORKFLOW.md for complete dashboard workflow
 
@@ -214,6 +215,32 @@ evalCmd
 //   2. Add to dashboard: ./quick-add-run.sh results/LATEST.json
 //
 // See WORKFLOW.md for complete documentation
+
+program
+  .command('import')
+  .description('Import a dataset as an eval pack')
+  .option('--hf <dataset>', 'HuggingFace dataset name (e.g., openai/gsm8k)')
+  .option('--split <split>', 'Dataset split to use', 'test')
+  .option('--config <config>', 'HuggingFace dataset config (e.g., main, socratic)')
+  .option('--max <n>', 'Maximum number of cases to import', (v) => parseInt(v, 10), 100)
+  .option('-o, --output <path>', 'Output eval pack path (default: eval-packs/<dataset>-<split>.yaml)')
+  .option('--input-field <name>', 'Override auto-detected input field name')
+  .option('--output-field <name>', 'Override auto-detected output/expected field name')
+  .option('--criteria <text>', 'Evaluation criteria for all cases')
+  .option('--scorer <type>', 'Scorer type for all cases (default: llm)', 'llm')
+  .option('--dry-run', 'Preview without writing files')
+  .action((opts) => importCommand({
+    hf: opts.hf,
+    split: opts.split,
+    config: opts.config,
+    max: opts.max,
+    output: opts.output,
+    inputField: opts.inputField,
+    outputField: opts.outputField,
+    criteria: opts.criteria,
+    scorer: opts.scorer,
+    dryRun: opts.dryRun,
+  }))
 
 program
   .command('contribute')


### PR DESCRIPTION
## Summary

Adds `verdict import --hf <dataset>` — pull any public HuggingFace dataset directly into a verdict eval pack.

## Usage

```bash
# Import GSM8K math benchmark (50 cases from test split)
verdict import --hf openai/gsm8k --split test --max 50

# Import Anthropic HH-RLHF with custom criteria
verdict import --hf Anthropic/hh-rlhf --split test --max 100 --criteria 'Helpful and harmless response'

# Preview without writing
verdict import --hf openai/gsm8k --dry-run

# Multi-config dataset (gsm8k has main/socratic configs)
verdict import --hf openai/gsm8k --config socratic --split test --max 50
```

## What's in this PR

- **`src/cli/commands/import.ts`** — new import command (299 lines)
  - HuggingFace Datasets Server API integration (no SDK, pure HTTP)
  - Auto-detects input/output fields across common naming patterns (`question`/`answer`, `prompt`/`completion`, `input`/`output`, `instruction`/`response`, etc.)
  - Strips GSM8K-style `#### 18` answer markers — extracts just the number
  - Paginated fetch for `--max > 100`
  - Config selection for multi-config datasets
  - Progress spinners, graceful error messages
  - `--dry-run` flag

- **`src/cli/index.ts`** — registers `verdict import` command

- **`src/cli/commands/__tests__/import.test.ts`** — 17 tests
  - Field detection for all common HF naming patterns
  - YAML output structure verification
  - GSM8K answer stripping
  - Config selection
  - Error paths (missing dataset, invalid split, API failure)
  - Tag inclusion in output cases

## Test results

```
✓ src/cli/commands/__tests__/import.test.ts (17 tests) 9ms
```

`pnpm typecheck` passes (no new TS errors introduced).

Closes #115