### PR TITLE
feat(tui): add Phase 1 interactive terminal UI (verdict tui)

### DIFF
--- a/package.json
+++ b/package.json
@@ -35,19 +35,27 @@
     "test:coverage": "vitest run --coverage"
   },
   "dependencies": {
+    "@inkjs/ui": "^2.0.0",
+    "asciichart": "^1.5.25",
     "better-sqlite3": "^12.8.0",
     "chalk": "^5.3.0",
     "commander": "^12.0.0",
+    "fuse.js": "^7.3.0",
+    "ink": "^6.8.0",
     "js-yaml": "^4.1.0",
     "openai": "^4.47.0",
     "ora": "^8.0.1",
+    "react": "^19.2.5",
+    "sparkly": "^6.0.1",
     "zod": "^3.22.0"
   },
   "devDependencies": {
     "@types/better-sqlite3": "^7.6.13",
     "@types/js-yaml": "^4.0.9",
     "@types/node": "^20.0.0",
+    "@types/react": "^19.2.14",
     "@vitest/coverage-v8": "^4.1.1",
+    "ink-testing-library": "^4.0.0",
     "tsup": "^8.0.0",
     "tsx": "^4.7.0",
     "typescript": "^5.9.3",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -8,6 +8,12 @@ importers:
 
   .:
     dependencies:
+      '@inkjs/ui':
+        specifier: ^2.0.0
+        version: 2.0.0(ink@6.8.0(@types/react@19.2.14)(react@19.2.5))
+      asciichart:
+        specifier: ^1.5.25
+        version: 1.5.25
       better-sqlite3:
         specifier: ^12.8.0
         version: 12.8.0
@@ -17,15 +23,27 @@ importers:
       commander:
         specifier: ^12.0.0
         version: 12.1.0
+      fuse.js:
+        specifier: ^7.3.0
+        version: 7.3.0
+      ink:
+        specifier: ^6.8.0
+        version: 6.8.0(@types/react@19.2.14)(react@19.2.5)
       js-yaml:
         specifier: ^4.1.0
         version: 4.1.1
       openai:
         specifier: ^4.47.0
-        version: 4.104.0(zod@3.25.76)
+        version: 4.104.0(ws@8.20.0)(zod@3.25.76)
       ora:
         specifier: ^8.0.1
         version: 8.2.0
+      react:
+        specifier: ^19.2.5
+        version: 19.2.5
+      sparkly:
+        specifier: ^6.0.1
+        version: 6.0.1
       zod:
         specifier: ^3.22.0
         version: 3.25.76
@@ -39,9 +57,15 @@ importers:
       '@types/node':
         specifier: ^20.0.0
         version: 20.19.37
+      '@types/react':
+        specifier: ^19.2.14
+        version: 19.2.14
       '@vitest/coverage-v8':
         specifier: ^4.1.1
         version: 4.1.2(vitest@4.1.2(@types/node@20.19.37)(vite@8.0.3(@emnapi/core@1.9.1)(@emnapi/runtime@1.9.1)(@types/node@20.19.37)(esbuild@0.27.5)(tsx@4.21.0)))
+      ink-testing-library:
+        specifier: ^4.0.0
+        version: 4.0.0(@types/react@19.2.14)
       tsup:
         specifier: ^8.0.0
         version: 8.5.1(postcss@8.5.8)(tsx@4.21.0)(typescript@5.9.3)
@@ -56,6 +80,10 @@ importers:
         version: 4.1.2(@types/node@20.19.37)(vite@8.0.3(@emnapi/core@1.9.1)(@emnapi/runtime@1.9.1)(@types/node@20.19.37)(esbuild@0.27.5)(tsx@4.21.0))
 
 packages:
+
+  '@alcalzone/ansi-tokenize@0.2.5':
+    resolution: {integrity: sha512-3NX/MpTdroi0aKz134A6RC2Gb2iXVECN4QaAXnvCIxxIm3C3AVB1mkUe8NaaiyvOpDfsrqWhYtj+Q6a62RrTsw==}
+    engines: {node: '>=18'}
 
   '@babel/helper-string-parser@7.27.1':
     resolution: {integrity: sha512-qMlSxKbpRlAridDExk92nSobyDdpPijUq2DW6oDnUqd0iOGxmQjyqhMIihI9+zv4LPyZdRje2cavWPbCbWm3eA==}
@@ -242,6 +270,12 @@ packages:
     engines: {node: '>=18'}
     cpu: [x64]
     os: [win32]
+
+  '@inkjs/ui@2.0.0':
+    resolution: {integrity: sha512-5+8fJmwtF9UvikzLfph9sA+LS+l37Ij/szQltkuXLOAXwNkBX9innfzh4pLGXIB59vKEQUtc6D4qGvhD7h3pAg==}
+    engines: {node: '>=18'}
+    peerDependencies:
+      ink: '>=5'
 
   '@jridgewell/gen-mapping@0.3.13':
     resolution: {integrity: sha512-2kkt/7niJ6MgEPxF0bYdQ6etZaA+fQvDcLKckhy1yIQOzaoKjBBjSj63/aLVjYE3qhRt5dvM+uUyfCg6UKCBbA==}
@@ -531,6 +565,9 @@ packages:
   '@types/node@20.19.37':
     resolution: {integrity: sha512-8kzdPJ3FsNsVIurqBs7oodNnCEVbni9yUEkaHbgptDACOPW04jimGagZ51E6+lXUwJjgnBw+hyko/lkFWCldqw==}
 
+  '@types/react@19.2.14':
+    resolution: {integrity: sha512-ilcTH/UniCkMdtexkoCN0bI7pMcJDvmQFPvuPvmEaYA/NSfFTAgdUSLAoVjaRJm7+6PvcM+q1zYOwS4wTYMF9w==}
+
   '@vitest/coverage-v8@4.1.2':
     resolution: {integrity: sha512-sPK//PHO+kAkScb8XITeB1bf7fsk85Km7+rt4eeuRR3VS1/crD47cmV5wicisJmjNdfeokTZwjMk4Mj2d58Mgg==}
     peerDependencies:
@@ -582,8 +619,20 @@ packages:
     resolution: {integrity: sha512-kja8j7PjmncONqaTsB8fQ+wE2mSU2DJ9D4XKoJ5PFWIdRMa6SLSN1ff4mOr4jCbfRSsxR4keIiySJU0N9T5hIQ==}
     engines: {node: '>= 8.0.0'}
 
+  ansi-escapes@7.3.0:
+    resolution: {integrity: sha512-BvU8nYgGQBxcmMuEeUEmNTvrMVjJNSH7RgW24vXexN4Ven6qCvy4TntnvlnwnMLTVlcRQQdbRY8NKnaIoeWDNg==}
+    engines: {node: '>=18'}
+
   ansi-regex@6.2.2:
     resolution: {integrity: sha512-Bq3SmSpyFHaWjPk8If9yc6svM8c56dB5BAtW4Qbw5jHTwwXXcTLoRMkpDJp6VL0XzlWaCHTXrkFURMYmD0sLqg==}
+    engines: {node: '>=12'}
+
+  ansi-styles@4.3.0:
+    resolution: {integrity: sha512-zbB9rCJAT1rbjiVDb2hqKFHNYLxgtk8NURxZ3IZwD3F6NtxbXZQCnnSi1Lkx+IDohdPlFp222wVALIheZJQSEg==}
+    engines: {node: '>=8'}
+
+  ansi-styles@6.2.3:
+    resolution: {integrity: sha512-4Dj6M28JB+oAH8kFkTLUo+a2jwOFkuqb3yucU0CANcRRUbxS0cP0nZYCGjcc3BNXwRIsUVmDGgzawme7zvJHvg==}
     engines: {node: '>=12'}
 
   any-promise@1.3.0:
@@ -591,6 +640,9 @@ packages:
 
   argparse@2.0.1:
     resolution: {integrity: sha512-8+9WqebbFzpX9OR+Wa6O29asIogeRMzcGtAINdpMHHyAg10f05aSFVBbcEqGf/PXw1EjAZ+q2/bEBg3DvurK3Q==}
+
+  asciichart@1.5.25:
+    resolution: {integrity: sha512-PNxzXIPPOtWq8T7bgzBtk9cI2lgS4SJZthUHEiQ1aoIc3lNzGfUvIvo9LiAnq26TACo9t1/4qP6KTGAUbzX9Xg==}
 
   assertion-error@2.0.1:
     resolution: {integrity: sha512-Izi8RQcffqCeNVgFigKli1ssklIbpHnCYc6AknXGYoB6grJqyeby7jv12JUQgmTAnIDnbck1uxksT4dzN3PWBA==}
@@ -601,6 +653,10 @@ packages:
 
   asynckit@0.4.0:
     resolution: {integrity: sha512-Oei9OH4tRh0YqU3GxhX79dM/mwVgvbZJaSNaRk+bshkj0S5cfHcgYakreBjrHwatXKbz+IoIdYLxrKim2MjW0Q==}
+
+  auto-bind@5.0.1:
+    resolution: {integrity: sha512-ooviqdwwgfIfNmDwo94wlshcdzfO64XV0Cg6oDsDYBJfITDz1EngD2z7DkbvCWn+XIMsIqW27sEVF6qcpJrRcg==}
+    engines: {node: ^12.20.0 || ^14.13.1 || >=16.0.0}
 
   base64-js@1.5.1:
     resolution: {integrity: sha512-AKpaYlHn8t4SVbOHCy+b5+KKgvR4vrsD8vbvrbiQJps7fKDTkjkDry6ji0rUJjC0kzbNePLwzxq8iypo41qeWA==}
@@ -636,6 +692,10 @@ packages:
     resolution: {integrity: sha512-NUPRluOfOiTKBKvWPtSD4PhFvWCqOi0BGStNWs57X9js7XGTprSmFoz5F0tWhR4WPjNeR9jXqdC7/UpSJTnlRg==}
     engines: {node: '>=18'}
 
+  chalk@4.1.2:
+    resolution: {integrity: sha512-oKnbhFyRIXpUuez8iBMmyEa4nbj4IOQyuhc/wy9kY7/WVPcwIO9VA668Pu8RkO7+0G76SLROeyw9CpQ061i4mA==}
+    engines: {node: '>=10'}
+
   chalk@5.6.2:
     resolution: {integrity: sha512-7NzBL0rN6fMUW+f7A6Io4h40qQlG+xGmtMxfbnH/K7TAtt8JQWVQK+6g0UXKMeVJoyV5EkkNsErQ8pVD3bLHbA==}
     engines: {node: ^12.17.0 || ^14.13 || >=16.0.0}
@@ -647,6 +707,14 @@ packages:
   chownr@1.1.4:
     resolution: {integrity: sha512-jJ0bqzaylmJtVnNgzTeSOs8DPavpbYgEr/b0YL8/2GO3xJEhInFmhKMUnEJQjZumK7KXGFhUy89PrsJWlakBVg==}
 
+  cli-boxes@3.0.0:
+    resolution: {integrity: sha512-/lzGpEWL/8PfI0BmBOPRwp0c/wFNX1RdUML3jK/RcSBA9T8mZDdQpqYBKtCFTOfQbwPqWEOpjqW+Fnayc0969g==}
+    engines: {node: '>=10'}
+
+  cli-cursor@4.0.0:
+    resolution: {integrity: sha512-VGtlMu3x/4DOtIUwEkRezxUZ2lBacNJCHash0N0WeZDBS+7Ux1dm3XWAgWYxLJFMMdOeXMHXorshEFhbMSGelg==}
+    engines: {node: ^12.20.0 || ^14.13.1 || >=16.0.0}
+
   cli-cursor@5.0.0:
     resolution: {integrity: sha512-aCj4O5wKyszjMmDT4tZj93kxyydN/K5zPWSCe6/0AV/AA1pqe5ZBIw0a2ZfPQV7lL5/yb5HsUreJ6UFAF1tEQw==}
     engines: {node: '>=18'}
@@ -654,6 +722,25 @@ packages:
   cli-spinners@2.9.2:
     resolution: {integrity: sha512-ywqV+5MmyL4E7ybXgKys4DugZbX0FC6LnwrhjuykIjnK9k8OQacQ7axGKnjDXWNhns0xot3bZI5h55H8yo9cJg==}
     engines: {node: '>=6'}
+
+  cli-spinners@3.4.0:
+    resolution: {integrity: sha512-bXfOC4QcT1tKXGorxL3wbJm6XJPDqEnij2gQ2m7ESQuE+/z9YFIWnl/5RpTiKWbMq3EVKR4fRLJGn6DVfu0mpw==}
+    engines: {node: '>=18.20'}
+
+  cli-truncate@5.2.0:
+    resolution: {integrity: sha512-xRwvIOMGrfOAnM1JYtqQImuaNtDEv9v6oIYAs4LIHwTiKee8uwvIi363igssOC0O5U04i4AlENs79LQLu9tEMw==}
+    engines: {node: '>=20'}
+
+  code-excerpt@4.0.0:
+    resolution: {integrity: sha512-xxodCmBen3iy2i0WtAK8FlFNrRzjUqjRsMfho58xT/wvZU1YTM3fCnRjcy1gJPMepaRlgm/0e6w8SpWHpn3/cA==}
+    engines: {node: ^12.20.0 || ^14.13.1 || >=16.0.0}
+
+  color-convert@2.0.1:
+    resolution: {integrity: sha512-RRECPsj7iu/xb5oKYcsFHSppFNnsj/52OVTRKb4zP5onXwVF3zVmmToNcOfGC+CRDpfK/U584fMg38ZHCaElKQ==}
+    engines: {node: '>=7.0.0'}
+
+  color-name@1.1.4:
+    resolution: {integrity: sha512-dOy+3AuW3a2wNbZHIuMZpTcgjGuLU/uBL/ubcZF9OXbDo8ff4O8yVp5Bf0efS8uEoYo5q4Fx7dY9OgQGXgAsQA==}
 
   combined-stream@1.0.8:
     resolution: {integrity: sha512-FQN4MRfuJeHf7cBbBMJFXhKSDq+2kAArBlmRBvcvFE5BB1HZKXtSFASDhdlz9zOYwxh8lDdnvmMOe/+5cdoEdg==}
@@ -677,6 +764,13 @@ packages:
   convert-source-map@2.0.0:
     resolution: {integrity: sha512-Kvp459HrV2FEJ1CAsi1Ku+MY3kasH19TFykTz2xWmMeq6bk2NU3XXvfJ+Q61m0xktWwt+1HSYf3JZsTms3aRJg==}
 
+  convert-to-spaces@2.0.1:
+    resolution: {integrity: sha512-rcQ1bsQO9799wq24uE5AM2tAILy4gXGIK/njFWcVQkGNZ96edlpY+A7bjwvzjYvLDyzmG1MmMLZhpcsb+klNMQ==}
+    engines: {node: ^12.20.0 || ^14.13.1 || >=16.0.0}
+
+  csstype@3.2.3:
+    resolution: {integrity: sha512-z1HGKcYy2xA8AGQfwrn0PAy+PB7X/GSj3UVJW9qKyn43xWa+gl5nXmU4qqLMRzWVLFC8KusUX8T/0kCiOYpAIQ==}
+
   debug@4.4.3:
     resolution: {integrity: sha512-RGwwWnwQvkVfavKVt22FGLw+xYSdzARwm0ru6DhTVA3umU5hZc28V3kO4stgYryrTlLpuvgI9GiijltAjNbcqA==}
     engines: {node: '>=6.0'}
@@ -693,6 +787,10 @@ packages:
   deep-extend@0.6.0:
     resolution: {integrity: sha512-LOHxIOaPYdHlJRtCQfDIVZtfw/ufM8+rVj649RIHzcm/vGwQRXFt6OPqIFWsm2XEMrNIEtWR64sY1LEKD2vAOA==}
     engines: {node: '>=4.0.0'}
+
+  deepmerge@4.3.1:
+    resolution: {integrity: sha512-3sUqbMEc77XqpdNO7FRyRog+eW3ph+GYCbj+rK+uYyRMuwsVy0rMiVtPn+QJlKFvWP/1PYpapqYn0Me2knFn+A==}
+    engines: {node: '>=0.10.0'}
 
   delayed-stream@1.0.0:
     resolution: {integrity: sha512-ZySD7Nf91aLB0RxL4KGrKHBXl7Eds1DAmEdcoVawXnLD7SDhpNgtuII2aAkg7a7QS41jxPSZ17p4VdGnMHk3MQ==}
@@ -711,6 +809,10 @@ packages:
 
   end-of-stream@1.4.5:
     resolution: {integrity: sha512-ooEGc6HP26xXq/N+GCGOT0JKCLDGrq2bQUZrQ7gyrJiZANJ/8YDTxTpQBXGMn+WbIQXNVpyWymm7KYVICQnyOg==}
+
+  environment@1.1.0:
+    resolution: {integrity: sha512-xUtoPkMggbz0MPyPiIWr1Kp4aeWJjDZ6SMvURhimjdZgsRuDplF5/s9hcgGhyXMhs+6vpnuoiZ2kFiu3FMnS8Q==}
+    engines: {node: '>=18'}
 
   es-define-property@1.0.1:
     resolution: {integrity: sha512-e3nRfgfUZ4rNGL232gUgX06QNyyez04KdjFrF+LTRoOXmrOgFKDg4BCdsjW8EnT69eqdYGmRpJwiPVYNrCaW3g==}
@@ -731,10 +833,17 @@ packages:
     resolution: {integrity: sha512-j6vWzfrGVfyXxge+O0x5sh6cvxAog0a/4Rdd2K36zCMV5eJ+/+tOAngRO8cODMNWbVRdVlmGZQL2YS3yR8bIUA==}
     engines: {node: '>= 0.4'}
 
+  es-toolkit@1.45.1:
+    resolution: {integrity: sha512-/jhoOj/Fx+A+IIyDNOvO3TItGmlMKhtX8ISAHKE90c4b/k1tqaqEZ+uUqfpU8DMnW5cgNJv606zS55jGvza0Xw==}
+
   esbuild@0.27.5:
     resolution: {integrity: sha512-zdQoHBjuDqKsvV5OPaWansOwfSQ0Js+Uj9J85TBvj3bFW1JjWTSULMRwdQAc8qMeIScbClxeMK0jlrtB9linhA==}
     engines: {node: '>=18'}
     hasBin: true
+
+  escape-string-regexp@2.0.0:
+    resolution: {integrity: sha512-UpzcLCXolUWcNu5HtVMHYdXJjArjsF9C0aNnquZYY4uW/Vu0miy5YoWvbV345HauVvcAUnpRuhMMcqTcGOY2+w==}
+    engines: {node: '>=8'}
 
   estree-walker@3.0.3:
     resolution: {integrity: sha512-7RUKfXgSMMkzt6ZuXmqapOurLGPPfgj6l9uRZ7lRGolvk0y2yocc35LdcxKC5PQZdn2DMqioAQ2NoWcrTKmm6g==}
@@ -759,6 +868,10 @@ packages:
     peerDependenciesMeta:
       picomatch:
         optional: true
+
+  figures@6.1.0:
+    resolution: {integrity: sha512-d+l3qxjSesT4V7v2fh+QnmFnUWv9lSpjarhShNTgBOfA0ttejbQUAlHLitbjkoRiDulW0OPoQPYIGhIC8ohejg==}
+    engines: {node: '>=18'}
 
   file-uri-to-path@1.0.0:
     resolution: {integrity: sha512-0Zt+s3L7Vf1biwWZ29aARiVYLx7iMGnEUl9x33fbB/j3jR81u/O2LbqK+Bm1CDSNDKVtJ/YjwY7TUd5SkeLQLw==}
@@ -787,6 +900,10 @@ packages:
 
   function-bind@1.1.2:
     resolution: {integrity: sha512-7XHNxH7qX9xG5mIwxkhumTox/MIRNcOgDrxWsMt2pAr23WHp6MrRlN7FBSFpCpr+oVO0F744iUgR82nJMfG2SA==}
+
+  fuse.js@7.3.0:
+    resolution: {integrity: sha512-plz8RVjfcDedTGfVngWH1jmJvBvAwi1v2jecfDerbEnMcmOYUEEwKFTHbNoCiYyzaK2Ws8lABkTCcRSqCY1q4w==}
+    engines: {node: '>=10'}
 
   get-east-asian-width@1.5.0:
     resolution: {integrity: sha512-CQ+bEO+Tva/qlmw24dCejulK5pMzVnUOFOijVogd3KQs07HnRIgp8TGipvCCRT06xeYEbpbgwaCxglFyiuIcmA==}
@@ -835,11 +952,46 @@ packages:
   ieee754@1.2.1:
     resolution: {integrity: sha512-dcyqhDvX1C46lXZcVqCpK+FtMRQVdIMN6/Df5js2zouUsqG7I6sFxitIC+7KYK29KdXOLHdu9zL4sFnoVQnqaA==}
 
+  indent-string@5.0.0:
+    resolution: {integrity: sha512-m6FAo/spmsW2Ab2fU35JTYwtOKa2yAwXSwgjSv1TJzh4Mh7mC3lzAOVLBprb72XsTrgkEIsl7YrFNAiDiRhIGg==}
+    engines: {node: '>=12'}
+
   inherits@2.0.4:
     resolution: {integrity: sha512-k/vGaX4/Yla3WzyMCvTQOXYeIHvqOKtnqBduzTHpzpQZzAskKMhZ2K+EnBiSM9zGSoIFeMpXKxa4dYeZIQqewQ==}
 
   ini@1.3.8:
     resolution: {integrity: sha512-JV/yugV2uzW5iMRSiZAyDtQd+nxtUnjeLt0acNdw98kKLrvuRVyB80tsREOE7yvGVgalhZ6RNXCmEHkUKBKxew==}
+
+  ink-testing-library@4.0.0:
+    resolution: {integrity: sha512-yF92kj3pmBvk7oKbSq5vEALO//o7Z9Ck/OaLNlkzXNeYdwfpxMQkSowGTFUCS5MSu9bWfSZMewGpp7bFc66D7Q==}
+    engines: {node: '>=18'}
+    peerDependencies:
+      '@types/react': '>=18.0.0'
+    peerDependenciesMeta:
+      '@types/react':
+        optional: true
+
+  ink@6.8.0:
+    resolution: {integrity: sha512-sbl1RdLOgkO9isK42WCZlJCFN9hb++sX9dsklOvfd1YQ3bQ2AiFu12Q6tFlr0HvEUvzraJntQCCpfEoUe9DSzA==}
+    engines: {node: '>=20'}
+    peerDependencies:
+      '@types/react': '>=19.0.0'
+      react: '>=19.0.0'
+      react-devtools-core: '>=6.1.2'
+    peerDependenciesMeta:
+      '@types/react':
+        optional: true
+      react-devtools-core:
+        optional: true
+
+  is-fullwidth-code-point@5.1.0:
+    resolution: {integrity: sha512-5XHYaSyiqADb4RnZ1Bdad6cPp8Toise4TzEjcOYDHZkTCbKgiUl7WTUCpNWHuxmDt91wnsZBc9xinNzopv3JMQ==}
+    engines: {node: '>=18'}
+
+  is-in-ci@2.0.0:
+    resolution: {integrity: sha512-cFeerHriAnhrQSbpAxL37W1wcJKUUX07HyLWZCW1URJT/ra3GyUTzBgUnh24TMVfNTV2Hij2HLxkPHFZfOZy5w==}
+    engines: {node: '>=20'}
+    hasBin: true
 
   is-interactive@2.0.0:
     resolution: {integrity: sha512-qP1vozQRI+BMOPcjFzrjXuQvdak2pHNUMZoeG2eRbiSqyvbEf/wQtEOTOX1guk6E3t36RkaqiSt8A/6YElNxLQ==}
@@ -987,6 +1139,10 @@ packages:
     resolution: {integrity: sha512-ZDY+bPm5zTTF+YpCrAU9nK0UgICYPT0QtT1NZWFv4s++TNkcgVaT0g6+4R2uI4MjQjzysHB1zxuWL50hzaeXiw==}
     engines: {node: '>= 0.6'}
 
+  mimic-fn@2.1.0:
+    resolution: {integrity: sha512-OqbOk5oEQeAZ8WXWydlu9HJjz9WVdEIvamMCcXmuqUYjTknH/sqsWvhQ3vgwKFRR1HpjvNBKQ37nbJgYzGqGcg==}
+    engines: {node: '>=6'}
+
   mimic-function@5.0.1:
     resolution: {integrity: sha512-VP79XUPxV2CigYP3jWwAUFSku2aKqBH7uTAapFWCBqutsbmDo96KY5o8uh6U+/YSIn5OxJnXp73beVkpqMIGhA==}
     engines: {node: '>=18'}
@@ -1046,6 +1202,10 @@ packages:
   once@1.4.0:
     resolution: {integrity: sha512-lNaJgI+2Q5URQBkccEKHTQOPaXdUxnZZElQTZY0MFUAuaEqe1E+Nyvgdz/aIyNi6Z9MzO5dv1H8n58/GELp3+w==}
 
+  onetime@5.1.2:
+    resolution: {integrity: sha512-kbpaSSGJTWdAY5KPVeMOKXSrPtr8C8C7wodJbcsd51jRnmD+GZu8Y0VoU6Dm5Z4vWr0Ig/1NKuWRKf7j5aaYSg==}
+    engines: {node: '>=6'}
+
   onetime@7.0.0:
     resolution: {integrity: sha512-VXJjc87FScF88uafS3JllDgvAm+c/Slfz06lorj2uAY34rlUu0Nt+v8wreiImcrgAjjIHp1rXpTDlLOGw29WwQ==}
     engines: {node: '>=18'}
@@ -1065,6 +1225,10 @@ packages:
   ora@8.2.0:
     resolution: {integrity: sha512-weP+BZ8MVNnlCm8c0Qdc1WSWq4Qn7I+9CJGm7Qali6g44e/PUzbjNqJX5NJ9ljlNMosfJvg1fKEGILklK9cwnw==}
     engines: {node: '>=18'}
+
+  patch-console@2.0.0:
+    resolution: {integrity: sha512-0YNdUceMdaQwoKce1gatDScmMo5pu/tfABfnzEqeG0gtTmd7mh/WcwgUjtAeOU7N8nFFlbQBnFK2gXW5fGvmMA==}
+    engines: {node: ^12.20.0 || ^14.13.1 || >=16.0.0}
 
   pathe@2.0.3:
     resolution: {integrity: sha512-WUjGcAqP1gQacoQe+OBJsFA7Ld4DyXuUIjZ5cc75cLHvJ7dtNsTugphxIADwspS+AraAUePCKrSVtPLFj/F88w==}
@@ -1118,6 +1282,16 @@ packages:
     resolution: {integrity: sha512-y3bGgqKj3QBdxLbLkomlohkvsA8gdAiUQlSBJnBhfn+BPxg4bc62d8TcBW15wavDfgexCgccckhcZvywyQYPOw==}
     hasBin: true
 
+  react-reconciler@0.33.0:
+    resolution: {integrity: sha512-KetWRytFv1epdpJc3J4G75I4WrplZE5jOL7Yq0p34+OVOKF4Se7WrdIdVC45XsSSmUTlht2FM/fM1FZb1mfQeA==}
+    engines: {node: '>=0.10.0'}
+    peerDependencies:
+      react: ^19.2.0
+
+  react@19.2.5:
+    resolution: {integrity: sha512-llUJLzz1zTUBrskt2pwZgLq59AemifIftw4aB7JxOqf1HY2FDaGDxgwpAPVzHU1kdWabH7FauP4i1oEeer2WCA==}
+    engines: {node: '>=0.10.0'}
+
   readable-stream@3.6.2:
     resolution: {integrity: sha512-9u/sniCrY3D5WdsERHzHE4G2YCXqoG5FTHUiCC4SIbr6XcLZBY05ya9EKjYek9O5xOAwjGq+1JdGBAS7Q9ScoA==}
     engines: {node: '>= 6'}
@@ -1132,6 +1306,10 @@ packages:
 
   resolve-pkg-maps@1.0.0:
     resolution: {integrity: sha512-seS2Tj26TBVOC2NIc2rOe2y2ZO7efxITtLZcGSOnHHNOQ7CkiUBfw0Iw2ck6xkIhPwLhKNLS8BO+hEpngQlqzw==}
+
+  restore-cursor@4.0.0:
+    resolution: {integrity: sha512-I9fPXU9geO9bHOt9pHHOhOkYerIMsmVaWB0rA2AI9ERh/+x/i7MV5HKBNrg+ljO5eoPVgCcnFuRjJ9uH6I/3eg==}
+    engines: {node: ^12.20.0 || ^14.13.1 || >=16.0.0}
 
   restore-cursor@5.1.0:
     resolution: {integrity: sha512-oMA2dcrw6u0YfxJQXm342bFKX/E4sG9rbTzO9ptUcR/e8A33cHuvStiYOwH7fszkZlZ1z/ta9AAoPk2F4qIOHA==}
@@ -1150,6 +1328,9 @@ packages:
   safe-buffer@5.2.1:
     resolution: {integrity: sha512-rp3So07KcdmmKbGvgaNxQSJr7bGVSVk5S9Eq1F+ppbRo70+YeaDxkw5Dd8NPN+GD6bjnYm2VuPuCXmpuYvmCXQ==}
 
+  scheduler@0.27.0:
+    resolution: {integrity: sha512-eNv+WrVbKu1f3vbYJT/xtiF5syA5HPIMtf9IgY/nKg0sWqzAUEvqY/xm7OcZc/qafLx/iO9FgOmeSAp4v5ti/Q==}
+
   semver@7.7.4:
     resolution: {integrity: sha512-vFKC2IEtQnVhpT78h1Yp8wzwrf8CM+MzKMHGJZfBtzhZNycRFnXsHk6E5TxIkkMsgNS7mdX3AGB7x2QM2di4lA==}
     engines: {node: '>=10'}
@@ -1157,6 +1338,9 @@ packages:
 
   siginfo@2.0.0:
     resolution: {integrity: sha512-ybx0WO1/8bSBLEWXZvEd7gMW3Sn3JFlW3TvX1nREbDLRNQNaeNN8WK0meBwPdAaOI7TtRRRJn/Es1zhrrCHu7g==}
+
+  signal-exit@3.0.7:
+    resolution: {integrity: sha512-wnD2ZE+l+SPC/uoS0vXeE9L1+0wuaMqKlfz9AMUo38JsyLSBWSFcHR1Rri62LZc12vLr1gb3jl7iwQhgwpAbGQ==}
 
   signal-exit@4.1.0:
     resolution: {integrity: sha512-bzyZ1e88w9O1iNJbKnOlvYTrWPDl46O1bG0D3XInv+9tkPrxrN8jUUTiFlDkkmKWgn1M6CfIA13SuGqOa9Korw==}
@@ -1168,6 +1352,10 @@ packages:
   simple-get@4.0.1:
     resolution: {integrity: sha512-brv7p5WgH0jmQJr1ZDDfKDOSeWWg+OVypG99A/5vYGPqJ6pxiaHLy8nxtFjBA7oMa01ebA9gfh1uMCFqOuXxvA==}
 
+  slice-ansi@8.0.0:
+    resolution: {integrity: sha512-stxByr12oeeOyY2BlviTNQlYV5xOj47GirPr4yA1hE9JCtxfQN0+tVbkxwCtYDQWhEKWFHsEK48ORg5jrouCAg==}
+    engines: {node: '>=20'}
+
   source-map-js@1.2.1:
     resolution: {integrity: sha512-UXWMKhLOwVKb728IUtQPXxfYU+usdybtUrK/8uGE8CQMvrhOpwvzDBwj0QhSL7MQc7vIsISBG8VQ8+IDQxpfQA==}
     engines: {node: '>=0.10.0'}
@@ -1175,6 +1363,14 @@ packages:
   source-map@0.7.6:
     resolution: {integrity: sha512-i5uvt8C3ikiWeNZSVZNWcfZPItFQOsYTUAOkcUPGd8DqDy1uOUikjt5dG+uRlwyvR108Fb9DOd4GvXfT0N2/uQ==}
     engines: {node: '>= 12'}
+
+  sparkly@6.0.1:
+    resolution: {integrity: sha512-CG0p45e9YCfzmPvBqFEgK4miRCrt++3ByBWSixPLC6pkhg72qtpM8zedqfUr8RYVRoqCv++Oc140m13C2m9MbQ==}
+    engines: {node: ^12.20.0 || ^14.13.1 || >=16.0.0}
+
+  stack-utils@2.0.6:
+    resolution: {integrity: sha512-XlkWvfIm6RmsWtNJx+uqtKLS8eqFbxUg0ZzLXqY0caEy9l7hruX8IpiDnjsLavoBgqCCR71TqWO8MaXYheJ3RQ==}
+    engines: {node: '>=10'}
 
   stackback@0.0.2:
     resolution: {integrity: sha512-1XMJE5fQo1jGH6Y/7ebnwPOBEkIEnT4QF32d5R1+VXdXveM0IBMJt8zfaxX1P3QhVwrYe+576+jkANtSS2mBbw==}
@@ -1189,6 +1385,10 @@ packages:
   string-width@7.2.0:
     resolution: {integrity: sha512-tsaTIkKW9b4N+AEj+SVA+WhJzV7/zMhcSu78mLKWSk7cXMOSHsBKFWUs0fWwq8QyK3MgJBQRX6Gbi4kYbdvGkQ==}
     engines: {node: '>=18'}
+
+  string-width@8.2.0:
+    resolution: {integrity: sha512-6hJPQ8N0V0P3SNmP6h2J99RLuzrWz2gvT7VnK5tKvrNqJoyS9W4/Fb8mo31UiPvy00z7DQXkP2hnKBVav76thw==}
+    engines: {node: '>=20'}
 
   string_decoder@1.3.0:
     resolution: {integrity: sha512-hkRX8U1WjJFd8LsDJ2yQ/wWWxaopEsABU1XfkM8A+j0+85JAGppt16cr1Whg6KIbb4okU6Mql6BOj+uup/wKeA==}
@@ -1210,12 +1410,20 @@ packages:
     resolution: {integrity: sha512-qpCAvRl9stuOHveKsn7HncJRvv501qIacKzQlO/+Lwxc9+0q2wLyv4Dfvt80/DPn2pqOBsJdDiogXGR9+OvwRw==}
     engines: {node: '>=8'}
 
+  tagged-tag@1.0.0:
+    resolution: {integrity: sha512-yEFYrVhod+hdNyx7g5Bnkkb0G6si8HJurOoOEgC8B/O0uXLHlaey/65KRv6cuWBNhBgHKAROVpc7QyYqE5gFng==}
+    engines: {node: '>=20'}
+
   tar-fs@2.1.4:
     resolution: {integrity: sha512-mDAjwmZdh7LTT6pNleZ05Yt65HC3E+NiQzl672vQG38jIrehtJk/J3mNwIg+vShQPcLF/LV7CMnDW6vjj6sfYQ==}
 
   tar-stream@2.2.0:
     resolution: {integrity: sha512-ujeqbceABgwMZxEJnk2HDY2DlnUZ+9oEcb1KzTVfYHio0UE6dG71n60d8D2I4qNvleWrrXpmjpt7vZeF1LnMZQ==}
     engines: {node: '>=6'}
+
+  terminal-size@4.0.1:
+    resolution: {integrity: sha512-avMLDQpUI9I5XFrklECw1ZEUPJhqzcwSWsyyI8blhRLT+8N1jLJWLWWYQpB2q2xthq8xDvjZPISVh53T/+CLYQ==}
+    engines: {node: '>=18'}
 
   thenify-all@1.6.0:
     resolution: {integrity: sha512-RNxQH/qI8/t3thXJDwcstUO4zeqo64+Uy/+sNVRBx4Xn2OX+OZ9oP+iJnNFqplFra2ZUVeKCSa2oVWi3T4uVmA==}
@@ -1281,6 +1489,10 @@ packages:
 
   tunnel-agent@0.6.0:
     resolution: {integrity: sha512-McnNiV1l8RYeY8tBgEpuodCC1mLUdbSN+CYBL7kJsJNInOP8UjDDEwdk6Mw60vdLLrr5NHKZhMAOSrR2NZuQ+w==}
+
+  type-fest@5.5.0:
+    resolution: {integrity: sha512-PlBfpQwiUvGViBNX84Yxwjsdhd1TUlXr6zjX7eoirtCPIr08NAmxwa+fcYBTeRQxHo9YC9wwF3m9i700sHma8g==}
+    engines: {node: '>=20'}
 
   typescript@5.9.3:
     resolution: {integrity: sha512-jl1vZzPDinLr9eUt3J/t7V6FgNEw9QjvBPdysz9KfQDD41fQrC2Y4vKQdiaUpFT4bXlb1RHhLpp8wtm6M5TgSw==}
@@ -1392,13 +1604,41 @@ packages:
     engines: {node: '>=8'}
     hasBin: true
 
+  widest-line@6.0.0:
+    resolution: {integrity: sha512-U89AsyEeAsyoF0zVJBkG9zBgekjgjK7yk9sje3F4IQpXBJ10TF6ByLlIfjMhcmHMJgHZI4KHt4rdNfktzxIAMA==}
+    engines: {node: '>=20'}
+
+  wrap-ansi@9.0.2:
+    resolution: {integrity: sha512-42AtmgqjV+X1VpdOfyTGOYRi0/zsoLqtXQckTmqTeybT+BDIbM/Guxo7x3pE2vtpr1ok6xRqM9OpBe+Jyoqyww==}
+    engines: {node: '>=18'}
+
   wrappy@1.0.2:
     resolution: {integrity: sha512-l4Sp/DRseor9wL6EvV2+TuQn63dMkPjZ/sp9XkghTEbV9KlPS1xUsZ3u7/IQO4wxtcFB4bgpQPRcR3QCvezPcQ==}
+
+  ws@8.20.0:
+    resolution: {integrity: sha512-sAt8BhgNbzCtgGbt2OxmpuryO63ZoDk/sqaB/znQm94T4fCEsy/yV+7CdC1kJhOU9lboAEU7R3kquuycDoibVA==}
+    engines: {node: '>=10.0.0'}
+    peerDependencies:
+      bufferutil: ^4.0.1
+      utf-8-validate: '>=5.0.2'
+    peerDependenciesMeta:
+      bufferutil:
+        optional: true
+      utf-8-validate:
+        optional: true
+
+  yoga-layout@3.2.1:
+    resolution: {integrity: sha512-0LPOt3AxKqMdFBZA3HBAt/t/8vIKq7VaQYbuA8WxCgung+p9TVyKRYdpvCb80HcdTN2NkbIKbhNwKUfm3tQywQ==}
 
   zod@3.25.76:
     resolution: {integrity: sha512-gzUt/qt81nXsFGKIFcC3YnfEAx5NkunCfnDlvuBSSFS02bcXu4Lmea0AFIUwbLWxWPx3d9p8S5QoaujKcNQxcQ==}
 
 snapshots:
+
+  '@alcalzone/ansi-tokenize@0.2.5':
+    dependencies:
+      ansi-styles: 6.2.3
+      is-fullwidth-code-point: 5.1.0
 
   '@babel/helper-string-parser@7.27.1': {}
 
@@ -1508,6 +1748,14 @@ snapshots:
 
   '@esbuild/win32-x64@0.27.5':
     optional: true
+
+  '@inkjs/ui@2.0.0(ink@6.8.0(@types/react@19.2.14)(react@19.2.5))':
+    dependencies:
+      chalk: 5.6.2
+      cli-spinners: 3.4.0
+      deepmerge: 4.3.1
+      figures: 6.1.0
+      ink: 6.8.0(@types/react@19.2.14)(react@19.2.5)
 
   '@jridgewell/gen-mapping@0.3.13':
     dependencies:
@@ -1694,6 +1942,10 @@ snapshots:
     dependencies:
       undici-types: 6.21.0
 
+  '@types/react@19.2.14':
+    dependencies:
+      csstype: 3.2.3
+
   '@vitest/coverage-v8@4.1.2(vitest@4.1.2(@types/node@20.19.37)(vite@8.0.3(@emnapi/core@1.9.1)(@emnapi/runtime@1.9.1)(@types/node@20.19.37)(esbuild@0.27.5)(tsx@4.21.0)))':
     dependencies:
       '@bcoe/v8-coverage': 1.0.2
@@ -1759,11 +2011,23 @@ snapshots:
     dependencies:
       humanize-ms: 1.2.1
 
+  ansi-escapes@7.3.0:
+    dependencies:
+      environment: 1.1.0
+
   ansi-regex@6.2.2: {}
+
+  ansi-styles@4.3.0:
+    dependencies:
+      color-convert: 2.0.1
+
+  ansi-styles@6.2.3: {}
 
   any-promise@1.3.0: {}
 
   argparse@2.0.1: {}
+
+  asciichart@1.5.25: {}
 
   assertion-error@2.0.1: {}
 
@@ -1774,6 +2038,8 @@ snapshots:
       js-tokens: 10.0.0
 
   asynckit@0.4.0: {}
+
+  auto-bind@5.0.1: {}
 
   base64-js@1.5.1: {}
 
@@ -1811,6 +2077,11 @@ snapshots:
 
   chai@6.2.2: {}
 
+  chalk@4.1.2:
+    dependencies:
+      ansi-styles: 4.3.0
+      supports-color: 7.2.0
+
   chalk@5.6.2: {}
 
   chokidar@4.0.3:
@@ -1819,11 +2090,34 @@ snapshots:
 
   chownr@1.1.4: {}
 
+  cli-boxes@3.0.0: {}
+
+  cli-cursor@4.0.0:
+    dependencies:
+      restore-cursor: 4.0.0
+
   cli-cursor@5.0.0:
     dependencies:
       restore-cursor: 5.1.0
 
   cli-spinners@2.9.2: {}
+
+  cli-spinners@3.4.0: {}
+
+  cli-truncate@5.2.0:
+    dependencies:
+      slice-ansi: 8.0.0
+      string-width: 8.2.0
+
+  code-excerpt@4.0.0:
+    dependencies:
+      convert-to-spaces: 2.0.1
+
+  color-convert@2.0.1:
+    dependencies:
+      color-name: 1.1.4
+
+  color-name@1.1.4: {}
 
   combined-stream@1.0.8:
     dependencies:
@@ -1839,6 +2133,10 @@ snapshots:
 
   convert-source-map@2.0.0: {}
 
+  convert-to-spaces@2.0.1: {}
+
+  csstype@3.2.3: {}
+
   debug@4.4.3:
     dependencies:
       ms: 2.1.3
@@ -1848,6 +2146,8 @@ snapshots:
       mimic-response: 3.1.0
 
   deep-extend@0.6.0: {}
+
+  deepmerge@4.3.1: {}
 
   delayed-stream@1.0.0: {}
 
@@ -1865,6 +2165,8 @@ snapshots:
     dependencies:
       once: 1.4.0
 
+  environment@1.1.0: {}
+
   es-define-property@1.0.1: {}
 
   es-errors@1.3.0: {}
@@ -1881,6 +2183,8 @@ snapshots:
       get-intrinsic: 1.3.0
       has-tostringtag: 1.0.2
       hasown: 2.0.2
+
+  es-toolkit@1.45.1: {}
 
   esbuild@0.27.5:
     optionalDependencies:
@@ -1911,6 +2215,8 @@ snapshots:
       '@esbuild/win32-ia32': 0.27.5
       '@esbuild/win32-x64': 0.27.5
 
+  escape-string-regexp@2.0.0: {}
+
   estree-walker@3.0.3:
     dependencies:
       '@types/estree': 1.0.8
@@ -1924,6 +2230,10 @@ snapshots:
   fdir@6.5.0(picomatch@4.0.4):
     optionalDependencies:
       picomatch: 4.0.4
+
+  figures@6.1.0:
+    dependencies:
+      is-unicode-supported: 2.1.0
 
   file-uri-to-path@1.0.0: {}
 
@@ -1954,6 +2264,8 @@ snapshots:
     optional: true
 
   function-bind@1.1.2: {}
+
+  fuse.js@7.3.0: {}
 
   get-east-asian-width@1.5.0: {}
 
@@ -2003,9 +2315,55 @@ snapshots:
 
   ieee754@1.2.1: {}
 
+  indent-string@5.0.0: {}
+
   inherits@2.0.4: {}
 
   ini@1.3.8: {}
+
+  ink-testing-library@4.0.0(@types/react@19.2.14):
+    optionalDependencies:
+      '@types/react': 19.2.14
+
+  ink@6.8.0(@types/react@19.2.14)(react@19.2.5):
+    dependencies:
+      '@alcalzone/ansi-tokenize': 0.2.5
+      ansi-escapes: 7.3.0
+      ansi-styles: 6.2.3
+      auto-bind: 5.0.1
+      chalk: 5.6.2
+      cli-boxes: 3.0.0
+      cli-cursor: 4.0.0
+      cli-truncate: 5.2.0
+      code-excerpt: 4.0.0
+      es-toolkit: 1.45.1
+      indent-string: 5.0.0
+      is-in-ci: 2.0.0
+      patch-console: 2.0.0
+      react: 19.2.5
+      react-reconciler: 0.33.0(react@19.2.5)
+      scheduler: 0.27.0
+      signal-exit: 3.0.7
+      slice-ansi: 8.0.0
+      stack-utils: 2.0.6
+      string-width: 8.2.0
+      terminal-size: 4.0.1
+      type-fest: 5.5.0
+      widest-line: 6.0.0
+      wrap-ansi: 9.0.2
+      ws: 8.20.0
+      yoga-layout: 3.2.1
+    optionalDependencies:
+      '@types/react': 19.2.14
+    transitivePeerDependencies:
+      - bufferutil
+      - utf-8-validate
+
+  is-fullwidth-code-point@5.1.0:
+    dependencies:
+      get-east-asian-width: 1.5.0
+
+  is-in-ci@2.0.0: {}
 
   is-interactive@2.0.0: {}
 
@@ -2116,6 +2474,8 @@ snapshots:
     dependencies:
       mime-db: 1.52.0
 
+  mimic-fn@2.1.0: {}
+
   mimic-function@5.0.1: {}
 
   mimic-response@3.1.0: {}
@@ -2161,11 +2521,15 @@ snapshots:
     dependencies:
       wrappy: 1.0.2
 
+  onetime@5.1.2:
+    dependencies:
+      mimic-fn: 2.1.0
+
   onetime@7.0.0:
     dependencies:
       mimic-function: 5.0.1
 
-  openai@4.104.0(zod@3.25.76):
+  openai@4.104.0(ws@8.20.0)(zod@3.25.76):
     dependencies:
       '@types/node': 18.19.130
       '@types/node-fetch': 2.6.13
@@ -2175,6 +2539,7 @@ snapshots:
       formdata-node: 4.4.1
       node-fetch: 2.7.0
     optionalDependencies:
+      ws: 8.20.0
       zod: 3.25.76
     transitivePeerDependencies:
       - encoding
@@ -2190,6 +2555,8 @@ snapshots:
       stdin-discarder: 0.2.2
       string-width: 7.2.0
       strip-ansi: 7.2.0
+
+  patch-console@2.0.0: {}
 
   pathe@2.0.3: {}
 
@@ -2245,6 +2612,13 @@ snapshots:
       minimist: 1.2.8
       strip-json-comments: 2.0.1
 
+  react-reconciler@0.33.0(react@19.2.5):
+    dependencies:
+      react: 19.2.5
+      scheduler: 0.27.0
+
+  react@19.2.5: {}
+
   readable-stream@3.6.2:
     dependencies:
       inherits: 2.0.4
@@ -2256,6 +2630,11 @@ snapshots:
   resolve-from@5.0.0: {}
 
   resolve-pkg-maps@1.0.0: {}
+
+  restore-cursor@4.0.0:
+    dependencies:
+      onetime: 5.1.2
+      signal-exit: 3.0.7
 
   restore-cursor@5.1.0:
     dependencies:
@@ -2319,9 +2698,13 @@ snapshots:
 
   safe-buffer@5.2.1: {}
 
+  scheduler@0.27.0: {}
+
   semver@7.7.4: {}
 
   siginfo@2.0.0: {}
+
+  signal-exit@3.0.7: {}
 
   signal-exit@4.1.0: {}
 
@@ -2333,9 +2716,22 @@ snapshots:
       once: 1.4.0
       simple-concat: 1.0.1
 
+  slice-ansi@8.0.0:
+    dependencies:
+      ansi-styles: 6.2.3
+      is-fullwidth-code-point: 5.1.0
+
   source-map-js@1.2.1: {}
 
   source-map@0.7.6: {}
+
+  sparkly@6.0.1:
+    dependencies:
+      chalk: 4.1.2
+
+  stack-utils@2.0.6:
+    dependencies:
+      escape-string-regexp: 2.0.0
 
   stackback@0.0.2: {}
 
@@ -2346,6 +2742,11 @@ snapshots:
   string-width@7.2.0:
     dependencies:
       emoji-regex: 10.6.0
+      get-east-asian-width: 1.5.0
+      strip-ansi: 7.2.0
+
+  string-width@8.2.0:
+    dependencies:
       get-east-asian-width: 1.5.0
       strip-ansi: 7.2.0
 
@@ -2373,6 +2774,8 @@ snapshots:
     dependencies:
       has-flag: 4.0.0
 
+  tagged-tag@1.0.0: {}
+
   tar-fs@2.1.4:
     dependencies:
       chownr: 1.1.4
@@ -2387,6 +2790,8 @@ snapshots:
       fs-constants: 1.0.0
       inherits: 2.0.4
       readable-stream: 3.6.2
+
+  terminal-size@4.0.1: {}
 
   thenify-all@1.6.0:
     dependencies:
@@ -2457,6 +2862,10 @@ snapshots:
     dependencies:
       safe-buffer: 5.2.1
 
+  type-fest@5.5.0:
+    dependencies:
+      tagged-tag: 1.0.0
+
   typescript@5.9.3: {}
 
   ufo@1.6.3: {}
@@ -2524,6 +2933,20 @@ snapshots:
       siginfo: 2.0.0
       stackback: 0.0.2
 
+  widest-line@6.0.0:
+    dependencies:
+      string-width: 8.2.0
+
+  wrap-ansi@9.0.2:
+    dependencies:
+      ansi-styles: 6.2.3
+      string-width: 7.2.0
+      strip-ansi: 7.2.0
+
   wrappy@1.0.2: {}
+
+  ws@8.20.0: {}
+
+  yoga-layout@3.2.1: {}
 
   zod@3.25.76: {}

--- a/src/cli/commands/tui.ts
+++ b/src/cli/commands/tui.ts
@@ -1,0 +1,10 @@
+/**
+ * `verdict tui` — opens the interactive TUI.
+ */
+
+export async function tuiCommand(): Promise<void> {
+  // Dynamic import so the CLI start-up stays fast for non-TUI commands.
+  // Also avoids loading Ink/React into contexts that only want `verdict run`.
+  const { startTui } = await import('../../tui/index.js')
+  startTui()
+}

--- a/src/cli/index.ts
+++ b/src/cli/index.ts
@@ -16,6 +16,7 @@ import { leaderboardCommand } from './commands/leaderboard.js'
 import { reportCommand } from './commands/report.js'
 import { evalAddCommand, evalRemoveCommand, evalListCommand, evalInitCommand } from './commands/eval.js'
 import { contributeCommand } from './commands/contribute.js'
+import { tuiCommand } from './commands/tui.js'
 // Dashboard CLI removed - use custom build system in dashboard/build/ instead
 // See WORKFLOW.md for complete dashboard workflow
 
@@ -25,6 +26,11 @@ program
   .name('verdict')
   .description(chalk.bold('verdict') + '\nLLM eval framework. Benchmark local and cloud models with one config file.')
   .version('0.2.0')
+
+program
+  .command('tui')
+  .description('Open the interactive terminal UI (browse runs, launch evals, monitor daemon)')
+  .action(tuiCommand)
 
 program
   .command('init')

--- a/src/tui/App.tsx
+++ b/src/tui/App.tsx
@@ -1,0 +1,84 @@
+/**
+ * Root TUI component. Holds global keymap + screen router + overlays
+ * (palette, help). Individual screens are mounted based on state.screen.
+ */
+
+import { useState } from 'react'
+import { Box } from 'ink'
+import { useKeymap } from './hooks/useKeymap.js'
+import type { Screen } from './hooks/useKeymap.js'
+import { Layout } from './components/Layout.js'
+import { Palette, defaultCommands } from './components/Palette.js'
+import { HelpOverlay } from './components/HelpOverlay.js'
+import { Home } from './screens/Home.js'
+import { Runs } from './screens/Runs.js'
+import { RunDetail } from './screens/RunDetail.js'
+import { LiveRun } from './screens/LiveRun.js'
+import { Models } from './screens/Models.js'
+import type { EvalHistoryRow } from '../db/client.js'
+
+export function App() {
+  const { state, dispatch } = useKeymap()
+  const [detailRow, setDetailRow] = useState<EvalHistoryRow | null>(null)
+
+  const goto = (screen: Screen) => dispatch({ type: 'set-screen', screen })
+
+  const commands = defaultCommands(goto)
+
+  const renderScreen = () => {
+    switch (state.screen) {
+      case 'home':
+        return <Home />
+      case 'runs':
+        return (
+          <Runs
+            mode={state.mode}
+            filterQuery={state.filterQuery}
+            onFilterChange={(q) => dispatch({ type: 'set-filter-query', q })}
+            onExitFilter={() => dispatch({ type: 'set-mode', mode: 'normal' })}
+            onOpenRun={(row) => { setDetailRow(row); goto('run-detail') }}
+            onStartLiveRun={() => goto('live-run')}
+          />
+        )
+      case 'run-detail':
+        return detailRow
+          ? <RunDetail row={detailRow} onBack={() => goto('runs')} />
+          : <Runs
+              mode={state.mode}
+              filterQuery={state.filterQuery}
+              onFilterChange={(q) => dispatch({ type: 'set-filter-query', q })}
+              onExitFilter={() => dispatch({ type: 'set-mode', mode: 'normal' })}
+              onOpenRun={(row) => { setDetailRow(row); goto('run-detail') }}
+              onStartLiveRun={() => goto('live-run')}
+            />
+      case 'live-run':
+        return <LiveRun onBack={() => goto('home')} />
+      case 'models':
+        return <Models onBack={() => goto('home')} />
+      default:
+        return <Home />
+    }
+  }
+
+  return (
+    <Layout screen={state.screen} mode={state.mode}>
+      {renderScreen()}
+      {state.mode === 'command' && (
+        <Box marginTop={1}>
+          <Palette
+            commands={commands}
+            onClose={() => dispatch({ type: 'reset' })}
+          />
+        </Box>
+      )}
+      {state.mode === 'help' && (
+        <Box marginTop={1}>
+          <HelpOverlay
+            screen={state.screen}
+            onClose={() => dispatch({ type: 'reset' })}
+          />
+        </Box>
+      )}
+    </Layout>
+  )
+}

--- a/src/tui/__tests__/App.test.tsx
+++ b/src/tui/__tests__/App.test.tsx
@@ -1,0 +1,52 @@
+/**
+ * Smoke tests — render each screen via ink-testing-library and assert
+ * nothing crashes + key chrome is present.
+ */
+
+import { describe, it, expect } from 'vitest'
+import { render } from 'ink-testing-library'
+import { App } from '../App.js'
+import { Home } from '../screens/Home.js'
+import { Layout } from '../components/Layout.js'
+import { HelpOverlay } from '../components/HelpOverlay.js'
+
+describe('TUI smoke', () => {
+  it('renders App with header chrome', () => {
+    const { lastFrame, unmount } = render(<App />)
+    const frame = lastFrame() ?? ''
+    expect(frame).toContain('verdict')
+    expect(frame).toContain('Home')
+    unmount()
+  })
+
+  it('renders Home screen directly', () => {
+    const { lastFrame, unmount } = render(<Home />)
+    const frame = lastFrame() ?? ''
+    expect(frame).toContain('Top models')
+    expect(frame).toContain('Daemon')
+    unmount()
+  })
+
+  it('Layout renders footer hints', () => {
+    const { lastFrame, unmount } = render(
+      <Layout screen="home" mode="normal">
+        <></>
+      </Layout>
+    )
+    const frame = lastFrame() ?? ''
+    expect(frame).toContain(':')
+    expect(frame).toContain('cmd')
+    expect(frame).toContain('quit')
+    unmount()
+  })
+
+  it('HelpOverlay lists global keys', () => {
+    const { lastFrame, unmount } = render(
+      <HelpOverlay screen="home" onClose={() => {}} />
+    )
+    const frame = lastFrame() ?? ''
+    expect(frame).toContain('Command palette')
+    expect(frame).toContain('Filter visible list')
+    unmount()
+  })
+})

--- a/src/tui/components/FilterInput.tsx
+++ b/src/tui/components/FilterInput.tsx
@@ -1,0 +1,35 @@
+/**
+ * Small '/' filter bar. Displays when focused; screens pass the query into
+ * their own filter predicate.
+ */
+
+import { Box, Text, useInput } from 'ink'
+import { theme } from '../theme.js'
+
+export interface FilterInputProps {
+  value: string
+  onChange: (v: string) => void
+  onSubmit: () => void
+  onCancel: () => void
+  active: boolean
+}
+
+export function FilterInput({ value, onChange, onSubmit, onCancel, active }: FilterInputProps) {
+  useInput((input, key) => {
+    if (!active) return
+    if (key.escape) { onCancel(); return }
+    if (key.return) { onSubmit(); return }
+    if (key.backspace || key.delete) { onChange(value.slice(0, -1)); return }
+    if (input && !key.ctrl && !key.meta) onChange(value + input)
+  }, { isActive: active })
+
+  if (!active && !value) return null
+
+  return (
+    <Box>
+      <Text color={theme.accent}>/</Text>
+      <Text>{value}</Text>
+      {active && <Text color={theme.muted}>▏</Text>}
+    </Box>
+  )
+}

--- a/src/tui/components/HelpOverlay.tsx
+++ b/src/tui/components/HelpOverlay.tsx
@@ -1,0 +1,88 @@
+/**
+ * '?' help overlay. Lists global + screen-local keybinds.
+ */
+
+import { Box, Text, useInput } from 'ink'
+import { theme } from '../theme.js'
+
+export interface HelpOverlayProps {
+  screen: string
+  onClose: () => void
+}
+
+const GLOBAL = [
+  [':',       'Command palette'],
+  ['/',       'Filter visible list'],
+  ['?',       'Toggle this help'],
+  ['q',       'Quit'],
+  ['Esc',     'Cancel / back to normal mode'],
+  ['Tab',     'Next pane'],
+  ['1/2/3',   'Jump to Home / Runs / Models'],
+]
+
+const SCREEN_KEYS: Record<string, string[][]> = {
+  home: [
+    ['Enter',   'Open selected run'],
+  ],
+  runs: [
+    ['j/k',     'Next / prev row'],
+    ['g/G',     'Top / bottom'],
+    ['Enter',   'Open run detail'],
+    ['n',       'Start a new live run'],
+  ],
+  'run-detail': [
+    ['j/k',     'Next / prev case'],
+    ['d',       'Diff against baseline (Phase 2)'],
+  ],
+  'live-run': [
+    ['Ctrl-C',  'Abort run (checkpoint preserved)'],
+    ['s',       'Save as baseline (when done)'],
+  ],
+  models: [
+    ['d',       'Discover local models (Ollama/MLX/LM Studio)'],
+    ['r',       'Refresh list'],
+  ],
+}
+
+export function HelpOverlay({ screen, onClose }: HelpOverlayProps) {
+  useInput((_, key) => {
+    if (key.escape || key.return) onClose()
+  })
+
+  const screenKeys = SCREEN_KEYS[screen] ?? []
+
+  return (
+    <Box
+      flexDirection="column"
+      borderStyle="round"
+      borderColor={theme.accent}
+      paddingX={2}
+      paddingY={1}
+      width={60}
+    >
+      <Text color={theme.accent} bold>Keybinds — global</Text>
+      <Box flexDirection="column" marginTop={1}>
+        {GLOBAL.map(([k, v]) => (
+          <Box key={k}>
+            <Text color={theme.highlight}>{k.padEnd(10)}</Text>
+            <Text color={theme.text}>{v}</Text>
+          </Box>
+        ))}
+      </Box>
+      {screenKeys.length > 0 && (
+        <>
+          <Text color={theme.accent} bold>{'\n'}{screen}</Text>
+          <Box flexDirection="column" marginTop={1}>
+            {screenKeys.map(([k, v]) => (
+              <Box key={k}>
+                <Text color={theme.highlight}>{k.padEnd(10)}</Text>
+                <Text color={theme.text}>{v}</Text>
+              </Box>
+            ))}
+          </Box>
+        </>
+      )}
+      <Text color={theme.muted} dimColor>{'\n'}Press Esc or Enter to close</Text>
+    </Box>
+  )
+}

--- a/src/tui/components/Layout.tsx
+++ b/src/tui/components/Layout.tsx
@@ -1,0 +1,71 @@
+/**
+ * Top-to-bottom app chrome: header with the current screen + keybind footer.
+ */
+
+import { Box, Text } from 'ink'
+import { theme } from '../theme.js'
+import type { Screen, Mode } from '../hooks/useKeymap.js'
+
+export interface LayoutProps {
+  screen: Screen
+  mode: Mode
+  title?: string
+  children: React.ReactNode
+  footerHints?: [string, string][]
+}
+
+const SCREEN_NAMES: Record<Screen, string> = {
+  'home':       '1 Home',
+  'runs':       '2 Runs',
+  'models':     '3 Models',
+  'run-detail': 'Run Detail',
+  'live-run':   'Live Run',
+}
+
+export function Layout({ screen, mode, title, children, footerHints }: LayoutProps) {
+  const tabs: Screen[] = ['home', 'runs', 'models']
+  const globalHints: [string, string][] = [
+    [':', 'cmd'],
+    ['/', 'filter'],
+    ['?', 'help'],
+    ['q', 'quit'],
+  ]
+  const hints = [...(footerHints ?? []), ...globalHints]
+
+  return (
+    <Box flexDirection="column">
+      {/* Header */}
+      <Box borderStyle="round" borderColor={theme.border} paddingX={1}>
+        <Text color={theme.primary} bold>verdict </Text>
+        <Text color={theme.muted}>│ </Text>
+        {tabs.map(t => (
+          <Text
+            key={t}
+            color={t === screen ? theme.highlight : theme.muted}
+            bold={t === screen}
+          >
+            {SCREEN_NAMES[t]}  </Text>
+        ))}
+        <Text color={theme.muted}>│ </Text>
+        <Text color={theme.accent}>{title ?? SCREEN_NAMES[screen]}</Text>
+        <Box flexGrow={1}><Text> </Text></Box>
+        <Text color={theme.muted}>[{mode}] </Text>
+      </Box>
+
+      {/* Body */}
+      <Box flexDirection="column" paddingX={1} paddingY={1}>
+        {children}
+      </Box>
+
+      {/* Footer */}
+      <Box borderStyle="single" borderColor={theme.borderDim} paddingX={1}>
+        {hints.map(([k, v], i) => (
+          <Text key={i}>
+            <Text color={theme.highlight}>{k}</Text>
+            <Text color={theme.muted}>:{v}  </Text>
+          </Text>
+        ))}
+      </Box>
+    </Box>
+  )
+}

--- a/src/tui/components/LogStream.tsx
+++ b/src/tui/components/LogStream.tsx
@@ -1,0 +1,36 @@
+/**
+ * Auto-scrolling log pane. Last-N-lines view of a string[] source.
+ * Pause behavior is Phase 2 — for MVP we always show the tail.
+ */
+
+import { Box, Text } from 'ink'
+import { theme } from '../theme.js'
+
+export interface LogStreamProps {
+  lines: string[]
+  height?: number
+  title?: string
+}
+
+function colorFor(line: string): string {
+  const l = line.toLowerCase()
+  if (l.includes('error') || l.includes('failed')) return 'red'
+  if (l.includes('done') || l.includes('completed') || l.includes('success')) return 'green'
+  if (l.includes('starting') || l.includes('running') || l.includes('judging')) return 'cyan'
+  if (l.includes('warning') || l.includes('warn')) return 'yellow'
+  return theme.text
+}
+
+export function LogStream({ lines, height = 12, title }: LogStreamProps) {
+  const tail = lines.slice(-height)
+
+  return (
+    <Box flexDirection="column">
+      {title && <Text color={theme.muted} bold>{title}</Text>}
+      {tail.length === 0 && <Text color={theme.muted}>  (no output yet)</Text>}
+      {tail.map((line, i) => (
+        <Text key={i} color={colorFor(line)}>{' '}{line.slice(0, 200)}</Text>
+      ))}
+    </Box>
+  )
+}

--- a/src/tui/components/Palette.tsx
+++ b/src/tui/components/Palette.tsx
@@ -1,0 +1,106 @@
+/**
+ * Modal command palette, opened with ':' (see useKeymap).
+ * Fuzzy matches over a static command list using Fuse.js.
+ */
+
+import { useMemo, useState } from 'react'
+import { Box, Text, useInput } from 'ink'
+import Fuse from 'fuse.js'
+import { theme } from '../theme.js'
+import type { Screen } from '../hooks/useKeymap.js'
+
+export interface Command {
+  id: string
+  label: string
+  hint?: string
+  action: () => void
+}
+
+export interface PaletteProps {
+  commands: Command[]
+  onClose: () => void
+}
+
+export function Palette({ commands, onClose }: PaletteProps) {
+  const [query, setQuery] = useState('')
+  const [cursor, setCursor] = useState(0)
+
+  const fuse = useMemo(
+    () => new Fuse(commands, { keys: ['label', 'id'], threshold: 0.4 }),
+    [commands]
+  )
+  const results = query
+    ? fuse.search(query).map(r => r.item).slice(0, 10)
+    : commands.slice(0, 10)
+
+  useInput((input, key) => {
+    if (key.escape) { onClose(); return }
+    if (key.return) {
+      const cmd = results[cursor]
+      if (cmd) { cmd.action(); onClose() }
+      return
+    }
+    if (key.downArrow || (key.ctrl && input === 'n')) {
+      setCursor(c => Math.min(c + 1, results.length - 1))
+      return
+    }
+    if (key.upArrow || (key.ctrl && input === 'p')) {
+      setCursor(c => Math.max(c - 1, 0))
+      return
+    }
+    if (key.backspace || key.delete) {
+      setQuery(q => q.slice(0, -1))
+      setCursor(0)
+      return
+    }
+    if (input && !key.ctrl && !key.meta) {
+      setQuery(q => q + input)
+      setCursor(0)
+    }
+  })
+
+  return (
+    <Box
+      flexDirection="column"
+      borderStyle="round"
+      borderColor={theme.accent}
+      paddingX={1}
+      width={60}
+    >
+      <Box>
+        <Text color={theme.accent} bold>: </Text>
+        <Text>{query}</Text>
+        <Text color={theme.muted}>▏</Text>
+      </Box>
+      <Box flexDirection="column" marginTop={1}>
+        {results.length === 0 && (
+          <Text color={theme.muted}>  No matching commands</Text>
+        )}
+        {results.map((cmd, i) => {
+          const selected = i === cursor
+          return (
+            <Box key={cmd.id}>
+              <Text color={selected ? theme.highlight : theme.text} inverse={selected}>
+                {' '}{cmd.label.padEnd(30)}
+              </Text>
+              {cmd.hint && (
+                <Text color={theme.muted} dimColor>{' '}{cmd.hint}</Text>
+              )}
+            </Box>
+          )
+        })}
+      </Box>
+    </Box>
+  )
+}
+
+/** Build the default command list given a dispatch. Used by App. */
+export function defaultCommands(goto: (s: Screen) => void): Command[] {
+  return [
+    { id: 'goto:home',    label: 'Go to Home',         hint: '1', action: () => goto('home') },
+    { id: 'goto:runs',    label: 'Go to Runs',         hint: '2', action: () => goto('runs') },
+    { id: 'goto:models',  label: 'Go to Models',       hint: '3', action: () => goto('models') },
+    { id: 'goto:live',    label: 'New Live Run',       hint: 'Start a fresh eval', action: () => goto('live-run') },
+    { id: 'help',         label: 'Show help',          hint: '?', action: () => { /* overlay triggered by caller */ } },
+  ]
+}

--- a/src/tui/components/Sparkline.tsx
+++ b/src/tui/components/Sparkline.tsx
@@ -1,0 +1,18 @@
+/**
+ * Thin wrapper around `sparkly` for per-model score trend display.
+ */
+
+import { Text } from 'ink'
+import sparkly from 'sparkly'
+import { theme, type ThemeColor } from '../theme.js'
+
+export interface SparklineProps {
+  values: number[]
+  color?: ThemeColor
+}
+
+export function Sparkline({ values, color = theme.highlight }: SparklineProps) {
+  if (values.length === 0) return <Text color={theme.muted}>·</Text>
+  const chart = sparkly(values)
+  return <Text color={color}>{chart}</Text>
+}

--- a/src/tui/components/Table.tsx
+++ b/src/tui/components/Table.tsx
@@ -1,0 +1,114 @@
+/**
+ * Simple scrollable table. Viewport-windowed so ~10k rows scroll smoothly.
+ *
+ * No virtualized re-render magic — we just slice the rows array to the
+ * visible window. That's plenty for <10k rows and avoids DOM-like diffing.
+ */
+
+import { useState } from 'react'
+import { Box, Text, useInput } from 'ink'
+import { theme, type ThemeColor } from '../theme.js'
+
+export interface Column<T> {
+  key: string
+  header: string
+  width?: number
+  align?: 'left' | 'right'
+  render: (row: T) => string
+  color?: (row: T) => ThemeColor | undefined
+}
+
+export interface TableProps<T> {
+  rows: T[]
+  columns: Column<T>[]
+  focused?: boolean
+  height?: number
+  emptyMessage?: string
+  onEnter?: (row: T, index: number) => void
+  onSelectionChange?: (row: T | null, index: number) => void
+}
+
+function padCell(s: string, width: number, align: 'left' | 'right' = 'left'): string {
+  if (s.length >= width) return s.slice(0, width)
+  const pad = ' '.repeat(width - s.length)
+  return align === 'right' ? pad + s : s + pad
+}
+
+export function Table<T>({
+  rows,
+  columns,
+  focused = true,
+  height = 15,
+  emptyMessage = 'No rows',
+  onEnter,
+  onSelectionChange,
+}: TableProps<T>) {
+  const [cursor, setCursor] = useState(0)
+  const [offset, setOffset] = useState(0)
+
+  useInput((input, key) => {
+    if (!focused || rows.length === 0) return
+    let next = cursor
+    if (input === 'j' || key.downArrow) next = Math.min(cursor + 1, rows.length - 1)
+    else if (input === 'k' || key.upArrow) next = Math.max(cursor - 1, 0)
+    else if (key.pageDown) next = Math.min(cursor + height, rows.length - 1)
+    else if (key.pageUp) next = Math.max(cursor - height, 0)
+    else if (input === 'g') next = 0
+    else if (input === 'G') next = rows.length - 1
+    else if (key.return && onEnter) { onEnter(rows[cursor], cursor); return }
+    else return
+    if (next !== cursor) {
+      setCursor(next)
+      if (next < offset) setOffset(next)
+      else if (next >= offset + height) setOffset(next - height + 1)
+      if (onSelectionChange) onSelectionChange(rows[next] ?? null, next)
+    }
+  }, { isActive: focused })
+
+  const visibleRows = rows.slice(offset, offset + height)
+
+  return (
+    <Box flexDirection="column">
+      {/* Header */}
+      <Box>
+        {columns.map(c => (
+          <Text key={c.key} color={theme.muted} bold>
+            {padCell(c.header, c.width ?? 12, c.align)}{' '}
+          </Text>
+        ))}
+      </Box>
+      {/* Rows */}
+      {rows.length === 0 && (
+        <Text color={theme.muted}>  {emptyMessage}</Text>
+      )}
+      {visibleRows.map((row, i) => {
+        const absoluteIdx = offset + i
+        const isSelected = absoluteIdx === cursor
+        return (
+          <Box key={absoluteIdx}>
+            {columns.map(c => {
+              const raw = c.render(row)
+              const color = c.color?.(row)
+              return (
+                <Text
+                  key={c.key}
+                  color={isSelected ? theme.highlight : color}
+                  inverse={isSelected && focused}
+                >
+                  {padCell(raw, c.width ?? 12, c.align)}{' '}
+                </Text>
+              )
+            })}
+          </Box>
+        )
+      })}
+      {/* Scroll indicator */}
+      {rows.length > height && (
+        <Text color={theme.muted} dimColor>
+          {' '}
+          {Math.min(offset + height, rows.length)}/{rows.length}
+        </Text>
+      )}
+    </Box>
+  )
+}

--- a/src/tui/hooks/useConfig.ts
+++ b/src/tui/hooks/useConfig.ts
@@ -1,0 +1,32 @@
+/**
+ * Load a verdict.yaml config (Zod-validated) for read-only display in the TUI.
+ * Writing is Phase 2 (Config Editor screen).
+ */
+
+import { useEffect, useState } from 'react'
+import fs from 'fs'
+import path from 'path'
+import { loadConfig } from '../../core/config.js'
+import type { Config } from '../../types/index.js'
+
+export function useConfig(configPath = './verdict.yaml') {
+  const [config, setConfig] = useState<Config | null>(null)
+  const [error, setError] = useState<string | null>(null)
+
+  useEffect(() => {
+    try {
+      const abs = path.resolve(configPath)
+      if (!fs.existsSync(abs)) {
+        setError(`Config not found: ${abs}`)
+        return
+      }
+      const cfg = loadConfig(abs)
+      setConfig(cfg)
+      setError(null)
+    } catch (e) {
+      setError((e as Error).message)
+    }
+  }, [configPath])
+
+  return { config, error }
+}

--- a/src/tui/hooks/useDaemon.ts
+++ b/src/tui/hooks/useDaemon.ts
@@ -1,0 +1,65 @@
+/**
+ * Subscribe to daemon state. Polls the Unix-socket IPC at ~/.verdict/daemon.sock
+ * and tails ~/.verdict/daemon.log for live output.
+ */
+
+import { useEffect, useState, useRef } from 'react'
+import fs from 'fs'
+import { sendIpc } from '../../daemon/ipc.js'
+import { LOG_FILE } from '../../daemon/index.js'
+import type { DaemonStatus } from '../../daemon/index.js'
+
+export function useDaemonStatus(refreshMs = 3000) {
+  const [status, setStatus] = useState<DaemonStatus | null>(null)
+  const [reachable, setReachable] = useState(false)
+  const [tick, setTick] = useState(0)
+
+  useEffect(() => {
+    let cancelled = false
+    sendIpc({ action: 'status' })
+      .then(res => {
+        if (cancelled) return
+        if (res.ok && res.data) {
+          setStatus(res.data as DaemonStatus)
+          setReachable(true)
+        } else {
+          setReachable(false)
+        }
+      })
+      .catch(() => { if (!cancelled) setReachable(false) })
+    return () => { cancelled = true }
+  }, [tick])
+
+  useEffect(() => {
+    const t = setInterval(() => setTick(x => x + 1), refreshMs)
+    return () => clearInterval(t)
+  }, [refreshMs])
+
+  return { status, reachable, refresh: () => setTick(x => x + 1) }
+}
+
+/** Tail the daemon log file — returns the last `maxLines` lines, kept fresh. */
+export function useDaemonLog(maxLines = 200, refreshMs = 1000) {
+  const [lines, setLines] = useState<string[]>([])
+  const lastSize = useRef(0)
+
+  useEffect(() => {
+    const read = () => {
+      try {
+        const stat = fs.statSync(LOG_FILE)
+        if (stat.size === lastSize.current) return
+        lastSize.current = stat.size
+        const buf = fs.readFileSync(LOG_FILE, 'utf8')
+        const all = buf.split('\n').filter(Boolean)
+        setLines(all.slice(-maxLines))
+      } catch {
+        setLines([])
+      }
+    }
+    read()
+    const t = setInterval(read, refreshMs)
+    return () => clearInterval(t)
+  }, [maxLines, refreshMs])
+
+  return lines
+}

--- a/src/tui/hooks/useDb.ts
+++ b/src/tui/hooks/useDb.ts
@@ -1,0 +1,76 @@
+/**
+ * Thin hook around the existing SQLite client in src/db/client.ts.
+ * Opens the DB once on mount and exposes memoized query helpers that re-run
+ * when their args change.
+ */
+
+import { useEffect, useMemo, useState } from 'react'
+import type Database from 'better-sqlite3'
+import { getDb, initSchema, queryHistory, getJobs } from '../../db/client.js'
+import type { EvalHistoryRow, HistoryOpts, JobRow } from '../../db/client.js'
+
+let cachedDb: Database.Database | null = null
+
+function openDb(): Database.Database {
+  if (cachedDb) return cachedDb
+  const db = getDb()
+  initSchema(db)
+  cachedDb = db
+  return db
+}
+
+export function useDb() {
+  const db = useMemo(() => openDb(), [])
+  return db
+}
+
+/** Poll history every `refreshMs` ms. Returns rows + a manual refresh function. */
+export function useHistory(opts: HistoryOpts = {}, refreshMs = 5000) {
+  const db = useDb()
+  const [rows, setRows] = useState<EvalHistoryRow[]>([])
+  const [tick, setTick] = useState(0)
+  const key = JSON.stringify(opts)
+
+  useEffect(() => {
+    let cancelled = false
+    try {
+      const r = queryHistory(db, opts)
+      if (!cancelled) setRows(r)
+    } catch {
+      if (!cancelled) setRows([])
+    }
+    return () => { cancelled = true }
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, [key, tick, db])
+
+  useEffect(() => {
+    if (!refreshMs) return
+    const t = setInterval(() => setTick(x => x + 1), refreshMs)
+    return () => clearInterval(t)
+  }, [refreshMs])
+
+  return { rows, refresh: () => setTick(x => x + 1) }
+}
+
+export function useJobs(status?: string, refreshMs = 3000) {
+  const db = useDb()
+  const [rows, setRows] = useState<JobRow[]>([])
+  const [tick, setTick] = useState(0)
+
+  useEffect(() => {
+    try {
+      const r = getJobs(db, { status, limit: 20 })
+      setRows(r)
+    } catch {
+      setRows([])
+    }
+  }, [tick, status, db])
+
+  useEffect(() => {
+    if (!refreshMs) return
+    const t = setInterval(() => setTick(x => x + 1), refreshMs)
+    return () => clearInterval(t)
+  }, [refreshMs])
+
+  return { rows, refresh: () => setTick(x => x + 1) }
+}

--- a/src/tui/hooks/useKeymap.ts
+++ b/src/tui/hooks/useKeymap.ts
@@ -1,0 +1,108 @@
+/**
+ * Centralized keymap reducer for vim-style TUI modes.
+ *
+ * Modes:
+ *  - normal   — hjkl navigation, screen-level shortcuts
+ *  - insert   — text input (form fields, search)
+ *  - command  — ':' palette open, fuzzy match commands
+ *  - filter   — '/' filter open on a list
+ *  - help     — '?' help overlay visible
+ */
+
+import { useReducer, useEffect } from 'react'
+import { useInput, useApp } from 'ink'
+
+export type Mode = 'normal' | 'insert' | 'command' | 'filter' | 'help'
+
+export interface KeymapState {
+  mode: Mode
+  screen: Screen
+  paletteQuery: string
+  filterQuery: string
+}
+
+export type Screen =
+  | 'home'
+  | 'runs'
+  | 'run-detail'
+  | 'live-run'
+  | 'models'
+
+export type Action =
+  | { type: 'set-mode'; mode: Mode }
+  | { type: 'set-screen'; screen: Screen }
+  | { type: 'set-palette-query'; q: string }
+  | { type: 'set-filter-query'; q: string }
+  | { type: 'reset' }
+
+const initial: KeymapState = {
+  mode: 'normal',
+  screen: 'home',
+  paletteQuery: '',
+  filterQuery: '',
+}
+
+function reducer(state: KeymapState, action: Action): KeymapState {
+  switch (action.type) {
+    case 'set-mode':
+      return { ...state, mode: action.mode }
+    case 'set-screen':
+      return { ...state, screen: action.screen, mode: 'normal', filterQuery: '' }
+    case 'set-palette-query':
+      return { ...state, paletteQuery: action.q }
+    case 'set-filter-query':
+      return { ...state, filterQuery: action.q }
+    case 'reset':
+      return { ...state, mode: 'normal', paletteQuery: '', filterQuery: '' }
+    default:
+      return state
+  }
+}
+
+/**
+ * Global keymap — handles :, /, ?, q (quit), g (go), and screen-level
+ * routing. Individual screens can consume useInput() additionally to handle
+ * pane-local keys (hjkl etc).
+ */
+export function useKeymap() {
+  const [state, dispatch] = useReducer(reducer, initial)
+  const { exit } = useApp()
+
+  useInput((input, key) => {
+    // Global escape returns to normal mode
+    if (key.escape) {
+      dispatch({ type: 'reset' })
+      return
+    }
+    // Global exit (only in normal mode, to avoid eating q in search)
+    if (state.mode === 'normal' && (input === 'q' || (key.ctrl && input === 'c'))) {
+      exit()
+      return
+    }
+    // Route openers
+    if (state.mode === 'normal') {
+      if (input === ':') {
+        dispatch({ type: 'set-mode', mode: 'command' })
+        return
+      }
+      if (input === '/') {
+        dispatch({ type: 'set-mode', mode: 'filter' })
+        return
+      }
+      if (input === '?') {
+        dispatch({ type: 'set-mode', mode: 'help' })
+        return
+      }
+      // Number-key screen jumps (lazygit-style)
+      if (input === '1') dispatch({ type: 'set-screen', screen: 'home' })
+      if (input === '2') dispatch({ type: 'set-screen', screen: 'runs' })
+      if (input === '3') dispatch({ type: 'set-screen', screen: 'models' })
+    }
+  })
+
+  useEffect(() => {
+    // Noop — placeholder for future effects (e.g. hide cursor)
+  }, [])
+
+  return { state, dispatch }
+}

--- a/src/tui/hooks/useLiveRun.ts
+++ b/src/tui/hooks/useLiveRun.ts
@@ -1,0 +1,88 @@
+/**
+ * Wraps core/runner.ts runEvals() with a React-friendly event log.
+ *
+ * runEvals accepts onProgress(msg: string). The TUI captures every message
+ * and exposes:
+ *   - log:      all messages (for LogStream pane)
+ *   - phase:    'idle' | 'running' | 'done' | 'error'
+ *   - current:  the last message (status line)
+ *   - result:   the RunResult when done
+ *
+ * Throttled to ~30fps to avoid flicker on high-frequency updates.
+ */
+
+import { useCallback, useRef, useState } from 'react'
+import { runEvals } from '../../core/runner.js'
+import { loadConfig, loadEvalPack } from '../../core/config.js'
+import path from 'path'
+import type { Config, EvalPack, RunResult } from '../../types/index.js'
+
+export type Phase = 'idle' | 'running' | 'done' | 'error'
+
+export interface LiveRunState {
+  phase: Phase
+  current: string
+  log: string[]
+  result: RunResult | null
+  error: string | null
+}
+
+export function useLiveRun() {
+  const [state, setState] = useState<LiveRunState>({
+    phase: 'idle',
+    current: '',
+    log: [],
+    result: null,
+    error: null,
+  })
+  const pendingRef = useRef<string[]>([])
+  const rafRef = useRef<NodeJS.Timeout | null>(null)
+
+  const flush = useCallback(() => {
+    const pending = pendingRef.current
+    if (pending.length === 0) return
+    pendingRef.current = []
+    setState(s => ({
+      ...s,
+      log: [...s.log, ...pending].slice(-500),
+      current: pending[pending.length - 1] ?? s.current,
+    }))
+  }, [])
+
+  const push = useCallback((msg: string) => {
+    pendingRef.current.push(msg)
+    if (rafRef.current) return
+    rafRef.current = setTimeout(() => {
+      rafRef.current = null
+      flush()
+    }, 33) // ~30 fps
+  }, [flush])
+
+  const start = useCallback(async (opts: {
+    configPath?: string
+    config?: Config
+    packs?: EvalPack[]
+    resume?: boolean
+    categoryFilter?: string[]
+  }) => {
+    setState({ phase: 'running', current: '', log: [], result: null, error: null })
+    try {
+      const cfgPath = opts.configPath ?? './verdict.yaml'
+      const config = opts.config ?? loadConfig(path.resolve(cfgPath))
+      const packs = opts.packs ?? config.packs.map(p =>
+        loadEvalPack(p, path.dirname(path.resolve(cfgPath)))
+      )
+      const result = await runEvals(
+        config, packs, push, opts.resume, opts.categoryFilter, true, cfgPath
+      )
+      // Ensure any pending messages flushed before we mark done
+      flush()
+      setState(s => ({ ...s, phase: 'done', result }))
+    } catch (e) {
+      flush()
+      setState(s => ({ ...s, phase: 'error', error: (e as Error).message }))
+    }
+  }, [push, flush])
+
+  return { state, start }
+}

--- a/src/tui/index.tsx
+++ b/src/tui/index.tsx
@@ -1,0 +1,12 @@
+/**
+ * Entry point — `verdict tui` renders <App /> via Ink.
+ */
+
+import { render } from 'ink'
+import { App } from './App.js'
+
+export function startTui(): void {
+  // Clear screen on start for a clean slate
+  process.stdout.write('\x1Bc')
+  render(<App />)
+}

--- a/src/tui/screens/Home.tsx
+++ b/src/tui/screens/Home.tsx
@@ -1,0 +1,97 @@
+/**
+ * Home screen — at-a-glance dashboard.
+ * Shows top models (avg score across recent runs), daemon status, job queue depth.
+ */
+
+import { useMemo } from 'react'
+import { Box, Text } from 'ink'
+import { theme, scoreColor } from '../theme.js'
+import { useHistory, useJobs } from '../hooks/useDb.js'
+import { useDaemonStatus } from '../hooks/useDaemon.js'
+import { Sparkline } from '../components/Sparkline.js'
+import type { EvalHistoryRow } from '../../db/client.js'
+
+interface ModelAgg {
+  model_id: string
+  runs: number
+  avgScore: number
+  scoreHistory: number[]
+  lastSeen: string
+}
+
+function aggregateByModel(rows: EvalHistoryRow[]): ModelAgg[] {
+  const byModel = new Map<string, ModelAgg>()
+  // rows come in date DESC; walk in reverse so scoreHistory is chronological
+  const chrono = [...rows].reverse()
+  for (const r of chrono) {
+    const agg = byModel.get(r.model_id) ?? {
+      model_id: r.model_id, runs: 0, avgScore: 0, scoreHistory: [], lastSeen: r.run_at,
+    }
+    agg.runs += 1
+    agg.avgScore = (agg.avgScore * (agg.runs - 1) + r.score) / agg.runs
+    agg.scoreHistory.push(r.score)
+    agg.lastSeen = r.run_at
+    byModel.set(r.model_id, agg)
+  }
+  return [...byModel.values()].sort((a, b) => b.avgScore - a.avgScore)
+}
+
+export function Home() {
+  const { rows } = useHistory({ limit: 200 }, 5000)
+  const { rows: jobs } = useJobs(undefined, 3000)
+  const { status, reachable } = useDaemonStatus()
+
+  const agg = useMemo(() => aggregateByModel(rows), [rows])
+  const top = agg.slice(0, 8)
+
+  const queued = jobs.filter(j => j.status === 'queued').length
+  const running = jobs.filter(j => j.status === 'running').length
+
+  return (
+    <Box flexDirection="column">
+      <Box marginBottom={1}>
+        <Text color={theme.accent} bold>⚡ Top models  </Text>
+        <Text color={theme.muted}>(avg across {rows.length} runs)</Text>
+      </Box>
+
+      {top.length === 0 && (
+        <Text color={theme.muted}>
+          No runs yet. Press <Text color={theme.highlight}>:</Text> and run{' '}
+          <Text color={theme.highlight}>New Live Run</Text>, or use <Text color={theme.highlight}>verdict run</Text>.
+        </Text>
+      )}
+
+      {top.map((m, i) => (
+        <Box key={m.model_id}>
+          <Text color={theme.muted}>{String(i + 1).padStart(2)}. </Text>
+          <Text color={theme.text}>{m.model_id.padEnd(32).slice(0, 32)}  </Text>
+          <Text color={scoreColor(m.avgScore)} bold>{m.avgScore.toFixed(2).padStart(5)}  </Text>
+          <Sparkline values={m.scoreHistory.slice(-20)} />
+          <Text color={theme.muted}>  {m.runs} run{m.runs === 1 ? '' : 's'}</Text>
+        </Box>
+      ))}
+
+      {/* Daemon status */}
+      <Box marginTop={2} flexDirection="column">
+        <Text color={theme.accent} bold>🛰  Daemon</Text>
+        {reachable && status ? (
+          <>
+            <Text>   status: <Text color={theme.success}>running</Text>{' '}
+              {status.uptimeSeconds ? <Text color={theme.muted}>uptime {Math.floor(status.uptimeSeconds)}s</Text> : null}
+            </Text>
+            <Text>   queue:  <Text color={theme.text}>{status.queueDepth}</Text>{' '}
+              <Text color={theme.muted}>({running} running, {queued} queued)</Text>
+            </Text>
+            <Text>   today:  <Text color={theme.success}>✓ {status.completedToday}</Text>{' '}
+              <Text color={theme.danger}>✗ {status.failedToday}</Text>
+            </Text>
+          </>
+        ) : (
+          <Text color={theme.muted}>
+            {'   '}stopped — run <Text color={theme.highlight}>verdict daemon start</Text>
+          </Text>
+        )}
+      </Box>
+    </Box>
+  )
+}

--- a/src/tui/screens/LiveRun.tsx
+++ b/src/tui/screens/LiveRun.tsx
@@ -1,0 +1,96 @@
+/**
+ * LiveRun — start an eval and watch progress in real time.
+ *
+ * MVP: uses the verdict.yaml in cwd, shows a single Start action, then streams
+ * runner onProgress() messages via useLiveRun.
+ */
+
+import { useEffect } from 'react'
+import { Box, Text, useInput } from 'ink'
+import { Spinner } from '@inkjs/ui'
+import { theme, scoreColor } from '../theme.js'
+import { LogStream } from '../components/LogStream.js'
+import { useLiveRun } from '../hooks/useLiveRun.js'
+import { useConfig } from '../hooks/useConfig.js'
+
+export interface LiveRunProps {
+  onBack: () => void
+}
+
+export function LiveRun({ onBack: _onBack }: LiveRunProps) {
+  const { state, start } = useLiveRun()
+  const { config, error: cfgErr } = useConfig('./verdict.yaml')
+
+  // Auto-start on mount if config loaded and idle — easier for MVP than a form
+  useEffect(() => {
+    if (state.phase === 'idle' && config) {
+      start({ configPath: './verdict.yaml' })
+    }
+  }, [state.phase, config, start])
+
+  useInput((input) => {
+    if (input === 'r' && state.phase !== 'running') {
+      start({ configPath: './verdict.yaml' })
+    }
+  })
+
+  if (cfgErr) {
+    return (
+      <Box flexDirection="column">
+        <Text color={theme.danger}>Config error</Text>
+        <Text color={theme.muted}>{cfgErr}</Text>
+        <Text color={theme.muted}>{'\n'}Esc to go back</Text>
+      </Box>
+    )
+  }
+
+  return (
+    <Box flexDirection="column">
+      <Box marginBottom={1}>
+        <Text color={theme.accent} bold>▶ Live run</Text>
+        {config && <Text color={theme.muted}>
+          {'  '}·  {config.models.length} model{config.models.length === 1 ? '' : 's'}
+          {'  ·  judge: '}{config.judge.model}
+          {'  ·  concurrency: '}{config.run.concurrency}
+        </Text>}
+      </Box>
+
+      {state.phase === 'running' && (
+        <Box>
+          <Spinner />
+          <Text color={theme.primary}> {state.current || 'starting…'}</Text>
+        </Box>
+      )}
+      {state.phase === 'done' && (
+        <Text color={theme.success} bold>✓ Done. Press r to run again, Esc to go back.</Text>
+      )}
+      {state.phase === 'error' && (
+        <Box flexDirection="column">
+          <Text color={theme.danger}>✗ {state.error}</Text>
+          <Text color={theme.muted}>Press r to retry</Text>
+        </Box>
+      )}
+
+      <Box marginTop={1}>
+        <LogStream lines={state.log} height={14} title="progress" />
+      </Box>
+
+      {state.result && (
+        <Box marginTop={1} flexDirection="column" borderStyle="single" borderColor={theme.borderDim} paddingX={1}>
+          <Text color={theme.accent} bold>Summary</Text>
+          {Object.values(state.result.summary)
+            .sort((a, b) => b.avg_total - a.avg_total)
+            .slice(0, 8)
+            .map((s, i) => (
+              <Box key={s.model_id}>
+                <Text color={theme.muted}>{String(i + 1).padStart(2)}. </Text>
+                <Text>{s.model_id.padEnd(30).slice(0, 30)} </Text>
+                <Text color={scoreColor(s.avg_total)} bold>{s.avg_total.toFixed(2).padStart(5)}</Text>
+                <Text color={theme.muted}>  wins {s.wins}/{s.cases_run}</Text>
+              </Box>
+            ))}
+        </Box>
+      )}
+    </Box>
+  )
+}

--- a/src/tui/screens/Models.tsx
+++ b/src/tui/screens/Models.tsx
@@ -1,0 +1,101 @@
+/**
+ * Models screen — list configured models from verdict.yaml and (on 'd')
+ * discover local Ollama/MLX running servers.
+ */
+
+import { useState } from 'react'
+import { Box, Text, useInput } from 'ink'
+import { theme } from '../theme.js'
+import { Table, type Column } from '../components/Table.js'
+import { useConfig } from '../hooks/useConfig.js'
+import { discoverOllama } from '../../providers/ollama.js'
+import { discoverMLX } from '../../providers/mlx.js'
+import type { DiscoveredModel, ModelConfig } from '../../types/index.js'
+
+export interface ModelsProps {
+  onBack?: () => void
+}
+
+export function Models(_props: ModelsProps) {
+  const { config, error } = useConfig('./verdict.yaml')
+  const [discovered, setDiscovered] = useState<DiscoveredModel[]>([])
+  const [scanning, setScanning] = useState(false)
+  const [scanError, setScanError] = useState<string | null>(null)
+
+  const discover = async () => {
+    setScanning(true)
+    setScanError(null)
+    try {
+      const [oll, mlx] = await Promise.all([
+        discoverOllama().catch(() => []),
+        discoverMLX().catch(() => []),
+      ])
+      setDiscovered([...oll, ...mlx])
+    } catch (e) {
+      setScanError((e as Error).message)
+    } finally {
+      setScanning(false)
+    }
+  }
+
+  useInput((input) => {
+    if (input === 'd') discover()
+  })
+
+  const configuredCols: Column<ModelConfig>[] = [
+    { key: 'id', header: 'ID', width: 26, render: m => m.id },
+    { key: 'provider', header: 'PROVIDER', width: 10, render: m => m.provider ?? 'compat' },
+    { key: 'model', header: 'MODEL', width: 30, render: m => m.model },
+    { key: 'tags', header: 'TAGS', width: 20, render: m => (m.tags ?? []).join(', ') },
+  ]
+
+  const discoveredCols: Column<DiscoveredModel>[] = [
+    { key: 'provider', header: 'PROVIDER', width: 10, render: m => m.provider },
+    { key: 'model', header: 'MODEL', width: 34, render: m => m.model },
+    { key: 'size', header: 'SIZE', width: 7, align: 'right',
+      render: m => m.size_gb ? m.size_gb.toFixed(1) + 'G' : '-' },
+    { key: 'moe', header: 'MoE', width: 4, render: m => m.is_moe ? '●' : ' ' },
+    { key: 'tags', header: 'TAGS', width: 18, render: m => m.tags.join(', ') },
+  ]
+
+  return (
+    <Box flexDirection="column">
+      <Box marginBottom={1}>
+        <Text color={theme.accent} bold>🤖 Configured models  </Text>
+        <Text color={theme.muted}>(from verdict.yaml)  </Text>
+        <Text color={theme.muted}>d: discover local</Text>
+      </Box>
+
+      {error && <Text color={theme.danger}>  {error}</Text>}
+
+      {config && (
+        <Table
+          rows={config.models}
+          columns={configuredCols}
+          height={10}
+          emptyMessage="No models configured"
+        />
+      )}
+
+      <Box marginTop={2}>
+        <Text color={theme.accent} bold>🔎 Discovered on this machine  </Text>
+        {scanning && <Text color={theme.primary}>scanning…</Text>}
+        {!scanning && discovered.length > 0 && (
+          <Text color={theme.muted}>({discovered.length} found)</Text>
+        )}
+      </Box>
+      {scanError && <Text color={theme.danger}>  {scanError}</Text>}
+      {!scanning && discovered.length === 0 && (
+        <Text color={theme.muted}>  Press <Text color={theme.highlight}>d</Text> to scan Ollama / MLX / LM Studio</Text>
+      )}
+      {discovered.length > 0 && (
+        <Table
+          rows={discovered}
+          columns={discoveredCols}
+          height={8}
+          focused={false}
+        />
+      )}
+    </Box>
+  )
+}

--- a/src/tui/screens/RunDetail.tsx
+++ b/src/tui/screens/RunDetail.tsx
@@ -1,0 +1,91 @@
+/**
+ * RunDetail — per-case breakdown for a single run.
+ *
+ * Reads question_results rows directly via the raw DB (existing saveRunResult
+ * persists them). In Phase 2 we'll wire richer per-case JSON display.
+ */
+
+import { useEffect, useMemo, useState } from 'react'
+import { Box, Text } from 'ink'
+import { theme, scoreColor } from '../theme.js'
+import { Table, type Column } from '../components/Table.js'
+import { useDb } from '../hooks/useDb.js'
+import type { EvalHistoryRow } from '../../db/client.js'
+
+export interface RunDetailProps {
+  row: EvalHistoryRow
+  onBack: () => void
+}
+
+interface CaseRow {
+  case_id: string
+  prompt: string
+  score: number
+  latency_ms: number | null
+  response: string | null
+}
+
+export function RunDetail({ row, onBack: _onBack }: RunDetailProps) {
+  const db = useDb()
+  const [cases, setCases] = useState<CaseRow[]>([])
+  const [selected, setSelected] = useState<CaseRow | null>(null)
+
+  useEffect(() => {
+    try {
+      const stmt = db.prepare(`
+        SELECT qr.case_id, qr.prompt, qr.score, qr.latency_ms, qr.response
+          FROM question_results qr
+          JOIN eval_results er ON er.id = qr.eval_result_id
+         WHERE er.run_id = @run_id AND qr.model_id = @model_id
+         ORDER BY qr.id ASC
+      `)
+      const rows = stmt.all({ run_id: row.run_id, model_id: row.model_id }) as CaseRow[]
+      setCases(rows)
+    } catch {
+      setCases([])
+    }
+  }, [db, row.run_id, row.model_id])
+
+  const columns: Column<CaseRow>[] = useMemo(() => [
+    { key: 'id',    header: 'CASE',   width: 22, render: c => c.case_id },
+    { key: 'score', header: 'SCORE',  width: 6, align: 'right',
+      render: c => c.score.toFixed(2),
+      color: c => scoreColor(c.score) },
+    { key: 'lat',   header: 'LAT ms', width: 7, align: 'right',
+      render: c => (c.latency_ms ?? 0).toFixed(0) },
+    { key: 'prompt', header: 'PROMPT', width: 40,
+      render: c => c.prompt.slice(0, 38).replace(/\n/g, ' ') },
+  ], [])
+
+  return (
+    <Box flexDirection="column">
+      <Box marginBottom={1} flexDirection="column">
+        <Text color={theme.accent} bold>📊 {row.model_id}  </Text>
+        <Text color={theme.muted}>
+          {row.pack} · {row.cases_run} cases · avg{' '}
+          <Text color={scoreColor(row.score)}>{row.score.toFixed(2)}</Text>
+          {row.total_cost_usd != null && <> · ${row.total_cost_usd.toFixed(4)}</>}
+        </Text>
+        <Text color={theme.muted}>run_id: {row.run_id}</Text>
+      </Box>
+      <Table
+        rows={cases}
+        columns={columns}
+        height={12}
+        emptyMessage="No per-case data stored for this run"
+        onSelectionChange={(r) => setSelected(r)}
+      />
+      {selected && (
+        <Box marginTop={1} flexDirection="column" borderStyle="single" borderColor={theme.borderDim} paddingX={1}>
+          <Text color={theme.muted}>prompt</Text>
+          <Text>{selected.prompt.slice(0, 500)}</Text>
+          <Text color={theme.muted}>{'\n'}response</Text>
+          <Text color={theme.text}>{(selected.response ?? '').slice(0, 800)}</Text>
+        </Box>
+      )}
+      <Box marginTop={1}>
+        <Text color={theme.muted}>Esc: back to runs</Text>
+      </Box>
+    </Box>
+  )
+}

--- a/src/tui/screens/Runs.tsx
+++ b/src/tui/screens/Runs.tsx
@@ -1,0 +1,113 @@
+/**
+ * Runs screen — paginated history table filterable by `/`.
+ * Enter opens RunDetail for the selected row.
+ */
+
+import { useMemo, useState } from 'react'
+import { Box, Text, useInput } from 'ink'
+import { theme, scoreColor } from '../theme.js'
+import { Table, type Column } from '../components/Table.js'
+import { FilterInput } from '../components/FilterInput.js'
+import { useHistory } from '../hooks/useDb.js'
+import type { EvalHistoryRow } from '../../db/client.js'
+import type { Mode } from '../hooks/useKeymap.js'
+
+export interface RunsProps {
+  mode: Mode
+  filterQuery: string
+  onFilterChange: (q: string) => void
+  onOpenRun: (row: EvalHistoryRow) => void
+  onStartLiveRun: () => void
+  onExitFilter: () => void
+}
+
+function fmtDate(iso: string): string {
+  try {
+    const d = new Date(iso)
+    return d.toISOString().slice(0, 16).replace('T', ' ')
+  } catch { return iso.slice(0, 16) }
+}
+
+export function Runs({ mode, filterQuery, onFilterChange, onOpenRun, onStartLiveRun, onExitFilter }: RunsProps) {
+  const { rows } = useHistory({ limit: 500 }, 5000)
+  const [selected, setSelected] = useState<EvalHistoryRow | null>(null)
+
+  const filtered = useMemo(() => {
+    const q = filterQuery.trim().toLowerCase()
+    if (!q) return rows
+    return rows.filter(r =>
+      r.model_id.toLowerCase().includes(q) ||
+      r.pack.toLowerCase().includes(q) ||
+      (r.provider ?? '').toLowerCase().includes(q) ||
+      r.run_id.toLowerCase().includes(q)
+    )
+  }, [rows, filterQuery])
+
+  const listFocused = mode === 'normal'
+
+  useInput((input) => {
+    if (mode !== 'normal') return
+    if (input === 'n') onStartLiveRun()
+  }, { isActive: mode === 'normal' })
+
+  const columns: Column<EvalHistoryRow>[] = [
+    { key: 'when',  header: 'WHEN',   width: 17, render: r => fmtDate(r.run_at) },
+    { key: 'model', header: 'MODEL',  width: 30, render: r => r.model_id },
+    { key: 'pack',  header: 'PACK',   width: 18, render: r => r.pack },
+    { key: 'score', header: 'SCORE',  width: 6, align: 'right',
+      render: r => r.score.toFixed(2),
+      color: r => scoreColor(r.score) },
+    { key: 'cases', header: 'CASES',  width: 6, align: 'right', render: r => String(r.cases_run) },
+    { key: 'wins',  header: 'WINS',   width: 5, align: 'right', render: r => String(r.wins) },
+    { key: 'lat',   header: 'LAT ms', width: 7, align: 'right',
+      render: r => (r.avg_latency_ms ?? 0).toFixed(0) },
+  ]
+
+  return (
+    <Box flexDirection="column">
+      <Box marginBottom={1}>
+        <Text color={theme.accent} bold>📜 Run history  </Text>
+        <Text color={theme.muted}>({filtered.length}/{rows.length} shown)  </Text>
+        <Text color={theme.muted}>n: new run · Enter: open</Text>
+      </Box>
+      <Table
+        rows={filtered}
+        columns={columns}
+        focused={listFocused}
+        height={18}
+        emptyMessage={filterQuery ? 'No matching runs' : 'No runs yet — press n to start one'}
+        onEnter={(row) => onOpenRun(row)}
+        onSelectionChange={(row) => setSelected(row)}
+      />
+      {mode === 'filter' && (
+        <Box marginTop={1}>
+          <FilterInput
+            value={filterQuery}
+            onChange={onFilterChange}
+            onSubmit={onExitFilter}
+            onCancel={() => { onFilterChange(''); onExitFilter() }}
+            active
+          />
+        </Box>
+      )}
+      {selected && (
+        <Box marginTop={1} flexDirection="column">
+          <Text color={theme.muted}>─ selected ────────────────────────</Text>
+          <Text color={theme.text}>
+            <Text color={theme.muted}>run_id: </Text>{selected.run_id}
+          </Text>
+          {selected.total_cost_usd != null && (
+            <Text color={theme.text}>
+              <Text color={theme.muted}>cost:   </Text>${selected.total_cost_usd.toFixed(4)}
+            </Text>
+          )}
+          {selected.tokens_per_sec != null && (
+            <Text color={theme.text}>
+              <Text color={theme.muted}>tok/s:  </Text>{selected.tokens_per_sec.toFixed(1)}
+            </Text>
+          )}
+        </Box>
+      )}
+    </Box>
+  )
+}

--- a/src/tui/theme.ts
+++ b/src/tui/theme.ts
@@ -1,0 +1,30 @@
+/**
+ * Color tokens used across the TUI. Single source of truth so the theme
+ * can be swapped later (monokai, dracula, etc) without combing files.
+ */
+export const theme = {
+  primary: 'cyan',
+  accent: 'magenta',
+  success: 'green',
+  warning: 'yellow',
+  danger: 'red',
+  muted: 'gray',
+  dim: 'gray',
+  text: 'white',
+  highlight: 'cyanBright',
+  // semantic
+  border: 'cyan',
+  borderDim: 'gray',
+  winner: 'green',
+  regression: 'red',
+} as const
+
+export type ThemeColor = typeof theme[keyof typeof theme]
+
+/** Score → color band, same buckets used in src/reporter/terminal.ts. */
+export function scoreColor(score: number): ThemeColor {
+  if (score >= 8) return theme.success
+  if (score >= 6) return theme.warning
+  if (score >= 3) return 'yellow'
+  return theme.danger
+}

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -8,7 +8,8 @@
     "strict": true,
     "esModuleInterop": true,
     "skipLibCheck": true,
-    "resolveJsonModule": true
+    "resolveJsonModule": true,
+    "jsx": "react-jsx"
   },
   "include": ["src/**/*"],
   "exclude": ["node_modules", "dist"]

--- a/tsup.config.ts
+++ b/tsup.config.ts
@@ -13,7 +13,7 @@ export default defineConfig([
     shims: false,
     // Mark openai as external so it loads from node_modules at runtime rather
     // than being bundled inline. Bundling the openai SDK breaks its HTTP handling.
-    external: ['openai', 'better-sqlite3'],
+    external: ['openai', 'better-sqlite3', 'react', 'react/jsx-runtime', 'ink', '@inkjs/ui'],
     banner: {
       js: '#!/usr/bin/env node',
     },
@@ -27,6 +27,6 @@ export default defineConfig([
     clean: false,
     dts: true,
     shims: false,
-    external: ['openai', 'better-sqlite3'],
+    external: ['openai', 'better-sqlite3', 'react', 'react/jsx-runtime', 'ink', '@inkjs/ui'],
   },
 ])

--- a/vitest.config.ts
+++ b/vitest.config.ts
@@ -3,6 +3,6 @@ import { defineConfig } from 'vitest/config'
 export default defineConfig({
   test: {
     globals: true,
-    include: ['src/**/__tests__/**/*.test.ts'],
+    include: ['src/**/__tests__/**/*.test.ts', 'src/**/__tests__/**/*.test.tsx'],
   },
 })


### PR DESCRIPTION
## Summary

Adds a slick, vim-style Ink 6 / React 19 TUI behind the new `verdict tui` command — a single interactive terminal app that wraps the existing Verdict core so power users can browse runs, launch evals, and monitor the daemon without juggling 18 CLI subcommands.

This is **Phase 1 (MVP)** of a staged rollout. The plan (framework research, screen map, future phases) is in `/root/.claude/plans/twinkling-snuggling-chipmunk.md`.

### Phase 1 screens
- **Home** — top models with sparkline trends, daemon status, job queue depth
- **Runs** — full history table with `/` fuzzy filter, Enter to drill in
- **Run Detail** — per-case scores + responses for a selected run
- **Live Run** — 30fps-throttled live view of `core/runner.ts` `onProgress`
- **Models** — configured models + on-demand Ollama/MLX discovery

### Patterns (copied from lazygit / k9s / btop)
- Vim modes: normal, insert, command, filter, help
- `:` command palette with Fuse.js fuzzy match
- `/` universal list filter
- `?` help overlay with context-sensitive keybinds
- `1`/`2`/`3` number-key tab jumps, `hjkl`+`g/G`+PgUp/PgDn navigation
- Footer always shows active keybinds

### Implementation notes
- Additive only — existing CLI commands, `--json` output, SQLite schema, and the GitHub Action are untouched
- Hooks reuse existing core with zero refactor: `useDb` → `queryHistory`/`getJobs`, `useLiveRun` → `runEvals`, `useDaemon` → `sendIpc` + log tail, `useConfig` → `loadConfig`
- `Table.tsx` has built-in windowing so ~10k rows scroll smoothly
- `tsup` now externalizes `react`/`ink`/`@inkjs/ui`; `tsconfig` enables JSX
- Framework choice (Ink over blessed/terminal-kit/OpenTUI) documented in plan with 2026 ecosystem data

## Test plan

- [x] Full suite green: 345/345 tests, 18 files
- [x] 4 new TUI smoke tests via `ink-testing-library`
- [x] Build: `dist/cli/tui-*.js` (41 KB) produced cleanly
- [x] Manual: `verdict tui` renders Home, `?` shows help, `:` opens palette, number keys jump tabs
- [ ] Real-terminal smoke: `verdict tui`, start a live run, Ctrl-C, verify checkpoint, resume from Runs screen
- [ ] `verdict run --json` and CI action still work unchanged

https://claude.ai/code/session_01Xiis22wDRDqb4Ke4MQToPv