### PR TITLE
feat(tui): Phase 2 — Baselines, Compare, Daemon, Packs, NewRun, Config

### DIFF
--- a/src/tui/App.tsx
+++ b/src/tui/App.tsx
@@ -14,7 +14,13 @@ import { Home } from './screens/Home.js'
 import { Runs } from './screens/Runs.js'
 import { RunDetail } from './screens/RunDetail.js'
 import { LiveRun } from './screens/LiveRun.js'
+import { NewRun } from './screens/NewRun.js'
 import { Models } from './screens/Models.js'
+import { Baselines } from './screens/Baselines.js'
+import { Compare } from './screens/Compare.js'
+import { Daemon } from './screens/Daemon.js'
+import { EvalPacks } from './screens/EvalPacks.js'
+import { ConfigEditor } from './screens/ConfigEditor.js'
 import type { EvalHistoryRow } from '../db/client.js'
 
 export function App() {
@@ -37,7 +43,7 @@ export function App() {
             onFilterChange={(q) => dispatch({ type: 'set-filter-query', q })}
             onExitFilter={() => dispatch({ type: 'set-mode', mode: 'normal' })}
             onOpenRun={(row) => { setDetailRow(row); goto('run-detail') }}
-            onStartLiveRun={() => goto('live-run')}
+            onStartLiveRun={() => goto('new-run')}
           />
         )
       case 'run-detail':
@@ -49,12 +55,24 @@ export function App() {
               onFilterChange={(q) => dispatch({ type: 'set-filter-query', q })}
               onExitFilter={() => dispatch({ type: 'set-mode', mode: 'normal' })}
               onOpenRun={(row) => { setDetailRow(row); goto('run-detail') }}
-              onStartLiveRun={() => goto('live-run')}
+              onStartLiveRun={() => goto('new-run')}
             />
       case 'live-run':
         return <LiveRun onBack={() => goto('home')} />
+      case 'new-run':
+        return <NewRun onBack={() => goto('home')} />
       case 'models':
         return <Models onBack={() => goto('home')} />
+      case 'baselines':
+        return <Baselines onBack={() => goto('home')} />
+      case 'compare':
+        return <Compare onBack={() => goto('home')} />
+      case 'daemon':
+        return <Daemon onBack={() => goto('home')} />
+      case 'eval-packs':
+        return <EvalPacks onBack={() => goto('home')} />
+      case 'config':
+        return <ConfigEditor onBack={() => goto('home')} />
       default:
         return <Home />
     }

--- a/src/tui/__tests__/Phase2.test.tsx
+++ b/src/tui/__tests__/Phase2.test.tsx
@@ -1,0 +1,84 @@
+/**
+ * Phase 2 smoke tests — render each new screen and assert key labels.
+ */
+
+import { describe, it, expect } from 'vitest'
+import { render } from 'ink-testing-library'
+import { Daemon } from '../screens/Daemon.js'
+import { Baselines } from '../screens/Baselines.js'
+import { Compare } from '../screens/Compare.js'
+import { EvalPacks } from '../screens/EvalPacks.js'
+import { NewRun } from '../screens/NewRun.js'
+import { ConfigEditor } from '../screens/ConfigEditor.js'
+import { DiffPane } from '../components/DiffPane.js'
+import type { BaselineComparison } from '../../types/index.js'
+
+describe('Phase 2 TUI smoke', () => {
+  it('Daemon renders status + log panels', () => {
+    const { lastFrame, unmount } = render(<Daemon />)
+    const frame = lastFrame() ?? ''
+    expect(frame).toContain('Daemon')
+    expect(frame).toContain('Log tail')
+    unmount()
+  })
+
+  it('Baselines renders header + hint', () => {
+    const { lastFrame, unmount } = render(<Baselines />)
+    const frame = lastFrame() ?? ''
+    expect(frame).toContain('Baselines')
+    expect(frame).toContain('save latest')
+    unmount()
+  })
+
+  it('Compare renders pick-A prompt', () => {
+    const { lastFrame, unmount } = render(<Compare />)
+    const frame = lastFrame() ?? ''
+    expect(frame).toContain('Compare')
+    expect(frame).toContain('Pick result A')
+    unmount()
+  })
+
+  it('EvalPacks renders header', () => {
+    const { lastFrame, unmount } = render(<EvalPacks />)
+    const frame = lastFrame() ?? ''
+    expect(frame).toContain('Eval packs')
+    unmount()
+  })
+
+  it('NewRun renders wizard chrome', () => {
+    const { lastFrame, unmount } = render(<NewRun />)
+    const frame = lastFrame() ?? ''
+    expect(frame).toContain('New run')
+    expect(frame).toContain('toggle')
+    unmount()
+  })
+
+  it('ConfigEditor renders loading or error state', () => {
+    const { lastFrame, unmount } = render(<ConfigEditor />)
+    const frame = lastFrame() ?? ''
+    // Either loading, or shows config/header if verdict.yaml exists in cwd
+    expect(frame.length).toBeGreaterThan(0)
+    unmount()
+  })
+
+  it('DiffPane renders headers and deltas', () => {
+    const cmp: BaselineComparison = {
+      baselineName: 'base-a',
+      baselineDate: '2026-04-14',
+      deltas: [
+        { model: 'qwen-7b', scoreA: 7.5, scoreB: 8.0, delta: 0.5, pctChange: 6.7, regression: false },
+        { model: 'llama-3', scoreA: 8.2, scoreB: 7.5, delta: -0.7, pctChange: -8.5, regression: true },
+      ],
+      newModels: ['gpt-4o'],
+      removedModels: [],
+      regressionAlert: true,
+    }
+    const { lastFrame, unmount } = render(<DiffPane comparison={cmp} />)
+    const frame = lastFrame() ?? ''
+    expect(frame).toContain('qwen-7b')
+    expect(frame).toContain('llama-3')
+    expect(frame).toContain('Regression detected')
+    expect(frame).toContain('gpt-4o')
+    unmount()
+  })
+})

--- a/src/tui/components/DiffPane.tsx
+++ b/src/tui/components/DiffPane.tsx
@@ -1,0 +1,88 @@
+/**
+ * Synced-scroll side-by-side diff of two model-summary sets.
+ *
+ * Takes the `deltas` from `compareWithBaseline` plus newModels/removedModels
+ * and renders a two-column view with regression highlights.
+ *
+ * Phase 2 keeps this flat (no scroll) because summaries are O(models) which
+ * is rarely >20. Per-case diffing is Phase 3.
+ */
+
+import { Box, Text } from 'ink'
+import { theme, scoreColor } from '../theme.js'
+import type { BaselineComparison } from '../../types/index.js'
+
+export interface DiffPaneProps {
+  comparison: BaselineComparison
+  nameA?: string
+  nameB?: string
+}
+
+function formatDelta(delta: number): { text: string; color: string } {
+  if (Math.abs(delta) < 0.05) return { text: ' —   ', color: theme.muted }
+  const sign = delta > 0 ? '+' : ''
+  const text = `${sign}${delta.toFixed(2)}`
+  return { text: text.padStart(6), color: delta > 0 ? theme.success : theme.danger }
+}
+
+export function DiffPane({ comparison, nameA = 'baseline', nameB = 'current' }: DiffPaneProps) {
+  const sorted = [...comparison.deltas].sort((a, b) => b.scoreB - a.scoreB)
+
+  return (
+    <Box flexDirection="column">
+      {/* Header row */}
+      <Box>
+        <Text color={theme.muted} bold>{'MODEL'.padEnd(30)} </Text>
+        <Text color={theme.muted} bold>{nameA.padStart(7)}  </Text>
+        <Text color={theme.muted} bold>{nameB.padStart(7)}  </Text>
+        <Text color={theme.muted} bold>{'Δ'.padStart(6)}   </Text>
+        <Text color={theme.muted} bold>{'%'.padStart(6)}   </Text>
+      </Box>
+
+      {sorted.length === 0 && (
+        <Text color={theme.muted}>  No shared models between runs</Text>
+      )}
+
+      {sorted.map(d => {
+        const dlt = formatDelta(d.delta)
+        return (
+          <Box key={d.model}>
+            <Text color={d.regression ? theme.regression : theme.text}>
+              {d.regression ? '⚠ ' : '  '}{d.model.padEnd(28).slice(0, 28)} </Text>
+            <Text color={scoreColor(d.scoreA)}>{d.scoreA.toFixed(2).padStart(7)}  </Text>
+            <Text color={scoreColor(d.scoreB)}>{d.scoreB.toFixed(2).padStart(7)}  </Text>
+            <Text color={dlt.color}>{dlt.text}  </Text>
+            <Text color={dlt.color}>
+              {(d.pctChange > 0 ? '+' : '') + d.pctChange.toFixed(1) + '%'}
+            </Text>
+          </Box>
+        )
+      })}
+
+      {/* New / removed models */}
+      {comparison.newModels.length > 0 && (
+        <Box flexDirection="column" marginTop={1}>
+          <Text color={theme.success} bold>+ New models</Text>
+          {comparison.newModels.map(m => (
+            <Text key={m} color={theme.success}>  + {m}</Text>
+          ))}
+        </Box>
+      )}
+      {comparison.removedModels.length > 0 && (
+        <Box flexDirection="column" marginTop={1}>
+          <Text color={theme.danger} bold>− Removed models</Text>
+          {comparison.removedModels.map(m => (
+            <Text key={m} color={theme.danger}>  - {m}</Text>
+          ))}
+        </Box>
+      )}
+
+      {/* Regression banner */}
+      {comparison.regressionAlert && (
+        <Box marginTop={1} borderStyle="single" borderColor={theme.danger} paddingX={1}>
+          <Text color={theme.danger} bold>⚠ Regression detected — one or more models dropped {'>'}0.5 points</Text>
+        </Box>
+      )}
+    </Box>
+  )
+}

--- a/src/tui/components/HelpOverlay.tsx
+++ b/src/tui/components/HelpOverlay.tsx
@@ -17,7 +17,7 @@ const GLOBAL = [
   ['q',       'Quit'],
   ['Esc',     'Cancel / back to normal mode'],
   ['Tab',     'Next pane'],
-  ['1/2/3',   'Jump to Home / Runs / Models'],
+  ['1..6',    'Jump to Home / Runs / Models / Baselines / Daemon / Packs'],
 ]
 
 const SCREEN_KEYS: Record<string, string[][]> = {

--- a/src/tui/components/Layout.tsx
+++ b/src/tui/components/Layout.tsx
@@ -18,12 +18,18 @@ const SCREEN_NAMES: Record<Screen, string> = {
   'home':       '1 Home',
   'runs':       '2 Runs',
   'models':     '3 Models',
+  'baselines':  '4 Baselines',
+  'daemon':     '5 Daemon',
+  'eval-packs': '6 Packs',
   'run-detail': 'Run Detail',
   'live-run':   'Live Run',
+  'new-run':    'New Run',
+  'compare':    'Compare',
+  'config':     'Config',
 }
 
 export function Layout({ screen, mode, title, children, footerHints }: LayoutProps) {
-  const tabs: Screen[] = ['home', 'runs', 'models']
+  const tabs: Screen[] = ['home', 'runs', 'models', 'baselines', 'daemon', 'eval-packs']
   const globalHints: [string, string][] = [
     [':', 'cmd'],
     ['/', 'filter'],

--- a/src/tui/components/Palette.tsx
+++ b/src/tui/components/Palette.tsx
@@ -97,10 +97,15 @@ export function Palette({ commands, onClose }: PaletteProps) {
 /** Build the default command list given a dispatch. Used by App. */
 export function defaultCommands(goto: (s: Screen) => void): Command[] {
   return [
-    { id: 'goto:home',    label: 'Go to Home',         hint: '1', action: () => goto('home') },
-    { id: 'goto:runs',    label: 'Go to Runs',         hint: '2', action: () => goto('runs') },
-    { id: 'goto:models',  label: 'Go to Models',       hint: '3', action: () => goto('models') },
-    { id: 'goto:live',    label: 'New Live Run',       hint: 'Start a fresh eval', action: () => goto('live-run') },
-    { id: 'help',         label: 'Show help',          hint: '?', action: () => { /* overlay triggered by caller */ } },
+    { id: 'goto:home',      label: 'Go to Home',        hint: '1', action: () => goto('home') },
+    { id: 'goto:runs',      label: 'Go to Runs',        hint: '2', action: () => goto('runs') },
+    { id: 'goto:models',    label: 'Go to Models',      hint: '3', action: () => goto('models') },
+    { id: 'goto:baselines', label: 'Go to Baselines',   hint: '4', action: () => goto('baselines') },
+    { id: 'goto:daemon',    label: 'Go to Daemon',      hint: '5', action: () => goto('daemon') },
+    { id: 'goto:packs',     label: 'Go to Eval Packs',  hint: '6', action: () => goto('eval-packs') },
+    { id: 'goto:compare',   label: 'Compare two runs',  hint: 'Pick A vs B', action: () => goto('compare') },
+    { id: 'goto:config',    label: 'Open Config',       hint: 'verdict.yaml view + $EDITOR', action: () => goto('config') },
+    { id: 'goto:new-run',   label: 'New Run (custom)',  hint: 'Pick models + packs', action: () => goto('new-run') },
+    { id: 'goto:live',      label: 'Quick Live Run',    hint: 'All models, all packs', action: () => goto('live-run') },
   ]
 }

--- a/src/tui/hooks/useKeymap.ts
+++ b/src/tui/hooks/useKeymap.ts
@@ -26,7 +26,13 @@ export type Screen =
   | 'runs'
   | 'run-detail'
   | 'live-run'
+  | 'new-run'
   | 'models'
+  | 'baselines'
+  | 'compare'
+  | 'daemon'
+  | 'eval-packs'
+  | 'config'
 
 export type Action =
   | { type: 'set-mode'; mode: Mode }
@@ -97,6 +103,9 @@ export function useKeymap() {
       if (input === '1') dispatch({ type: 'set-screen', screen: 'home' })
       if (input === '2') dispatch({ type: 'set-screen', screen: 'runs' })
       if (input === '3') dispatch({ type: 'set-screen', screen: 'models' })
+      if (input === '4') dispatch({ type: 'set-screen', screen: 'baselines' })
+      if (input === '5') dispatch({ type: 'set-screen', screen: 'daemon' })
+      if (input === '6') dispatch({ type: 'set-screen', screen: 'eval-packs' })
     }
   })
 

--- a/src/tui/screens/Baselines.tsx
+++ b/src/tui/screens/Baselines.tsx
@@ -1,0 +1,171 @@
+/**
+ * Baselines screen — list saved baselines, save the latest result, or diff
+ * the current latest result against a selected baseline.
+ *
+ * Reuses src/core/baseline.ts API:
+ *   listBaselines(), loadBaseline(), saveBaseline(), compareWithBaseline(),
+ *   findLatestResult()
+ */
+
+import { useEffect, useMemo, useState } from 'react'
+import fs from 'fs'
+import { Box, Text, useInput } from 'ink'
+import { theme } from '../theme.js'
+import { Table, type Column } from '../components/Table.js'
+import { DiffPane } from '../components/DiffPane.js'
+import {
+  listBaselines,
+  loadBaseline,
+  saveBaseline,
+  compareWithBaseline,
+  findLatestResult,
+  type BaselineInfo,
+} from '../../core/baseline.js'
+import { useConfig } from '../hooks/useConfig.js'
+import type { BaselineComparison, RunResult } from '../../types/index.js'
+
+export interface BaselinesProps {
+  onBack?: () => void
+}
+
+type Mode = 'list' | 'save-prompt' | 'diff'
+
+export function Baselines(_props: BaselinesProps) {
+  const { config } = useConfig('./verdict.yaml')
+  const [baselines, setBaselines] = useState<BaselineInfo[]>([])
+  const [selected, setSelected] = useState<BaselineInfo | null>(null)
+  const [comparison, setComparison] = useState<BaselineComparison | null>(null)
+  const [mode, setMode] = useState<Mode>('list')
+  const [saveName, setSaveName] = useState('')
+  const [toast, setToast] = useState<string | null>(null)
+
+  const refresh = () => setBaselines(listBaselines())
+
+  useEffect(() => { refresh() }, [])
+
+  const latestPath = useMemo(
+    () => config ? findLatestResult(config.output.dir) : null,
+    [config]
+  )
+
+  useInput((input, key) => {
+    if (mode === 'save-prompt') {
+      if (key.escape) { setMode('list'); setSaveName(''); return }
+      if (key.return) {
+        if (!saveName.trim() || !latestPath) { setMode('list'); return }
+        try {
+          saveBaseline(saveName.trim(), latestPath)
+          setToast(`Saved baseline "${saveName.trim()}"`)
+          refresh()
+        } catch (e) {
+          setToast(`Save failed: ${(e as Error).message}`)
+        }
+        setSaveName('')
+        setMode('list')
+        return
+      }
+      if (key.backspace || key.delete) { setSaveName(n => n.slice(0, -1)); return }
+      if (input && !key.ctrl && !key.meta) setSaveName(n => n + input)
+      return
+    }
+
+    if (mode === 'diff') {
+      if (key.escape) { setComparison(null); setMode('list'); return }
+      return
+    }
+
+    if (input === 's') {
+      if (!latestPath) {
+        setToast('No latest result to save — run an eval first')
+        return
+      }
+      setSaveName('')
+      setMode('save-prompt')
+      return
+    }
+    if (input === 'r') refresh()
+  })
+
+  // Auto-dismiss toast
+  useEffect(() => {
+    if (!toast) return
+    const t = setTimeout(() => setToast(null), 2500)
+    return () => clearTimeout(t)
+  }, [toast])
+
+  const openDiff = (b: BaselineInfo) => {
+    if (!latestPath) { setToast('No latest result — run an eval first'); return }
+    const baseline = loadBaseline(b.name)
+    if (!baseline) { setToast(`Could not load baseline ${b.name}`); return }
+    try {
+      const current = JSON.parse(fs.readFileSync(latestPath, 'utf8')) as RunResult
+      setComparison(compareWithBaseline(baseline, current, b.name))
+      setSelected(b)
+      setMode('diff')
+    } catch (e) {
+      setToast(`Could not load latest result: ${(e as Error).message}`)
+    }
+  }
+
+  const columns: Column<BaselineInfo>[] = [
+    { key: 'name',   header: 'NAME',   width: 22, render: b => b.name },
+    { key: 'date',   header: 'SAVED',  width: 20, render: b => b.date },
+    { key: 'models', header: 'MODELS', width: 7, align: 'right', render: b => String(b.modelCount) },
+    { key: 'cases',  header: 'CASES',  width: 6, align: 'right', render: b => String(b.caseCount) },
+  ]
+
+  if (mode === 'diff' && comparison) {
+    return (
+      <Box flexDirection="column">
+        <Box marginBottom={1} flexDirection="column">
+          <Text color={theme.accent} bold>⚖  Diff: latest vs {comparison.baselineName}</Text>
+          <Text color={theme.muted}>baseline saved {comparison.baselineDate}  ·  Esc to go back</Text>
+        </Box>
+        <DiffPane comparison={comparison} nameA={comparison.baselineName} nameB="latest" />
+      </Box>
+    )
+  }
+
+  return (
+    <Box flexDirection="column">
+      <Box marginBottom={1}>
+        <Text color={theme.accent} bold>📌 Baselines  </Text>
+        <Text color={theme.muted}>s: save latest · Enter: diff · r: refresh</Text>
+      </Box>
+
+      {!latestPath && (
+        <Text color={theme.warning}>  No latest result found in {config?.output.dir ?? 'output dir'}</Text>
+      )}
+
+      <Table
+        rows={baselines}
+        columns={columns}
+        height={10}
+        onEnter={openDiff}
+        onSelectionChange={(b) => setSelected(b)}
+        emptyMessage="No baselines saved yet. Press s to save the latest run as a baseline."
+      />
+
+      {mode === 'save-prompt' && (
+        <Box marginTop={1} borderStyle="single" borderColor={theme.accent} paddingX={1}>
+          <Text color={theme.accent}>Name: </Text>
+          <Text>{saveName}</Text>
+          <Text color={theme.muted}>▏ (Enter to save, Esc to cancel)</Text>
+        </Box>
+      )}
+
+      {selected && mode === 'list' && (
+        <Box marginTop={1} flexDirection="column">
+          <Text color={theme.muted}>─ selected ──────</Text>
+          <Text>name: <Text color={theme.text}>{selected.name}</Text></Text>
+        </Box>
+      )}
+
+      {toast && (
+        <Box marginTop={1}>
+          <Text color={theme.highlight}>» {toast}</Text>
+        </Box>
+      )}
+    </Box>
+  )
+}

--- a/src/tui/screens/Compare.tsx
+++ b/src/tui/screens/Compare.tsx
@@ -1,0 +1,128 @@
+/**
+ * Compare screen — pick two run result files from the config.output.dir and
+ * render a side-by-side diff via DiffPane.
+ *
+ * Flow: list result files → select A (Enter) → list again → select B (Enter)
+ *       → DiffPane. Esc at any point backs out.
+ */
+
+import { useEffect, useMemo, useState } from 'react'
+import fs from 'fs'
+import path from 'path'
+import { Box, Text, useInput } from 'ink'
+import { theme } from '../theme.js'
+import { Table, type Column } from '../components/Table.js'
+import { DiffPane } from '../components/DiffPane.js'
+import { compareWithBaseline } from '../../core/baseline.js'
+import { useConfig } from '../hooks/useConfig.js'
+import type { BaselineComparison, RunResult } from '../../types/index.js'
+
+export interface CompareProps {
+  onBack?: () => void
+}
+
+interface ResultFile {
+  name: string
+  path: string
+  mtime: number
+}
+
+function listResults(outputDir: string): ResultFile[] {
+  const dir = path.resolve(outputDir)
+  if (!fs.existsSync(dir)) return []
+  return fs.readdirSync(dir)
+    .filter(f => f.endsWith('.json') && !f.startsWith('.'))
+    .map(f => {
+      const full = path.join(dir, f)
+      let mtime = 0
+      try { mtime = fs.statSync(full).mtimeMs } catch {}
+      return { name: f, path: full, mtime }
+    })
+    .sort((a, b) => b.mtime - a.mtime)
+}
+
+type Stage = 'pick-a' | 'pick-b' | 'diff'
+
+export function Compare(_props: CompareProps) {
+  const { config } = useConfig('./verdict.yaml')
+  const [stage, setStage] = useState<Stage>('pick-a')
+  const [fileA, setFileA] = useState<ResultFile | null>(null)
+  const [fileB, setFileB] = useState<ResultFile | null>(null)
+  const [comparison, setComparison] = useState<BaselineComparison | null>(null)
+  const [error, setError] = useState<string | null>(null)
+
+  const files = useMemo(
+    () => config ? listResults(config.output.dir) : [],
+    [config]
+  )
+
+  useEffect(() => {
+    if (stage === 'diff' && fileA && fileB) {
+      try {
+        const a = JSON.parse(fs.readFileSync(fileA.path, 'utf8')) as RunResult
+        const b = JSON.parse(fs.readFileSync(fileB.path, 'utf8')) as RunResult
+        setComparison(compareWithBaseline(a, b, fileA.name))
+      } catch (e) {
+        setError((e as Error).message)
+        setStage('pick-a')
+      }
+    }
+  }, [stage, fileA, fileB])
+
+  useInput((_, key) => {
+    if (key.escape) {
+      if (stage === 'diff') { setStage('pick-b'); setComparison(null) }
+      else if (stage === 'pick-b') { setStage('pick-a'); setFileB(null) }
+    }
+  })
+
+  const columns: Column<ResultFile>[] = [
+    { key: 'name',  header: 'FILE',     width: 40, render: f => f.name },
+    { key: 'mtime', header: 'MODIFIED', width: 19,
+      render: f => new Date(f.mtime).toISOString().slice(0, 19).replace('T', ' ') },
+  ]
+
+  if (stage === 'diff' && comparison && fileA && fileB) {
+    return (
+      <Box flexDirection="column">
+        <Box marginBottom={1} flexDirection="column">
+          <Text color={theme.accent} bold>⚖  Compare</Text>
+          <Text color={theme.muted}>A: {fileA.name}</Text>
+          <Text color={theme.muted}>B: {fileB.name}</Text>
+          <Text color={theme.muted}>Esc to go back</Text>
+        </Box>
+        <DiffPane comparison={comparison} nameA="A" nameB="B" />
+      </Box>
+    )
+  }
+
+  return (
+    <Box flexDirection="column">
+      <Box marginBottom={1}>
+        <Text color={theme.accent} bold>⚖  Compare  </Text>
+        <Text color={theme.muted}>
+          {stage === 'pick-a' ? 'Pick result A (Enter)' : `A = ${fileA?.name}  ·  Pick result B (Enter)`}
+        </Text>
+      </Box>
+
+      {error && <Text color={theme.danger}>  {error}</Text>}
+
+      <Table
+        rows={files}
+        columns={columns}
+        height={16}
+        onEnter={(f) => {
+          if (stage === 'pick-a') { setFileA(f); setStage('pick-b') }
+          else if (stage === 'pick-b') {
+            if (fileA && f.path === fileA.path) {
+              setError('Pick a different file for B')
+              return
+            }
+            setFileB(f); setStage('diff')
+          }
+        }}
+        emptyMessage={config ? `No result JSONs in ${config.output.dir}` : 'Load config first'}
+      />
+    </Box>
+  )
+}

--- a/src/tui/screens/ConfigEditor.tsx
+++ b/src/tui/screens/ConfigEditor.tsx
@@ -1,0 +1,149 @@
+/**
+ * Config Editor — Phase 2 MVP.
+ *
+ * Shows a read-only structured view of verdict.yaml (models, judge, run).
+ * Press `E` to shell out to $EDITOR on the YAML file; re-validates via Zod
+ * on return. Full Zod-form editing is Phase 3.
+ */
+
+import { useEffect, useState } from 'react'
+import { spawn } from 'child_process'
+import path from 'path'
+import fs from 'fs'
+import { Box, Text, useInput, useApp } from 'ink'
+import { theme } from '../theme.js'
+import { useConfig } from '../hooks/useConfig.js'
+import { loadConfig } from '../../core/config.js'
+import type { Config } from '../../types/index.js'
+
+export interface ConfigEditorProps {
+  onBack?: () => void
+}
+
+export function ConfigEditor(_props: ConfigEditorProps) {
+  const { config: initial, error } = useConfig('./verdict.yaml')
+  const [config, setConfig] = useState<Config | null>(null)
+  const [toast, setToast] = useState<string | null>(null)
+  const [reloading, setReloading] = useState(false)
+  const { exit: _exit } = useApp()
+
+  useEffect(() => { if (initial) setConfig(initial) }, [initial])
+
+  const reload = () => {
+    try {
+      const next = loadConfig(path.resolve('./verdict.yaml'))
+      setConfig(next)
+      setToast('Reloaded — config valid')
+    } catch (e) {
+      setToast(`Invalid config: ${(e as Error).message.slice(0, 80)}`)
+    }
+  }
+
+  useInput((input) => {
+    if (input === 'r') reload()
+    if (input === 'E' || input === 'e') launchEditor()
+  })
+
+  // Auto-dismiss toast
+  useEffect(() => {
+    if (!toast) return
+    const t = setTimeout(() => setToast(null), 3000)
+    return () => clearTimeout(t)
+  }, [toast])
+
+  const launchEditor = () => {
+    const editor = process.env['EDITOR'] || process.env['VISUAL'] || 'vi'
+    const file = path.resolve('./verdict.yaml')
+    if (!fs.existsSync(file)) {
+      setToast(`verdict.yaml not found at ${file}`)
+      return
+    }
+    setReloading(true)
+    // Spawn synchronously-ish: detach from Ink's stdin, wait, then reload
+    const child = spawn(editor, [file], { stdio: 'inherit' })
+    child.on('exit', () => {
+      setReloading(false)
+      reload()
+    })
+    child.on('error', (err) => {
+      setReloading(false)
+      setToast(`Could not launch ${editor}: ${err.message}`)
+    })
+  }
+
+  if (error) {
+    return (
+      <Box flexDirection="column">
+        <Text color={theme.danger}>Config error</Text>
+        <Text color={theme.muted}>{error}</Text>
+        <Text color={theme.muted}>{'\n'}Press E to open $EDITOR and fix it</Text>
+      </Box>
+    )
+  }
+
+  if (!config) {
+    return <Text color={theme.muted}>Loading verdict.yaml…</Text>
+  }
+
+  if (reloading) {
+    return <Text color={theme.primary}>Editor is open — save and quit to return.</Text>
+  }
+
+  return (
+    <Box flexDirection="column">
+      <Box marginBottom={1}>
+        <Text color={theme.accent} bold>🧰 Config  </Text>
+        <Text color={theme.muted}>./verdict.yaml · E: edit in $EDITOR · r: reload</Text>
+      </Box>
+
+      <Text color={theme.accent} bold>name</Text>
+      <Text>  {config.name}</Text>
+
+      <Box marginTop={1} flexDirection="column">
+        <Text color={theme.accent} bold>models ({config.models.length})</Text>
+        {config.models.map(m => (
+          <Box key={m.id}>
+            <Text color={theme.text}>  • {m.id.padEnd(24).slice(0, 24)} </Text>
+            <Text color={theme.muted}>{(m.provider ?? 'compat').padEnd(9)}</Text>
+            <Text>{m.model.padEnd(28).slice(0, 28)} </Text>
+            <Text color={theme.muted}>max_tokens {m.max_tokens}</Text>
+          </Box>
+        ))}
+      </Box>
+
+      <Box marginTop={1} flexDirection="column">
+        <Text color={theme.accent} bold>judge</Text>
+        <Text>  model:    <Text color={theme.text}>{config.judge.model}</Text></Text>
+        <Text>  blind:    <Text color={theme.text}>{String(config.judge.blind)}</Text></Text>
+        <Text>  strategy: <Text color={theme.text}>{config.judge.strategy}</Text></Text>
+        <Text>  rubric:   <Text color={theme.muted}>
+          a={config.judge.rubric.accuracy} c={config.judge.rubric.completeness} b={config.judge.rubric.conciseness}
+        </Text></Text>
+      </Box>
+
+      <Box marginTop={1} flexDirection="column">
+        <Text color={theme.accent} bold>run</Text>
+        <Text>  concurrency: <Text color={theme.text}>{config.run.concurrency}</Text></Text>
+        <Text>  retries:     <Text color={theme.text}>{config.run.retries}</Text></Text>
+        <Text>  cache:       <Text color={theme.text}>{String(config.run.cache)}</Text></Text>
+      </Box>
+
+      <Box marginTop={1} flexDirection="column">
+        <Text color={theme.accent} bold>output</Text>
+        <Text>  dir:     <Text color={theme.text}>{config.output.dir}</Text></Text>
+        <Text>  formats: <Text color={theme.text}>{config.output.formats.join(', ')}</Text></Text>
+      </Box>
+
+      <Box marginTop={1} flexDirection="column">
+        <Text color={theme.accent} bold>packs ({config.packs.length})</Text>
+        {config.packs.map(p => <Text key={p}>  • {p}</Text>)}
+      </Box>
+
+      {toast && (
+        <Box marginTop={1}>
+          <Text color={theme.highlight}>» {toast}</Text>
+        </Box>
+      )}
+    </Box>
+  )
+}

--- a/src/tui/screens/Daemon.tsx
+++ b/src/tui/screens/Daemon.tsx
@@ -1,0 +1,107 @@
+/**
+ * Daemon screen — live status, job queue, and tailing log.
+ *
+ * Uses the existing IPC socket and tails ~/.verdict/daemon.log.
+ * Press `p` to pause auto-scroll (lazygit-style).
+ */
+
+import { useState } from 'react'
+import { Box, Text, useInput } from 'ink'
+import { theme } from '../theme.js'
+import { useDaemonStatus, useDaemonLog } from '../hooks/useDaemon.js'
+import { useJobs } from '../hooks/useDb.js'
+import { Table, type Column } from '../components/Table.js'
+import { LogStream } from '../components/LogStream.js'
+import type { JobRow } from '../../db/client.js'
+
+export interface DaemonProps {
+  onBack?: () => void
+}
+
+export function Daemon(_props: DaemonProps) {
+  const { status, reachable } = useDaemonStatus(2000)
+  const { rows: jobs } = useJobs(undefined, 2000)
+  const log = useDaemonLog(500, 1000)
+  const [paused, setPaused] = useState(false)
+  const [savedLog, setSavedLog] = useState<string[]>([])
+
+  useInput((input) => {
+    if (input === 'p') {
+      if (!paused) setSavedLog(log)
+      setPaused(p => !p)
+    }
+    if (input === 'G' && paused) {
+      setPaused(false)
+    }
+  })
+
+  const displayLog = paused ? savedLog : log
+
+  const jobCols: Column<JobRow>[] = [
+    { key: 'id',     header: 'ID',     width: 5, align: 'right', render: j => String(j.id) },
+    { key: 'type',   header: 'TYPE',   width: 14, render: j => j.type },
+    { key: 'status', header: 'STATUS', width: 8,  render: j => j.status,
+      color: j => j.status === 'done' ? theme.success
+             : j.status === 'running' ? theme.primary
+             : j.status === 'failed' ? theme.danger
+             : theme.warning },
+    { key: 'model',  header: 'MODEL',  width: 22, render: j => j.model_id ?? '-' },
+    { key: 'queued', header: 'QUEUED', width: 20, render: j => (j.queued_at ?? '').slice(0, 19).replace('T', ' ') },
+  ]
+
+  return (
+    <Box flexDirection="column">
+      {/* Status line */}
+      <Box marginBottom={1}>
+        <Text color={theme.accent} bold>🛰  Daemon</Text>
+        <Text>  </Text>
+        {reachable && status ? (
+          <>
+            <Text color={theme.success}>● running</Text>
+            {status.pid !== undefined && <Text color={theme.muted}>  pid {status.pid}</Text>}
+            {status.uptimeSeconds !== undefined && (
+              <Text color={theme.muted}>  up {Math.floor(status.uptimeSeconds)}s</Text>
+            )}
+            <Text color={theme.muted}>  queue {status.queueDepth}</Text>
+            <Text color={theme.muted}>  today  </Text>
+            <Text color={theme.success}>✓{status.completedToday}</Text>
+            <Text color={theme.muted}> </Text>
+            <Text color={theme.danger}>✗{status.failedToday}</Text>
+          </>
+        ) : (
+          <Text color={theme.danger}>● stopped</Text>
+        )}
+      </Box>
+
+      {!reachable && (
+        <Text color={theme.muted}>
+          Start it with: <Text color={theme.highlight}>verdict daemon start</Text>
+        </Text>
+      )}
+
+      {/* Jobs */}
+      <Box marginTop={1} flexDirection="column">
+        <Text color={theme.accent} bold>Recent jobs</Text>
+        <Table
+          rows={jobs}
+          columns={jobCols}
+          height={7}
+          focused={false}
+          emptyMessage={reachable ? 'No jobs yet' : 'Daemon not reachable'}
+        />
+      </Box>
+
+      {/* Log */}
+      <Box marginTop={1} flexDirection="column">
+        <Box>
+          <Text color={theme.accent} bold>Log tail  </Text>
+          {paused
+            ? <Text color={theme.warning}>[PAUSED — press G or p to resume]</Text>
+            : <Text color={theme.muted}>(auto · p to pause)</Text>
+          }
+        </Box>
+        <LogStream lines={displayLog} height={10} />
+      </Box>
+    </Box>
+  )
+}

--- a/src/tui/screens/EvalPacks.tsx
+++ b/src/tui/screens/EvalPacks.tsx
@@ -1,0 +1,116 @@
+/**
+ * EvalPacks browser — lists *.yaml files in ./eval-packs/ (and a few common
+ * neighbors), loads each via loadEvalPack, lets the user browse cases.
+ *
+ * Two panes: pack list on the left, selected-pack case list on the right.
+ */
+
+import { useEffect, useMemo, useState } from 'react'
+import fs from 'fs'
+import path from 'path'
+import { Box, Text } from 'ink'
+import { theme } from '../theme.js'
+import { Table, type Column } from '../components/Table.js'
+import { loadEvalPack } from '../../core/config.js'
+import type { EvalPack, EvalCase } from '../../types/index.js'
+
+export interface EvalPacksProps {
+  onBack?: () => void
+}
+
+interface PackEntry {
+  file: string
+  path: string
+  pack: EvalPack | null
+  error?: string
+}
+
+const PACK_DIRS = ['./eval-packs', './multimodal-evals']
+
+function listPacks(): PackEntry[] {
+  const entries: PackEntry[] = []
+  for (const rel of PACK_DIRS) {
+    const dir = path.resolve(rel)
+    if (!fs.existsSync(dir)) continue
+    for (const f of fs.readdirSync(dir)) {
+      if (!f.endsWith('.yaml') && !f.endsWith('.yml')) continue
+      const full = path.join(dir, f)
+      try {
+        const pack = loadEvalPack(full, path.dirname(full))
+        entries.push({ file: path.relative(process.cwd(), full), path: full, pack })
+      } catch (e) {
+        entries.push({ file: path.relative(process.cwd(), full), path: full, pack: null, error: (e as Error).message })
+      }
+    }
+  }
+  return entries.sort((a, b) => a.file.localeCompare(b.file))
+}
+
+export function EvalPacks(_props: EvalPacksProps) {
+  const [entries, setEntries] = useState<PackEntry[]>([])
+  const [selected, setSelected] = useState<PackEntry | null>(null)
+  const [selectedCase, setSelectedCase] = useState<EvalCase | null>(null)
+
+  useEffect(() => { setEntries(listPacks()) }, [])
+
+  const packCols: Column<PackEntry>[] = [
+    { key: 'file', header: 'FILE', width: 38,
+      render: p => p.file.replace(/^eval-packs\//, ''),
+      color: p => p.error ? theme.danger : undefined },
+    { key: 'name', header: 'NAME', width: 22, render: p => p.pack?.name ?? '—' },
+    { key: 'cases', header: 'CASES', width: 6, align: 'right',
+      render: p => String(p.pack?.cases.length ?? 0) },
+  ]
+
+  const caseCols: Column<EvalCase>[] = useMemo(() => [
+    { key: 'id', header: 'ID', width: 22, render: c => c.id },
+    { key: 'scorer', header: 'SCORER', width: 10, render: c => c.scorer },
+    { key: 'prompt', header: 'PROMPT', width: 36,
+      render: c => c.prompt.slice(0, 34).replace(/\n/g, ' ') },
+  ], [])
+
+  return (
+    <Box flexDirection="column">
+      <Box marginBottom={1}>
+        <Text color={theme.accent} bold>📦 Eval packs  </Text>
+        <Text color={theme.muted}>({entries.length} loaded · Enter to browse cases)</Text>
+      </Box>
+      <Table
+        rows={entries}
+        columns={packCols}
+        height={8}
+        onSelectionChange={(p) => { setSelected(p); setSelectedCase(null) }}
+        emptyMessage="No eval packs found in ./eval-packs/"
+      />
+      {selected?.error && (
+        <Text color={theme.danger}>  parse error: {selected.error}</Text>
+      )}
+      {selected?.pack && (
+        <Box marginTop={1} flexDirection="column">
+          <Box>
+            <Text color={theme.accent} bold>{selected.pack.name}  </Text>
+            <Text color={theme.muted}>v{selected.pack.version}  {selected.pack.cases.length} cases</Text>
+          </Box>
+          {selected.pack.description && (
+            <Text color={theme.muted}>{selected.pack.description.slice(0, 120)}</Text>
+          )}
+          <Table
+            rows={selected.pack.cases}
+            columns={caseCols}
+            height={8}
+            focused={false}
+            onSelectionChange={(c) => setSelectedCase(c)}
+          />
+        </Box>
+      )}
+      {selectedCase && (
+        <Box marginTop={1} flexDirection="column" borderStyle="single" borderColor={theme.borderDim} paddingX={1}>
+          <Text color={theme.muted}>prompt</Text>
+          <Text>{selectedCase.prompt.slice(0, 400)}</Text>
+          <Text color={theme.muted}>{'\n'}criteria</Text>
+          <Text color={theme.text}>{selectedCase.criteria.slice(0, 400)}</Text>
+        </Box>
+      )}
+    </Box>
+  )
+}

--- a/src/tui/screens/NewRun.tsx
+++ b/src/tui/screens/NewRun.tsx
@@ -1,0 +1,192 @@
+/**
+ * NewRun wizard — customize which models + packs to run, then launch.
+ *
+ * Two panes:
+ *   1. Models  — space to toggle, all on by default
+ *   2. Packs   — space to toggle, all on by default
+ * Tab moves between panes, Enter launches.
+ */
+
+import { useEffect, useMemo, useState } from 'react'
+import path from 'path'
+import { Box, Text, useInput } from 'ink'
+import { Spinner } from '@inkjs/ui'
+import { theme, scoreColor } from '../theme.js'
+import { useConfig } from '../hooks/useConfig.js'
+import { useLiveRun } from '../hooks/useLiveRun.js'
+import { loadEvalPack } from '../../core/config.js'
+import { LogStream } from '../components/LogStream.js'
+import type { EvalPack } from '../../types/index.js'
+
+export interface NewRunProps {
+  onBack?: () => void
+}
+
+type Pane = 'models' | 'packs'
+
+export function NewRun(_props: NewRunProps) {
+  const { config, error: cfgErr } = useConfig('./verdict.yaml')
+  const { state, start } = useLiveRun()
+
+  const [pane, setPane] = useState<Pane>('models')
+  const [modelIdx, setModelIdx] = useState(0)
+  const [packIdx, setPackIdx] = useState(0)
+  const [selectedModels, setSelectedModels] = useState<Set<string>>(new Set())
+  const [selectedPacks, setSelectedPacks] = useState<Set<string>>(new Set())
+  const [loadedPacks, setLoadedPacks] = useState<Array<{ path: string, pack: EvalPack | null, err?: string }>>([])
+
+  // Initialize selection sets from config
+  useEffect(() => {
+    if (!config) return
+    setSelectedModels(new Set(config.models.map(m => m.id)))
+    setSelectedPacks(new Set(config.packs))
+    const configDir = path.dirname(path.resolve('./verdict.yaml'))
+    setLoadedPacks(config.packs.map(p => {
+      try { return { path: p, pack: loadEvalPack(p, configDir) } }
+      catch (e) { return { path: p, pack: null, err: (e as Error).message } }
+    }))
+  }, [config])
+
+  const launching = state.phase === 'running' || state.phase === 'done' || state.phase === 'error'
+
+  useInput((input, key) => {
+    if (launching) return
+    if (key.tab) {
+      setPane(p => p === 'models' ? 'packs' : 'models')
+      return
+    }
+    const items = pane === 'models'
+      ? (config?.models ?? [])
+      : loadedPacks
+    const idx = pane === 'models' ? modelIdx : packIdx
+    const setIdx = pane === 'models' ? setModelIdx : setPackIdx
+
+    if (input === 'j' || key.downArrow) setIdx(Math.min(idx + 1, items.length - 1))
+    else if (input === 'k' || key.upArrow) setIdx(Math.max(idx - 1, 0))
+    else if (input === ' ') {
+      const current = pane === 'models'
+        ? (config?.models[idx]?.id ?? '')
+        : (loadedPacks[idx]?.path ?? '')
+      if (!current) return
+      const set = pane === 'models' ? new Set(selectedModels) : new Set(selectedPacks)
+      if (set.has(current)) set.delete(current)
+      else set.add(current)
+      if (pane === 'models') setSelectedModels(set)
+      else setSelectedPacks(set)
+    }
+    else if (key.return) {
+      if (!config) return
+      const newConfig = {
+        ...config,
+        models: config.models.filter(m => selectedModels.has(m.id)),
+      }
+      const packs = loadedPacks
+        .filter(lp => selectedPacks.has(lp.path) && lp.pack)
+        .map(lp => lp.pack!) as EvalPack[]
+      if (newConfig.models.length === 0) return
+      if (packs.length === 0) return
+      start({ config: newConfig, packs })
+    }
+  })
+
+  if (cfgErr) {
+    return (
+      <Box flexDirection="column">
+        <Text color={theme.danger}>Config error</Text>
+        <Text color={theme.muted}>{cfgErr}</Text>
+      </Box>
+    )
+  }
+
+  if (launching) {
+    return (
+      <Box flexDirection="column">
+        <Box marginBottom={1}>
+          <Text color={theme.accent} bold>▶ Run  </Text>
+          <Text color={theme.muted}>
+            {selectedModels.size} model{selectedModels.size === 1 ? '' : 's'} ·{' '}
+            {selectedPacks.size} pack{selectedPacks.size === 1 ? '' : 's'}
+          </Text>
+        </Box>
+        {state.phase === 'running' && (
+          <Box><Spinner /><Text color={theme.primary}> {state.current || 'starting…'}</Text></Box>
+        )}
+        {state.phase === 'done' && (
+          <Text color={theme.success} bold>✓ Done.</Text>
+        )}
+        {state.phase === 'error' && (
+          <Text color={theme.danger}>✗ {state.error}</Text>
+        )}
+        <Box marginTop={1}><LogStream lines={state.log} height={14} title="progress" /></Box>
+        {state.result && (
+          <Box marginTop={1} flexDirection="column" borderStyle="single" borderColor={theme.borderDim} paddingX={1}>
+            <Text color={theme.accent} bold>Summary</Text>
+            {Object.values(state.result.summary)
+              .sort((a, b) => b.avg_total - a.avg_total)
+              .slice(0, 6)
+              .map((s, i) => (
+                <Box key={s.model_id}>
+                  <Text color={theme.muted}>{String(i + 1).padStart(2)}. </Text>
+                  <Text>{s.model_id.padEnd(28).slice(0, 28)} </Text>
+                  <Text color={scoreColor(s.avg_total)} bold>{s.avg_total.toFixed(2).padStart(5)}</Text>
+                </Box>
+              ))}
+          </Box>
+        )}
+      </Box>
+    )
+  }
+
+  const models = config?.models ?? []
+
+  return (
+    <Box flexDirection="column">
+      <Box marginBottom={1}>
+        <Text color={theme.accent} bold>🛠  New run  </Text>
+        <Text color={theme.muted}>Tab: switch pane · Space: toggle · Enter: launch</Text>
+      </Box>
+
+      <Box flexDirection="column">
+        <Text color={pane === 'models' ? theme.highlight : theme.muted} bold>Models</Text>
+        {models.length === 0 && <Text color={theme.muted}>  (none)</Text>}
+        {models.map((m, i) => {
+          const active = pane === 'models' && i === modelIdx
+          const checked = selectedModels.has(m.id)
+          return (
+            <Box key={m.id}>
+              <Text color={active ? theme.highlight : theme.text} inverse={active}>
+                {' '}[{checked ? <Text color={theme.success}>x</Text> : ' '}] {m.id.padEnd(34).slice(0, 34)} {m.model}
+              </Text>
+            </Box>
+          )
+        })}
+      </Box>
+
+      <Box flexDirection="column" marginTop={1}>
+        <Text color={pane === 'packs' ? theme.highlight : theme.muted} bold>Packs</Text>
+        {loadedPacks.length === 0 && <Text color={theme.muted}>  (none)</Text>}
+        {loadedPacks.map((lp, i) => {
+          const active = pane === 'packs' && i === packIdx
+          const checked = selectedPacks.has(lp.path)
+          return (
+            <Box key={lp.path}>
+              <Text color={active ? theme.highlight : theme.text} inverse={active}>
+                {' '}[{checked ? <Text color={theme.success}>x</Text> : ' '}] {lp.path.padEnd(40).slice(0, 40)}
+              </Text>
+              {lp.pack && <Text color={theme.muted}>  {lp.pack.cases.length} cases</Text>}
+              {lp.err && <Text color={theme.danger}>  {lp.err.slice(0, 30)}</Text>}
+            </Box>
+          )
+        })}
+      </Box>
+
+      <Box marginTop={1}>
+        {selectedModels.size === 0 && <Text color={theme.warning}>⚠ select at least one model  </Text>}
+        {selectedPacks.size === 0 && <Text color={theme.warning}>⚠ select at least one pack  </Text>}
+        {selectedModels.size > 0 && selectedPacks.size > 0 && (
+          <Text color={theme.muted}>Press <Text color={theme.highlight}>Enter</Text> to launch</Text>
+        )}
+      </Box>
+    </Box>
+  )
+}


### PR DESCRIPTION
## Summary

Completes the `verdict tui` coverage of every major CLI workflow with **6 new screens** + a shared **DiffPane** component.

### New screens

| Screen | Wraps | Key features |
|---|---|---|
| **Daemon** | `daemon {status,logs}` + `jobs` table | Live IPC status, recent jobs, log tail with `p` to pause / `G` to resume |
| **Baselines** | `baseline {list,save,compare}` | List, `s` to save latest, Enter to diff latest vs selected |
| **Compare** | `compare` | Pick two result JSONs in sequence from `config.output.dir`, side-by-side |
| **EvalPacks** | `eval list` | Browse `./eval-packs/**.yaml` + `./multimodal-evals/**.yaml`, drill into cases |
| **NewRun** | `run` (custom) | Tab between Models + Packs panes, Space toggles, Enter launches |
| **Config** | `validate` + YAML editor | Structured view; `E` shells to `$EDITOR`, revalidates via Zod on return |

### Supporting infrastructure
- New `DiffPane` component renders the full output of `compareWithBaseline` with regression alerts, new/removed model callouts, and colored deltas
- Keymap adds `1..6` number-key tab jumps; Layout tabs row expanded
- Command palette now exposes every screen + Compare/Config entries
- Help overlay updated

### Reuse, not rewrite
All screens call existing core APIs directly — `baseline.ts` (listBaselines, saveBaseline, compareWithBaseline, findLatestResult), `core/runner.ts` via `useLiveRun`, `core/config.ts` + `loadEvalPack`, `daemon/ipc.ts`. Zero subprocess layer. Zero changes to existing CLI commands or outputs.

## Test plan

- [x] 7 new smoke tests via `ink-testing-library`
- [x] Full suite green: **352/352 tests, 19 files**
- [x] `pnpm build` clean
- [x] Zero TUI-related typecheck errors
- [ ] Manual: open each new tab with `1..6`, verify `:` palette routes to Compare + Config, `E` on Config screen opens `$EDITOR`
- [ ] Regression: existing `verdict run --json` / `verdict daemon status` / `verdict compare a.json b.json` still work unchanged

https://claude.ai/code/session_01Xiis22wDRDqb4Ke4MQToPv