### PR TITLE
docs: document verdict tui + CHANGELOG for 0.3.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,71 @@
 # Changelog
 
+## 0.3.0 (2026-04-15)
+
+### `verdict tui` — the full interactive terminal UI
+
+A single keyboard-driven app that covers the entire Verdict workflow.
+Run `verdict tui` to open it.
+
+**13 screens**
+
+- **Home** — leaderboard with sparklines, multi-series trend chart,
+  regression alerts for models whose latest score slid vs recent max,
+  daemon status, most-recent-run summary
+- **Runs** — full history table, `/` fuzzy filter across model / pack /
+  provider / run ID, Enter drills into per-case scores + responses
+- **Run Detail** — every case of a run with per-case score, latency,
+  and response preview
+- **Live Run** — streaming runner with 30 fps-throttled progress
+- **New Run** — wizard: Tab between Models + Packs panes, Space
+  toggles, Enter launches
+- **Models** — configured models + on-demand Ollama/MLX/LM Studio
+  discovery
+- **Baselines** — list, `s` saves latest result, Enter diffs latest
+  against selected via synced side-by-side `DiffPane`
+- **Compare** — pick two result JSONs from `config.output.dir`,
+  side-by-side diff with regression highlights
+- **Daemon** — live IPC status, recent jobs table, tailing log with
+  `p` to pause and `G` to resume (lazygit-style)
+- **Eval Packs** — browse every `*.yaml` in `./eval-packs/` +
+  `./multimodal-evals/`, drill into cases with prompt + criteria
+- **Router** — interactive prompt routing; Tab cycles task type,
+  `L` toggles prefer-local, Enter actually calls the selected model
+  and shows the response inline
+- **Serve** — managed child process for the OpenAI-compat HTTP proxy,
+  `s` starts/stops, `+`/`-` tune port, live log tail
+- **Config** — structured view of `verdict.yaml`; `E` shells out to
+  `$EDITOR`, revalidates via Zod on return; `r` reloads
+
+**Patterns**
+
+- Vim-style modes: normal / command / filter / help / insert
+- `:` command palette with Fuse.js fuzzy match over every action
+- `/` universal list filter
+- `?` context-sensitive help overlay
+- `1..6` lazygit-style tab jumps, `hjkl` + `g/G` + PgUp/PgDn navigation
+- `Ctrl-o` back through the last 20 screen transitions
+- `t` cycles through four themes (default, monokai, dracula, solarized),
+  persisted to `~/.verdict/tui-theme.json`
+- `q` force-terminates the process within 50 ms (avoids lingering
+  handles from SQLite / timers)
+
+**Built on**
+
+- [Ink 6](https://github.com/vadimdemedes/ink) + React 19 — same stack
+  as Claude Code, Gemini CLI, GitHub Copilot CLI
+- `@inkjs/ui`, `fuse.js`, `asciichart`, `sparkly`
+- Reuses existing `runEvals`, `queryHistory`, `getJobs`, `sendIpc`,
+  `discoverOllama/MLX`, `loadConfig`, `baseline.ts` — no new subprocess
+  layer, zero changes to existing CLI commands, `--json` output, SQLite
+  schema, or the GitHub Action
+
+**Quality**
+
+- 17 `ink-testing-library` smoke tests
+- 42-assertion real-PTY (tmux) smoke test walking every screen
+- 358 total tests passing
+
 ## 0.2.0 (2026-03-24)
 
 - **`verdict compare`** — compare two result JSON files side-by-side: score deltas per model, rank changes, notable per-case score changes (Δ ≥ 1.0), and overall verdict. `--output` flag saves a markdown report.

--- a/README.md
+++ b/README.md
@@ -431,12 +431,129 @@ judge:
 
 ---
 
+## Interactive TUI
+
+Don't want to remember 18 subcommands? Run
+
+```bash
+verdict tui
+```
+
+You get a single keyboard-driven terminal app that covers the entire
+workflow — browse runs, launch evals, diff baselines, manage the daemon,
+edit config, test the router, all without leaving your terminal.
+
+```
+╭─────────────────────────────────────────────────────────────────────╮
+│ verdict │ 1 Home  2 Runs  3 Models  4 Baselines  5 Daemon  6 Packs  │
+╰─────────────────────────────────────────────────────────────────────╯
+
+ ⚡ Top models  (avg across 15 runs)
+
+  1. gpt-4o            8.66  ▁▃▆▆█  5 runs  last 8.80
+  2. qwen-7b           7.70  ▁▃▆▇█  5 runs  last 8.20
+  3. llama-3           7.32  ▇█▆▄▁  5 runs  last 6.90
+
+ ⚠ 1 model regressed vs recent average: llama-3
+
+ 📈 Recent score trend  (top 3 models, last 5 runs)
+     10.00 ┤
+      8.33 ┤─╮──╭──╭──╯
+      6.66 ┤  ╰──╯
+      5.00 ┤
+
+ 🛰  Daemon   status: running   queue: 0   today: ✓ 14  ✗ 1
+
+ :cmd  /filter  ?help  t:theme  ^o:back  q:quit
+```
+
+### Screens
+
+| # | Screen | What it does |
+|---|---|---|
+| 1 | **Home** | Leaderboard, sparklines, trend chart, regression alerts, daemon status |
+| 2 | **Runs** | Full history table with `/` fuzzy filter; Enter opens per-case drill-in |
+| 3 | **Models** | Configured models + on-demand Ollama/MLX/LM Studio discovery |
+| 4 | **Baselines** | List saved baselines, `s` saves latest, Enter diffs side-by-side |
+| 5 | **Daemon** | Live job queue + tailing log (`p` to pause, `G` to resume) |
+| 6 | **Eval Packs** | Browse every pack under `./eval-packs/`, drill into cases |
+| · | **New Run** | Pick models + packs via Tab/Space, Enter launches with live progress |
+| · | **Compare** | Pick two result JSONs, side-by-side diff with regression highlights |
+| · | **Router** | Interactive prompt routing — type a prompt, see which model wins |
+| · | **Serve** | Start/stop the OpenAI-compat HTTP proxy, watch request log |
+| · | **Config** | Structured view of `verdict.yaml`; `E` opens `$EDITOR`, reloads on return |
+
+### Keymap
+
+**Global** (works from any screen)
+
+| Key | Action |
+|---|---|
+| `:` | Command palette (fuzzy-matches every screen + action) |
+| `/` | Filter the visible list |
+| `?` | Help overlay with context-sensitive keybinds |
+| `1`..`6` | Jump to tab 1..6 (lazygit-style) |
+| `Tab` / `Shift+Tab` | Next / previous pane |
+| `t` | Cycle theme (default → monokai → dracula → solarized) |
+| `Ctrl-o` | Back (navigation history, last 20 screens) |
+| `Esc` | Cancel / return to normal mode |
+| `q` | Quit |
+
+**List navigation**
+
+| Key | Action |
+|---|---|
+| `j` / `k` or `↓` / `↑` | Next / previous row |
+| `g` / `G` | Jump to top / bottom |
+| `PgDn` / `PgUp` | Scroll by page |
+| `Enter` | Open / drill in |
+
+**Screen-specific** (most useful)
+
+| Screen | Key | Action |
+|---|---|---|
+| Runs | `n` | Start a new run |
+| Models | `d` | Discover local Ollama / MLX / LM Studio models |
+| Baselines | `s` | Save latest result as a baseline |
+| Daemon | `p` / `G` | Pause / resume log auto-scroll |
+| New Run | `Space` | Toggle selection; `Tab` switches Models/Packs pane |
+| Router | `Tab` | Cycle task type; `L` prefers local models |
+| Serve | `s` | Start/stop proxy; `+`/`-` change port |
+| Config | `E` | Open `verdict.yaml` in `$EDITOR`; `r` reloads & revalidates |
+
+### Themes
+
+Four presets ship in the box:
+
+- `default` — ANSI 16-color (safe everywhere)
+- `monokai` — warm, high-contrast
+- `dracula` — cool purples and greens
+- `solarized` — muted classic
+
+Press `t` to cycle; your choice persists to `~/.verdict/tui-theme.json`
+so it's remembered across sessions.
+
+### Tips
+
+- **Everything reachable via `:`** — if you forget a keybind, hit `:` and
+  type a fragment of what you want (`com` → Compare, `rou` → Router,
+  `con` → Config).
+- **Filter anything with `/`** — on Runs, Models, Packs, the filter
+  matches across multiple columns (model ID, pack, provider, run ID).
+- **Back-button muscle memory** — `Ctrl-o` walks back like `hjkl` walks
+  sideways; it remembers the last 20 screens.
+- **`q` really quits** — even if a spinner is still animating, `q`
+  unmounts React and terminates the process within 50ms.
+
+---
+
 ## CLI Reference
 
 ```bash
 # Setup
 verdict init                            # Create verdict.yaml + eval-packs/
 verdict validate [config]               # Check config for errors
+verdict tui                             # Open the interactive terminal UI
 verdict models                          # Ping all configured models
 verdict models discover                 # Find Ollama/MLX models
 

--- a/src/cli/index.ts
+++ b/src/cli/index.ts
@@ -25,7 +25,7 @@ const program = new Command()
 program
   .name('verdict')
   .description(chalk.bold('verdict') + '\nLLM eval framework. Benchmark local and cloud models with one config file.')
-  .version('0.2.0')
+  .version('0.3.0')
 
 program
   .command('tui')

--- a/src/core/runner.ts
+++ b/src/core/runner.ts
@@ -15,7 +15,7 @@ import { preloadModels } from './preload.js'
  * Detect environment information
  */
 function detectEnvironment(): { verdict_version: string, node_version: string, provider_versions: { ollama?: string, mlx?: string } } {
-  const verdictVersion = '0.2.0' // TODO: Read from package.json
+  const verdictVersion = '0.3.0' // TODO: Read from package.json
   const nodeVersion = process.version
   
   const providerVersions: { ollama?: string, mlx?: string } = {}


### PR DESCRIPTION
## Summary

Documents the TUI that shipped across PRs #122, #123, and #124 so users can actually discover and use it.

### Changes

- **README** — new "Interactive TUI" section above the CLI reference with:
  - ASCII preview of the Home screen
  - Screen matrix (13 screens × what each does)
  - Full keymap cheat sheet: global keys, list navigation, screen-specific keys
  - Theme preset list
  - Tips for power users
- **README** — `verdict tui` added to the CLI reference setup block
- **CHANGELOG** — complete 0.3.0 entry covering all 13 screens, vim-style patterns, framework stack, and quality metrics (17 unit + 42-assertion tmux smoke)
- **Version sync** — bumped the hardcoded `'0.2.0'` strings in `src/cli/index.ts` and `src/core/runner.ts` to match `package.json@0.3.0`

No code changes beyond the version string alignment. 358/358 tests still pass.

## Test plan

- [x] `pnpm test` green
- [x] `pnpm build` green
- [x] README renders correctly (checked markdown structure)
- [x] `verdict --version` will now print `0.3.0`

https://claude.ai/code/session_01Xiis22wDRDqb4Ke4MQToPv