### PR TITLE
fix(tui): real-terminal smoke test fixes (regression heuristic + quit)

### DIFF
--- a/src/tui/hooks/useKeymap.ts
+++ b/src/tui/hooks/useKeymap.ts
@@ -117,6 +117,10 @@ export function useKeymap() {
     // Global exit (only in normal mode, to avoid eating q in search)
     if (state.mode === 'normal' && (input === 'q' || (key.ctrl && input === 'c'))) {
       exit()
+      // Ink's exit() unmounts React but does not force process termination.
+      // Any lingering handles (e.g. open sockets, sqlite WAL files) can keep
+      // Node's event loop alive. Give cleanup a tick, then hard-exit.
+      setTimeout(() => process.exit(0), 50)
       return
     }
     // Route openers

--- a/src/tui/screens/Home.tsx
+++ b/src/tui/screens/Home.tsx
@@ -48,8 +48,10 @@ function detectRegressions(agg: ModelAgg[]): ModelAgg[] {
     if (m.scoreHistory.length < 3) return false
     const prev = m.scoreHistory.slice(-4, -1)
     const latest = m.lastScore
-    const prevAvg = prev.reduce((s, v) => s + v, 0) / prev.length
-    return latest < prevAvg - 0.5
+    // Flag if latest is meaningfully below the best of the previous 3 runs.
+    // Using max (not avg) surfaces gradual slides that avg-based checks miss.
+    const prevMax = Math.max(...prev)
+    return latest < prevMax - 0.4
   })
 }
 


### PR DESCRIPTION
## Summary

Two bugs surfaced by driving the built TUI through a real PTY (tmux) with seeded data — an automated smoke test walked every screen, typed through the palette + filter + forms, and asserted expected text in each frame.

### Issues caught + fixed

**1. Regression banner missed a gradual slide.** A model with trend `[7.5, 7.6, 7.4, 7.2, 6.9]` was not flagged because the heuristic compared the latest score to the **avg** of the prior three runs. Switched to comparing against the **max** of the prior three with a tighter 0.4 threshold — gradual regressions now surface.

**2. `q` didn't actually terminate the process.** `exit()` from `useApp()` unmounts React and clears `setInterval` timers via effect cleanup, but the SQLite WAL connection and related handles kept Node's event loop alive indefinitely. Added an explicit `setTimeout(() => process.exit(0), 50)` after `exit()`.

### Smoke test coverage

The tmux harness walks Home → numeric tab jumps → `Ctrl-o` back stack → `:` palette → Router → `?` help → `t` theme cycle → `/` filter → Enter run detail → New Run → Config → Compare → `q` quit. **42/42 assertions green** against a seeded DB with 15 run rows, 60 per-case rows, and 3 jobs.

## Test plan

- [x] Full vitest suite: 358/358 pass
- [x] `pnpm build` clean
- [x] tmux smoke test: 42/42 green
- [x] Manual `ps` check confirms node process exits on `q` within 1.5s
- [x] Regression banner renders for seeded llama-3 slide

https://claude.ai/code/session_01Xiis22wDRDqb4Ke4MQToPv