### PR TITLE
fix: make eval runs CI-safe

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -9,12 +9,19 @@
       "version": "0.3.0",
       "license": "MIT",
       "dependencies": {
+        "@ink-tools/ink-mouse": "^2.1.0",
+        "@inkjs/ui": "^2.0.0",
+        "asciichart": "^1.5.25",
         "better-sqlite3": "^12.8.0",
         "chalk": "^5.3.0",
         "commander": "^12.0.0",
+        "fuse.js": "^7.3.0",
+        "ink": "^6.8.0",
         "js-yaml": "^4.1.0",
         "openai": "^4.47.0",
         "ora": "^8.0.1",
+        "react": "^19.2.5",
+        "sparkly": "^6.0.1",
         "zod": "^3.22.0"
       },
       "bin": {
@@ -24,11 +31,26 @@
         "@types/better-sqlite3": "^7.6.13",
         "@types/js-yaml": "^4.0.9",
         "@types/node": "^20.0.0",
+        "@types/react": "^19.2.14",
         "@vitest/coverage-v8": "^4.1.1",
+        "ink-testing-library": "^4.0.0",
         "tsup": "^8.0.0",
         "tsx": "^4.7.0",
         "typescript": "^5.9.3",
         "vitest": "^4.1.1"
+      },
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@alcalzone/ansi-tokenize": {
+      "version": "0.2.5",
+      "resolved": "https://registry.npmjs.org/@alcalzone/ansi-tokenize/-/ansi-tokenize-0.2.5.tgz",
+      "integrity": "sha512-3NX/MpTdroi0aKz134A6RC2Gb2iXVECN4QaAXnvCIxxIm3C3AVB1mkUe8NaaiyvOpDfsrqWhYtj+Q6a62RrTsw==",
+      "license": "MIT",
+      "dependencies": {
+        "ansi-styles": "^6.2.1",
+        "is-fullwidth-code-point": "^5.0.0"
       },
       "engines": {
         "node": ">=18"
@@ -568,6 +590,52 @@
       ],
       "engines": {
         "node": ">=18"
+      }
+    },
+    "node_modules/@ink-tools/ink-mouse": {
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/@ink-tools/ink-mouse/-/ink-mouse-2.1.0.tgz",
+      "integrity": "sha512-6EfKsu6R3VYRgRRWsQ7PI5kJy+OsS/VAVhbG+YvUeZePKuHSS2AvstFD5yU/748iQS6wBBENtMoCcBvCjbylog==",
+      "license": "MIT",
+      "dependencies": {
+        "xterm-mouse": "1.0.0"
+      },
+      "engines": {
+        "node": ">=20"
+      },
+      "peerDependencies": {
+        "ink": ">=6",
+        "react": ">=17"
+      }
+    },
+    "node_modules/@inkjs/ui": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/@inkjs/ui/-/ui-2.0.0.tgz",
+      "integrity": "sha512-5+8fJmwtF9UvikzLfph9sA+LS+l37Ij/szQltkuXLOAXwNkBX9innfzh4pLGXIB59vKEQUtc6D4qGvhD7h3pAg==",
+      "license": "MIT",
+      "dependencies": {
+        "chalk": "^5.3.0",
+        "cli-spinners": "^3.0.0",
+        "deepmerge": "^4.3.1",
+        "figures": "^6.1.0"
+      },
+      "engines": {
+        "node": ">=18"
+      },
+      "peerDependencies": {
+        "ink": ">=5"
+      }
+    },
+    "node_modules/@inkjs/ui/node_modules/cli-spinners": {
+      "version": "3.4.0",
+      "resolved": "https://registry.npmjs.org/cli-spinners/-/cli-spinners-3.4.0.tgz",
+      "integrity": "sha512-bXfOC4QcT1tKXGorxL3wbJm6XJPDqEnij2gQ2m7ESQuE+/z9YFIWnl/5RpTiKWbMq3EVKR4fRLJGn6DVfu0mpw==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=18.20"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
       }
     },
     "node_modules/@jridgewell/gen-mapping": {
@@ -1327,6 +1395,16 @@
         "form-data": "^4.0.4"
       }
     },
+    "node_modules/@types/react": {
+      "version": "19.2.14",
+      "resolved": "https://registry.npmjs.org/@types/react/-/react-19.2.14.tgz",
+      "integrity": "sha512-ilcTH/UniCkMdtexkoCN0bI7pMcJDvmQFPvuPvmEaYA/NSfFTAgdUSLAoVjaRJm7+6PvcM+q1zYOwS4wTYMF9w==",
+      "devOptional": true,
+      "license": "MIT",
+      "dependencies": {
+        "csstype": "^3.2.2"
+      }
+    },
     "node_modules/@vitest/coverage-v8": {
       "version": "4.1.1",
       "resolved": "https://registry.npmjs.org/@vitest/coverage-v8/-/coverage-v8-4.1.1.tgz",
@@ -1508,6 +1586,21 @@
         "node": ">= 8.0.0"
       }
     },
+    "node_modules/ansi-escapes": {
+      "version": "7.3.0",
+      "resolved": "https://registry.npmjs.org/ansi-escapes/-/ansi-escapes-7.3.0.tgz",
+      "integrity": "sha512-BvU8nYgGQBxcmMuEeUEmNTvrMVjJNSH7RgW24vXexN4Ven6qCvy4TntnvlnwnMLTVlcRQQdbRY8NKnaIoeWDNg==",
+      "license": "MIT",
+      "dependencies": {
+        "environment": "^1.0.0"
+      },
+      "engines": {
+        "node": ">=18"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
     "node_modules/ansi-regex": {
       "version": "6.2.2",
       "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-6.2.2.tgz",
@@ -1518,6 +1611,18 @@
       },
       "funding": {
         "url": "https://github.com/chalk/ansi-regex?sponsor=1"
+      }
+    },
+    "node_modules/ansi-styles": {
+      "version": "6.2.3",
+      "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-6.2.3.tgz",
+      "integrity": "sha512-4Dj6M28JB+oAH8kFkTLUo+a2jwOFkuqb3yucU0CANcRRUbxS0cP0nZYCGjcc3BNXwRIsUVmDGgzawme7zvJHvg==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=12"
+      },
+      "funding": {
+        "url": "https://github.com/chalk/ansi-styles?sponsor=1"
       }
     },
     "node_modules/any-promise": {
@@ -1532,6 +1637,12 @@
       "resolved": "https://registry.npmjs.org/argparse/-/argparse-2.0.1.tgz",
       "integrity": "sha512-8+9WqebbFzpX9OR+Wa6O29asIogeRMzcGtAINdpMHHyAg10f05aSFVBbcEqGf/PXw1EjAZ+q2/bEBg3DvurK3Q==",
       "license": "Python-2.0"
+    },
+    "node_modules/asciichart": {
+      "version": "1.5.25",
+      "resolved": "https://registry.npmjs.org/asciichart/-/asciichart-1.5.25.tgz",
+      "integrity": "sha512-PNxzXIPPOtWq8T7bgzBtk9cI2lgS4SJZthUHEiQ1aoIc3lNzGfUvIvo9LiAnq26TACo9t1/4qP6KTGAUbzX9Xg==",
+      "license": "MIT"
     },
     "node_modules/assertion-error": {
       "version": "2.0.1",
@@ -1560,6 +1671,18 @@
       "resolved": "https://registry.npmjs.org/asynckit/-/asynckit-0.4.0.tgz",
       "integrity": "sha512-Oei9OH4tRh0YqU3GxhX79dM/mwVgvbZJaSNaRk+bshkj0S5cfHcgYakreBjrHwatXKbz+IoIdYLxrKim2MjW0Q==",
       "license": "MIT"
+    },
+    "node_modules/auto-bind": {
+      "version": "5.0.1",
+      "resolved": "https://registry.npmjs.org/auto-bind/-/auto-bind-5.0.1.tgz",
+      "integrity": "sha512-ooviqdwwgfIfNmDwo94wlshcdzfO64XV0Cg6oDsDYBJfITDz1EngD2z7DkbvCWn+XIMsIqW27sEVF6qcpJrRcg==",
+      "license": "MIT",
+      "engines": {
+        "node": "^12.20.0 || ^14.13.1 || >=16.0.0"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
     },
     "node_modules/base64-js": {
       "version": "1.5.1",
@@ -1722,6 +1845,18 @@
       "integrity": "sha512-jJ0bqzaylmJtVnNgzTeSOs8DPavpbYgEr/b0YL8/2GO3xJEhInFmhKMUnEJQjZumK7KXGFhUy89PrsJWlakBVg==",
       "license": "ISC"
     },
+    "node_modules/cli-boxes": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/cli-boxes/-/cli-boxes-3.0.0.tgz",
+      "integrity": "sha512-/lzGpEWL/8PfI0BmBOPRwp0c/wFNX1RdUML3jK/RcSBA9T8mZDdQpqYBKtCFTOfQbwPqWEOpjqW+Fnayc0969g==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=10"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
     "node_modules/cli-cursor": {
       "version": "5.0.0",
       "resolved": "https://registry.npmjs.org/cli-cursor/-/cli-cursor-5.0.0.tgz",
@@ -1748,6 +1883,68 @@
       "funding": {
         "url": "https://github.com/sponsors/sindresorhus"
       }
+    },
+    "node_modules/cli-truncate": {
+      "version": "5.2.0",
+      "resolved": "https://registry.npmjs.org/cli-truncate/-/cli-truncate-5.2.0.tgz",
+      "integrity": "sha512-xRwvIOMGrfOAnM1JYtqQImuaNtDEv9v6oIYAs4LIHwTiKee8uwvIi363igssOC0O5U04i4AlENs79LQLu9tEMw==",
+      "license": "MIT",
+      "dependencies": {
+        "slice-ansi": "^8.0.0",
+        "string-width": "^8.2.0"
+      },
+      "engines": {
+        "node": ">=20"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/cli-truncate/node_modules/string-width": {
+      "version": "8.2.1",
+      "resolved": "https://registry.npmjs.org/string-width/-/string-width-8.2.1.tgz",
+      "integrity": "sha512-IIaP0g3iy9Cyy18w3M9YcaDudujEAVHKt3a3QJg1+sr/oX96TbaGUubG0hJyCjCBThFH+tFpcIyoUHUn1ogaLA==",
+      "license": "MIT",
+      "dependencies": {
+        "get-east-asian-width": "^1.5.0",
+        "strip-ansi": "^7.1.2"
+      },
+      "engines": {
+        "node": ">=20"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/code-excerpt": {
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/code-excerpt/-/code-excerpt-4.0.0.tgz",
+      "integrity": "sha512-xxodCmBen3iy2i0WtAK8FlFNrRzjUqjRsMfho58xT/wvZU1YTM3fCnRjcy1gJPMepaRlgm/0e6w8SpWHpn3/cA==",
+      "license": "MIT",
+      "dependencies": {
+        "convert-to-spaces": "^2.0.1"
+      },
+      "engines": {
+        "node": "^12.20.0 || ^14.13.1 || >=16.0.0"
+      }
+    },
+    "node_modules/color-convert": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/color-convert/-/color-convert-2.0.1.tgz",
+      "integrity": "sha512-RRECPsj7iu/xb5oKYcsFHSppFNnsj/52OVTRKb4zP5onXwVF3zVmmToNcOfGC+CRDpfK/U584fMg38ZHCaElKQ==",
+      "license": "MIT",
+      "dependencies": {
+        "color-name": "~1.1.4"
+      },
+      "engines": {
+        "node": ">=7.0.0"
+      }
+    },
+    "node_modules/color-name": {
+      "version": "1.1.4",
+      "resolved": "https://registry.npmjs.org/color-name/-/color-name-1.1.4.tgz",
+      "integrity": "sha512-dOy+3AuW3a2wNbZHIuMZpTcgjGuLU/uBL/ubcZF9OXbDo8ff4O8yVp5Bf0efS8uEoYo5q4Fx7dY9OgQGXgAsQA==",
+      "license": "MIT"
     },
     "node_modules/combined-stream": {
       "version": "1.0.8",
@@ -1794,6 +1991,22 @@
       "dev": true,
       "license": "MIT"
     },
+    "node_modules/convert-to-spaces": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/convert-to-spaces/-/convert-to-spaces-2.0.1.tgz",
+      "integrity": "sha512-rcQ1bsQO9799wq24uE5AM2tAILy4gXGIK/njFWcVQkGNZ96edlpY+A7bjwvzjYvLDyzmG1MmMLZhpcsb+klNMQ==",
+      "license": "MIT",
+      "engines": {
+        "node": "^12.20.0 || ^14.13.1 || >=16.0.0"
+      }
+    },
+    "node_modules/csstype": {
+      "version": "3.2.3",
+      "resolved": "https://registry.npmjs.org/csstype/-/csstype-3.2.3.tgz",
+      "integrity": "sha512-z1HGKcYy2xA8AGQfwrn0PAy+PB7X/GSj3UVJW9qKyn43xWa+gl5nXmU4qqLMRzWVLFC8KusUX8T/0kCiOYpAIQ==",
+      "devOptional": true,
+      "license": "MIT"
+    },
     "node_modules/debug": {
       "version": "4.4.3",
       "resolved": "https://registry.npmjs.org/debug/-/debug-4.4.3.tgz",
@@ -1834,6 +2047,15 @@
       "license": "MIT",
       "engines": {
         "node": ">=4.0.0"
+      }
+    },
+    "node_modules/deepmerge": {
+      "version": "4.3.1",
+      "resolved": "https://registry.npmjs.org/deepmerge/-/deepmerge-4.3.1.tgz",
+      "integrity": "sha512-3sUqbMEc77XqpdNO7FRyRog+eW3ph+GYCbj+rK+uYyRMuwsVy0rMiVtPn+QJlKFvWP/1PYpapqYn0Me2knFn+A==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=0.10.0"
       }
     },
     "node_modules/delayed-stream": {
@@ -1881,6 +2103,18 @@
       "license": "MIT",
       "dependencies": {
         "once": "^1.4.0"
+      }
+    },
+    "node_modules/environment": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/environment/-/environment-1.1.0.tgz",
+      "integrity": "sha512-xUtoPkMggbz0MPyPiIWr1Kp4aeWJjDZ6SMvURhimjdZgsRuDplF5/s9hcgGhyXMhs+6vpnuoiZ2kFiu3FMnS8Q==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=18"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
       }
     },
     "node_modules/es-define-property": {
@@ -1935,6 +2169,16 @@
         "node": ">= 0.4"
       }
     },
+    "node_modules/es-toolkit": {
+      "version": "1.46.1",
+      "resolved": "https://registry.npmjs.org/es-toolkit/-/es-toolkit-1.46.1.tgz",
+      "integrity": "sha512-5eNtXOs3tbfxXOj04tjjseeWkRWaoCjdEI+96DgwzZoe6c9juL49pXlzAFTI72aWC9Y8p7168g6XIKjh7k6pyQ==",
+      "license": "MIT",
+      "workspaces": [
+        "docs",
+        "benchmarks"
+      ]
+    },
     "node_modules/esbuild": {
       "version": "0.27.4",
       "resolved": "https://registry.npmjs.org/esbuild/-/esbuild-0.27.4.tgz",
@@ -1975,6 +2219,15 @@
         "@esbuild/win32-arm64": "0.27.4",
         "@esbuild/win32-ia32": "0.27.4",
         "@esbuild/win32-x64": "0.27.4"
+      }
+    },
+    "node_modules/escape-string-regexp": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/escape-string-regexp/-/escape-string-regexp-2.0.0.tgz",
+      "integrity": "sha512-UpzcLCXolUWcNu5HtVMHYdXJjArjsF9C0aNnquZYY4uW/Vu0miy5YoWvbV345HauVvcAUnpRuhMMcqTcGOY2+w==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=8"
       }
     },
     "node_modules/estree-walker": {
@@ -2031,6 +2284,21 @@
         "picomatch": {
           "optional": true
         }
+      }
+    },
+    "node_modules/figures": {
+      "version": "6.1.0",
+      "resolved": "https://registry.npmjs.org/figures/-/figures-6.1.0.tgz",
+      "integrity": "sha512-d+l3qxjSesT4V7v2fh+QnmFnUWv9lSpjarhShNTgBOfA0ttejbQUAlHLitbjkoRiDulW0OPoQPYIGhIC8ohejg==",
+      "license": "MIT",
+      "dependencies": {
+        "is-unicode-supported": "^2.0.0"
+      },
+      "engines": {
+        "node": ">=18"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
       }
     },
     "node_modules/file-uri-to-path": {
@@ -2114,6 +2382,19 @@
       "license": "MIT",
       "funding": {
         "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/fuse.js": {
+      "version": "7.3.0",
+      "resolved": "https://registry.npmjs.org/fuse.js/-/fuse.js-7.3.0.tgz",
+      "integrity": "sha512-plz8RVjfcDedTGfVngWH1jmJvBvAwi1v2jecfDerbEnMcmOYUEEwKFTHbNoCiYyzaK2Ws8lABkTCcRSqCY1q4w==",
+      "license": "Apache-2.0",
+      "engines": {
+        "node": ">=10"
+      },
+      "funding": {
+        "type": "github",
+        "url": "https://github.com/sponsors/krisk"
       }
     },
     "node_modules/get-east-asian-width": {
@@ -2200,7 +2481,6 @@
       "version": "4.0.0",
       "resolved": "https://registry.npmjs.org/has-flag/-/has-flag-4.0.0.tgz",
       "integrity": "sha512-EykJT/Q1KjTWctppgIAgfSO0tKVuZUjhgMr17kqTumMl6Afv3EISleU7qZUzoXDFTAHTDC4NOoG/ZxU3EvlMPQ==",
-      "dev": true,
       "license": "MIT",
       "engines": {
         "node": ">=8"
@@ -2281,6 +2561,18 @@
       ],
       "license": "BSD-3-Clause"
     },
+    "node_modules/indent-string": {
+      "version": "5.0.0",
+      "resolved": "https://registry.npmjs.org/indent-string/-/indent-string-5.0.0.tgz",
+      "integrity": "sha512-m6FAo/spmsW2Ab2fU35JTYwtOKa2yAwXSwgjSv1TJzh4Mh7mC3lzAOVLBprb72XsTrgkEIsl7YrFNAiDiRhIGg==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=12"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
     "node_modules/inherits": {
       "version": "2.0.4",
       "resolved": "https://registry.npmjs.org/inherits/-/inherits-2.0.4.tgz",
@@ -2292,6 +2584,171 @@
       "resolved": "https://registry.npmjs.org/ini/-/ini-1.3.8.tgz",
       "integrity": "sha512-JV/yugV2uzW5iMRSiZAyDtQd+nxtUnjeLt0acNdw98kKLrvuRVyB80tsREOE7yvGVgalhZ6RNXCmEHkUKBKxew==",
       "license": "ISC"
+    },
+    "node_modules/ink": {
+      "version": "6.8.0",
+      "resolved": "https://registry.npmjs.org/ink/-/ink-6.8.0.tgz",
+      "integrity": "sha512-sbl1RdLOgkO9isK42WCZlJCFN9hb++sX9dsklOvfd1YQ3bQ2AiFu12Q6tFlr0HvEUvzraJntQCCpfEoUe9DSzA==",
+      "license": "MIT",
+      "dependencies": {
+        "@alcalzone/ansi-tokenize": "^0.2.4",
+        "ansi-escapes": "^7.3.0",
+        "ansi-styles": "^6.2.1",
+        "auto-bind": "^5.0.1",
+        "chalk": "^5.6.0",
+        "cli-boxes": "^3.0.0",
+        "cli-cursor": "^4.0.0",
+        "cli-truncate": "^5.1.1",
+        "code-excerpt": "^4.0.0",
+        "es-toolkit": "^1.39.10",
+        "indent-string": "^5.0.0",
+        "is-in-ci": "^2.0.0",
+        "patch-console": "^2.0.0",
+        "react-reconciler": "^0.33.0",
+        "scheduler": "^0.27.0",
+        "signal-exit": "^3.0.7",
+        "slice-ansi": "^8.0.0",
+        "stack-utils": "^2.0.6",
+        "string-width": "^8.1.1",
+        "terminal-size": "^4.0.1",
+        "type-fest": "^5.4.1",
+        "widest-line": "^6.0.0",
+        "wrap-ansi": "^9.0.0",
+        "ws": "^8.18.0",
+        "yoga-layout": "~3.2.1"
+      },
+      "engines": {
+        "node": ">=20"
+      },
+      "peerDependencies": {
+        "@types/react": ">=19.0.0",
+        "react": ">=19.0.0",
+        "react-devtools-core": ">=6.1.2"
+      },
+      "peerDependenciesMeta": {
+        "@types/react": {
+          "optional": true
+        },
+        "react-devtools-core": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/ink-testing-library": {
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/ink-testing-library/-/ink-testing-library-4.0.0.tgz",
+      "integrity": "sha512-yF92kj3pmBvk7oKbSq5vEALO//o7Z9Ck/OaLNlkzXNeYdwfpxMQkSowGTFUCS5MSu9bWfSZMewGpp7bFc66D7Q==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=18"
+      },
+      "peerDependencies": {
+        "@types/react": ">=18.0.0"
+      },
+      "peerDependenciesMeta": {
+        "@types/react": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/ink/node_modules/cli-cursor": {
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/cli-cursor/-/cli-cursor-4.0.0.tgz",
+      "integrity": "sha512-VGtlMu3x/4DOtIUwEkRezxUZ2lBacNJCHash0N0WeZDBS+7Ux1dm3XWAgWYxLJFMMdOeXMHXorshEFhbMSGelg==",
+      "license": "MIT",
+      "dependencies": {
+        "restore-cursor": "^4.0.0"
+      },
+      "engines": {
+        "node": "^12.20.0 || ^14.13.1 || >=16.0.0"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/ink/node_modules/onetime": {
+      "version": "5.1.2",
+      "resolved": "https://registry.npmjs.org/onetime/-/onetime-5.1.2.tgz",
+      "integrity": "sha512-kbpaSSGJTWdAY5KPVeMOKXSrPtr8C8C7wodJbcsd51jRnmD+GZu8Y0VoU6Dm5Z4vWr0Ig/1NKuWRKf7j5aaYSg==",
+      "license": "MIT",
+      "dependencies": {
+        "mimic-fn": "^2.1.0"
+      },
+      "engines": {
+        "node": ">=6"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/ink/node_modules/restore-cursor": {
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/restore-cursor/-/restore-cursor-4.0.0.tgz",
+      "integrity": "sha512-I9fPXU9geO9bHOt9pHHOhOkYerIMsmVaWB0rA2AI9ERh/+x/i7MV5HKBNrg+ljO5eoPVgCcnFuRjJ9uH6I/3eg==",
+      "license": "MIT",
+      "dependencies": {
+        "onetime": "^5.1.0",
+        "signal-exit": "^3.0.2"
+      },
+      "engines": {
+        "node": "^12.20.0 || ^14.13.1 || >=16.0.0"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/ink/node_modules/signal-exit": {
+      "version": "3.0.7",
+      "resolved": "https://registry.npmjs.org/signal-exit/-/signal-exit-3.0.7.tgz",
+      "integrity": "sha512-wnD2ZE+l+SPC/uoS0vXeE9L1+0wuaMqKlfz9AMUo38JsyLSBWSFcHR1Rri62LZc12vLr1gb3jl7iwQhgwpAbGQ==",
+      "license": "ISC"
+    },
+    "node_modules/ink/node_modules/string-width": {
+      "version": "8.2.1",
+      "resolved": "https://registry.npmjs.org/string-width/-/string-width-8.2.1.tgz",
+      "integrity": "sha512-IIaP0g3iy9Cyy18w3M9YcaDudujEAVHKt3a3QJg1+sr/oX96TbaGUubG0hJyCjCBThFH+tFpcIyoUHUn1ogaLA==",
+      "license": "MIT",
+      "dependencies": {
+        "get-east-asian-width": "^1.5.0",
+        "strip-ansi": "^7.1.2"
+      },
+      "engines": {
+        "node": ">=20"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/is-fullwidth-code-point": {
+      "version": "5.1.0",
+      "resolved": "https://registry.npmjs.org/is-fullwidth-code-point/-/is-fullwidth-code-point-5.1.0.tgz",
+      "integrity": "sha512-5XHYaSyiqADb4RnZ1Bdad6cPp8Toise4TzEjcOYDHZkTCbKgiUl7WTUCpNWHuxmDt91wnsZBc9xinNzopv3JMQ==",
+      "license": "MIT",
+      "dependencies": {
+        "get-east-asian-width": "^1.3.1"
+      },
+      "engines": {
+        "node": ">=18"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/is-in-ci": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/is-in-ci/-/is-in-ci-2.0.0.tgz",
+      "integrity": "sha512-cFeerHriAnhrQSbpAxL37W1wcJKUUX07HyLWZCW1URJT/ra3GyUTzBgUnh24TMVfNTV2Hij2HLxkPHFZfOZy5w==",
+      "license": "MIT",
+      "bin": {
+        "is-in-ci": "cli.js"
+      },
+      "engines": {
+        "node": ">=20"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
     },
     "node_modules/is-interactive": {
       "version": "2.0.0",
@@ -2772,6 +3229,15 @@
         "node": ">= 0.6"
       }
     },
+    "node_modules/mimic-fn": {
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/mimic-fn/-/mimic-fn-2.1.0.tgz",
+      "integrity": "sha512-OqbOk5oEQeAZ8WXWydlu9HJjz9WVdEIvamMCcXmuqUYjTknH/sqsWvhQ3vgwKFRR1HpjvNBKQ37nbJgYzGqGcg==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=6"
+      }
+    },
     "node_modules/mimic-function": {
       "version": "5.0.1",
       "resolved": "https://registry.npmjs.org/mimic-function/-/mimic-function-5.0.1.tgz",
@@ -3032,6 +3498,15 @@
         "url": "https://github.com/sponsors/sindresorhus"
       }
     },
+    "node_modules/patch-console": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/patch-console/-/patch-console-2.0.0.tgz",
+      "integrity": "sha512-0YNdUceMdaQwoKce1gatDScmMo5pu/tfABfnzEqeG0gtTmd7mh/WcwgUjtAeOU7N8nFFlbQBnFK2gXW5fGvmMA==",
+      "license": "MIT",
+      "engines": {
+        "node": "^12.20.0 || ^14.13.1 || >=16.0.0"
+      }
+    },
     "node_modules/pathe": {
       "version": "2.0.3",
       "resolved": "https://registry.npmjs.org/pathe/-/pathe-2.0.3.tgz",
@@ -3205,6 +3680,30 @@
         "rc": "cli.js"
       }
     },
+    "node_modules/react": {
+      "version": "19.2.6",
+      "resolved": "https://registry.npmjs.org/react/-/react-19.2.6.tgz",
+      "integrity": "sha512-sfWGGfavi0xr8Pg0sVsyHMAOziVYKgPLNrS7ig+ivMNb3wbCBw3KxtflsGBAwD3gYQlE/AEZsTLgToRrSCjb0Q==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=0.10.0"
+      }
+    },
+    "node_modules/react-reconciler": {
+      "version": "0.33.0",
+      "resolved": "https://registry.npmjs.org/react-reconciler/-/react-reconciler-0.33.0.tgz",
+      "integrity": "sha512-KetWRytFv1epdpJc3J4G75I4WrplZE5jOL7Yq0p34+OVOKF4Se7WrdIdVC45XsSSmUTlht2FM/fM1FZb1mfQeA==",
+      "license": "MIT",
+      "dependencies": {
+        "scheduler": "^0.27.0"
+      },
+      "engines": {
+        "node": ">=0.10.0"
+      },
+      "peerDependencies": {
+        "react": "^19.2.0"
+      }
+    },
     "node_modules/readable-stream": {
       "version": "3.6.2",
       "resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-3.6.2.tgz",
@@ -3368,6 +3867,12 @@
       ],
       "license": "MIT"
     },
+    "node_modules/scheduler": {
+      "version": "0.27.0",
+      "resolved": "https://registry.npmjs.org/scheduler/-/scheduler-0.27.0.tgz",
+      "integrity": "sha512-eNv+WrVbKu1f3vbYJT/xtiF5syA5HPIMtf9IgY/nKg0sWqzAUEvqY/xm7OcZc/qafLx/iO9FgOmeSAp4v5ti/Q==",
+      "license": "MIT"
+    },
     "node_modules/semver": {
       "version": "7.7.4",
       "resolved": "https://registry.npmjs.org/semver/-/semver-7.7.4.tgz",
@@ -3444,6 +3949,22 @@
         "simple-concat": "^1.0.0"
       }
     },
+    "node_modules/slice-ansi": {
+      "version": "8.0.0",
+      "resolved": "https://registry.npmjs.org/slice-ansi/-/slice-ansi-8.0.0.tgz",
+      "integrity": "sha512-stxByr12oeeOyY2BlviTNQlYV5xOj47GirPr4yA1hE9JCtxfQN0+tVbkxwCtYDQWhEKWFHsEK48ORg5jrouCAg==",
+      "license": "MIT",
+      "dependencies": {
+        "ansi-styles": "^6.2.3",
+        "is-fullwidth-code-point": "^5.1.0"
+      },
+      "engines": {
+        "node": ">=20"
+      },
+      "funding": {
+        "url": "https://github.com/chalk/slice-ansi?sponsor=1"
+      }
+    },
     "node_modules/source-map": {
       "version": "0.7.6",
       "resolved": "https://registry.npmjs.org/source-map/-/source-map-0.7.6.tgz",
@@ -3462,6 +3983,64 @@
       "license": "BSD-3-Clause",
       "engines": {
         "node": ">=0.10.0"
+      }
+    },
+    "node_modules/sparkly": {
+      "version": "6.0.1",
+      "resolved": "https://registry.npmjs.org/sparkly/-/sparkly-6.0.1.tgz",
+      "integrity": "sha512-CG0p45e9YCfzmPvBqFEgK4miRCrt++3ByBWSixPLC6pkhg72qtpM8zedqfUr8RYVRoqCv++Oc140m13C2m9MbQ==",
+      "license": "MIT",
+      "dependencies": {
+        "chalk": "^4.1.2"
+      },
+      "engines": {
+        "node": "^12.20.0 || ^14.13.1 || >=16.0.0"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/sparkly/node_modules/ansi-styles": {
+      "version": "4.3.0",
+      "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-4.3.0.tgz",
+      "integrity": "sha512-zbB9rCJAT1rbjiVDb2hqKFHNYLxgtk8NURxZ3IZwD3F6NtxbXZQCnnSi1Lkx+IDohdPlFp222wVALIheZJQSEg==",
+      "license": "MIT",
+      "dependencies": {
+        "color-convert": "^2.0.1"
+      },
+      "engines": {
+        "node": ">=8"
+      },
+      "funding": {
+        "url": "https://github.com/chalk/ansi-styles?sponsor=1"
+      }
+    },
+    "node_modules/sparkly/node_modules/chalk": {
+      "version": "4.1.2",
+      "resolved": "https://registry.npmjs.org/chalk/-/chalk-4.1.2.tgz",
+      "integrity": "sha512-oKnbhFyRIXpUuez8iBMmyEa4nbj4IOQyuhc/wy9kY7/WVPcwIO9VA668Pu8RkO7+0G76SLROeyw9CpQ061i4mA==",
+      "license": "MIT",
+      "dependencies": {
+        "ansi-styles": "^4.1.0",
+        "supports-color": "^7.1.0"
+      },
+      "engines": {
+        "node": ">=10"
+      },
+      "funding": {
+        "url": "https://github.com/chalk/chalk?sponsor=1"
+      }
+    },
+    "node_modules/stack-utils": {
+      "version": "2.0.6",
+      "resolved": "https://registry.npmjs.org/stack-utils/-/stack-utils-2.0.6.tgz",
+      "integrity": "sha512-XlkWvfIm6RmsWtNJx+uqtKLS8eqFbxUg0ZzLXqY0caEy9l7hruX8IpiDnjsLavoBgqCCR71TqWO8MaXYheJ3RQ==",
+      "license": "MIT",
+      "dependencies": {
+        "escape-string-regexp": "^2.0.0"
+      },
+      "engines": {
+        "node": ">=10"
       }
     },
     "node_modules/stackback": {
@@ -3577,13 +4156,24 @@
       "version": "7.2.0",
       "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-7.2.0.tgz",
       "integrity": "sha512-qpCAvRl9stuOHveKsn7HncJRvv501qIacKzQlO/+Lwxc9+0q2wLyv4Dfvt80/DPn2pqOBsJdDiogXGR9+OvwRw==",
-      "dev": true,
       "license": "MIT",
       "dependencies": {
         "has-flag": "^4.0.0"
       },
       "engines": {
         "node": ">=8"
+      }
+    },
+    "node_modules/tagged-tag": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/tagged-tag/-/tagged-tag-1.0.0.tgz",
+      "integrity": "sha512-yEFYrVhod+hdNyx7g5Bnkkb0G6si8HJurOoOEgC8B/O0uXLHlaey/65KRv6cuWBNhBgHKAROVpc7QyYqE5gFng==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=20"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
       }
     },
     "node_modules/tar-fs": {
@@ -3612,6 +4202,18 @@
       },
       "engines": {
         "node": ">=6"
+      }
+    },
+    "node_modules/terminal-size": {
+      "version": "4.0.1",
+      "resolved": "https://registry.npmjs.org/terminal-size/-/terminal-size-4.0.1.tgz",
+      "integrity": "sha512-avMLDQpUI9I5XFrklECw1ZEUPJhqzcwSWsyyI8blhRLT+8N1jLJWLWWYQpB2q2xthq8xDvjZPISVh53T/+CLYQ==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=18"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
       }
     },
     "node_modules/thenify": {
@@ -3792,6 +4394,21 @@
       },
       "engines": {
         "node": "*"
+      }
+    },
+    "node_modules/type-fest": {
+      "version": "5.6.0",
+      "resolved": "https://registry.npmjs.org/type-fest/-/type-fest-5.6.0.tgz",
+      "integrity": "sha512-8ZiHFm91orbSAe2PSAiSVBVko18pbhbiB3U9GglSzF/zCGkR+rxpHx6sEMCUm4kxY4LjDIUGgCfUMtwfZfjfUA==",
+      "license": "(MIT OR CC0-1.0)",
+      "dependencies": {
+        "tagged-tag": "^1.0.0"
+      },
+      "engines": {
+        "node": ">=20"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
       }
     },
     "node_modules/typescript": {
@@ -4039,11 +4656,95 @@
         "node": ">=8"
       }
     },
+    "node_modules/widest-line": {
+      "version": "6.0.0",
+      "resolved": "https://registry.npmjs.org/widest-line/-/widest-line-6.0.0.tgz",
+      "integrity": "sha512-U89AsyEeAsyoF0zVJBkG9zBgekjgjK7yk9sje3F4IQpXBJ10TF6ByLlIfjMhcmHMJgHZI4KHt4rdNfktzxIAMA==",
+      "license": "MIT",
+      "dependencies": {
+        "string-width": "^8.1.0"
+      },
+      "engines": {
+        "node": ">=20"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/widest-line/node_modules/string-width": {
+      "version": "8.2.1",
+      "resolved": "https://registry.npmjs.org/string-width/-/string-width-8.2.1.tgz",
+      "integrity": "sha512-IIaP0g3iy9Cyy18w3M9YcaDudujEAVHKt3a3QJg1+sr/oX96TbaGUubG0hJyCjCBThFH+tFpcIyoUHUn1ogaLA==",
+      "license": "MIT",
+      "dependencies": {
+        "get-east-asian-width": "^1.5.0",
+        "strip-ansi": "^7.1.2"
+      },
+      "engines": {
+        "node": ">=20"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/wrap-ansi": {
+      "version": "9.0.2",
+      "resolved": "https://registry.npmjs.org/wrap-ansi/-/wrap-ansi-9.0.2.tgz",
+      "integrity": "sha512-42AtmgqjV+X1VpdOfyTGOYRi0/zsoLqtXQckTmqTeybT+BDIbM/Guxo7x3pE2vtpr1ok6xRqM9OpBe+Jyoqyww==",
+      "license": "MIT",
+      "dependencies": {
+        "ansi-styles": "^6.2.1",
+        "string-width": "^7.0.0",
+        "strip-ansi": "^7.1.0"
+      },
+      "engines": {
+        "node": ">=18"
+      },
+      "funding": {
+        "url": "https://github.com/chalk/wrap-ansi?sponsor=1"
+      }
+    },
     "node_modules/wrappy": {
       "version": "1.0.2",
       "resolved": "https://registry.npmjs.org/wrappy/-/wrappy-1.0.2.tgz",
       "integrity": "sha512-l4Sp/DRseor9wL6EvV2+TuQn63dMkPjZ/sp9XkghTEbV9KlPS1xUsZ3u7/IQO4wxtcFB4bgpQPRcR3QCvezPcQ==",
       "license": "ISC"
+    },
+    "node_modules/ws": {
+      "version": "8.20.1",
+      "resolved": "https://registry.npmjs.org/ws/-/ws-8.20.1.tgz",
+      "integrity": "sha512-It4dO0K5v//JtTXuPkfEOaI3uUN87iYPnqo/ZzqCoG3g8uhA66QUMs/SrM0YK7/NAu+r4LMh/9dq2A7k+rHs+w==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=10.0.0"
+      },
+      "peerDependencies": {
+        "bufferutil": "^4.0.1",
+        "utf-8-validate": ">=5.0.2"
+      },
+      "peerDependenciesMeta": {
+        "bufferutil": {
+          "optional": true
+        },
+        "utf-8-validate": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/xterm-mouse": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/xterm-mouse/-/xterm-mouse-1.0.0.tgz",
+      "integrity": "sha512-A+PkxOzlwgnhfeZclQvCNfLIcLbtTyDSgWs//adOYYUKdjhU9Lejot6wbnW5GEyNCWFFkfLHO8wdQ8eg35BMUg==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=20"
+      }
+    },
+    "node_modules/yoga-layout": {
+      "version": "3.2.1",
+      "resolved": "https://registry.npmjs.org/yoga-layout/-/yoga-layout-3.2.1.tgz",
+      "integrity": "sha512-0LPOt3AxKqMdFBZA3HBAt/t/8vIKq7VaQYbuA8WxCgung+p9TVyKRYdpvCb80HcdTN2NkbIKbhNwKUfm3tQywQ==",
+      "license": "MIT"
     },
     "node_modules/zod": {
       "version": "3.25.76",

--- a/src/cli/commands/__tests__/auto-contribute.test.ts
+++ b/src/cli/commands/__tests__/auto-contribute.test.ts
@@ -148,6 +148,6 @@ describe('Config schema validation', () => {
     }
 
     // settings is optional
-    expect(config.settings).toBeUndefined()
+    expect('settings' in config).toBe(false)
   })
 })

--- a/src/cli/commands/review.ts
+++ b/src/cli/commands/review.ts
@@ -122,12 +122,13 @@ Respond ONLY with valid JSON. No markdown code blocks, no text outside the JSON 
   const spinner = ora({ prefixText: '  ', text: 'Analyzing code...' }).start()
 
   let response: { text: string; latency_ms: number } | undefined
-  let result: ReviewResult
+  let result: ReviewResult | undefined
 
   try {
-    response = await callModel(modelConfig!, prompt, {
-      maxTokens: opts.maxTokens || 2000,
-    })
+    response = await callModel({
+      ...modelConfig!,
+      max_tokens: opts.maxTokens || modelConfig!.max_tokens || 2000,
+    }, prompt)
 
     spinner.succeed(`Review complete (${response.latency_ms}ms)`)
 
@@ -159,6 +160,10 @@ Respond ONLY with valid JSON. No markdown code blocks, no text outside the JSON 
     process.exit(1)
   }
 
+  if (!result) {
+    throw new Error('Review failed: missing parsed result')
+  }
+
   // Output
   if (opts.json) {
     console.log(JSON.stringify(result, null, 2))
@@ -179,7 +184,7 @@ Respond ONLY with valid JSON. No markdown code blocks, no text outside the JSON 
     for (const bug of result.bugs) {
       const sevColorFn = {
         critical: chalk.red,
-        high: chalk.orange,
+        high: chalk.hex('#f97316'),
         medium: chalk.yellow,
         low: chalk.dim,
       }[bug.severity as string] ?? chalk.dim

--- a/src/cli/commands/run.ts
+++ b/src/cli/commands/run.ts
@@ -21,7 +21,7 @@ interface RunOptions {
   dryRun?: boolean
   resume?: boolean
   question?: string
-  noStore?: boolean
+  store?: boolean
   category?: string[]
   json?: boolean
   failIfRegression?: boolean
@@ -232,7 +232,7 @@ export async function runCommand(opts: RunOptions): Promise<void> {
   fs.writeFileSync(`${base}.json`, JSON.stringify(result, null, 2))
 
   // Persist to SQLite unless --no-store
-  if (!opts.noStore) {
+  if (opts.store !== false) {
     try {
       const { getDb, initSchema, saveRunResult } = await import('../../db/client.js')
       const db = getDb()
@@ -271,8 +271,9 @@ export async function runCommand(opts: RunOptions): Promise<void> {
   }
   log(chalk.dim(`  raw:    ${base}.json`))
 
-  // Auto-contribute if enabled and run succeeded
-  if (config.settings?.auto_contribute && result.models.length > 0) {
+  // Auto-contribute if enabled and run succeeded. Respect --no-store as a
+  // side-effect-free mode for disposable/CI runs.
+  if (opts.store !== false && config.settings?.auto_contribute && result.models.length > 0) {
     await tryAutoContribute(`${base}.json`, config, log)
   }
 

--- a/src/cli/index.ts
+++ b/src/cli/index.ts
@@ -214,7 +214,7 @@ program
 program
   .command('report')
   .description('Generate detailed HTML report from a result file')
-  .option('--result <path>', 'Path to result JSON file', { required: true })
+  .requiredOption('--result <path>', 'Path to result JSON file')
   .option('--output <path>', 'Output HTML file path (default: docs/runs/<run_id>.html)')
   .action((opts: any) => reportCommand({ result: opts.result, output: opts.output }))
 const evalCmd = program

--- a/src/core/__tests__/runner.test.ts
+++ b/src/core/__tests__/runner.test.ts
@@ -119,8 +119,8 @@ describe('runEvals', () => {
   it('runs the right number of models × cases', async () => {
     const config = makeConfig()
     const pack = makePack([
-      { id: 'case-1', prompt: 'Hello', criteria: 'Be polite', scorer: 'llm', tags: [], judge_type: 'llm', max_tokens: undefined },
-      { id: 'case-2', prompt: 'World', criteria: 'Be concise', scorer: 'llm', tags: [], judge_type: 'llm', max_tokens: undefined },
+      { id: 'case-1', prompt: 'Hello', criteria: 'Be polite', scorer: 'llm', tags: [], judge_type: 'llm', judge_style: 'standard', max_tokens: undefined },
+      { id: 'case-2', prompt: 'World', criteria: 'Be concise', scorer: 'llm', tags: [], judge_type: 'llm', judge_style: 'standard', max_tokens: undefined },
     ])
 
     vi.mocked(callModel)
@@ -143,7 +143,7 @@ describe('runEvals', () => {
   it('uses scoreDeterministic when scorer != llm', async () => {
     const config = makeConfig()
     const pack = makePack([
-      { id: 'exact-case', prompt: 'What is 2+2?', criteria: 'Exact match', scorer: 'exact', expected: '4', tags: [], judge_type: 'llm', max_tokens: undefined },
+      { id: 'exact-case', prompt: 'What is 2+2?', criteria: 'Exact match', scorer: 'exact', expected: '4', tags: [], judge_type: 'llm', judge_style: 'standard', max_tokens: undefined },
     ])
 
     vi.mocked(callModel)
@@ -162,7 +162,7 @@ describe('runEvals', () => {
   it('returns RunResult with expected shape', async () => {
     const config = makeConfig()
     const pack = makePack([
-      { id: 'shape-case', prompt: 'Test', criteria: 'Test criteria', scorer: 'llm', tags: [], judge_type: 'llm', max_tokens: undefined },
+      { id: 'shape-case', prompt: 'Test', criteria: 'Test criteria', scorer: 'llm', tags: [], judge_type: 'llm', judge_style: 'standard', max_tokens: undefined },
     ])
 
     vi.mocked(callModel).mockResolvedValue(makeModelResponse('model-a'))
@@ -204,9 +204,9 @@ describe('runEvals', () => {
   it('filters cases by categoryFilter', async () => {
     const config = makeConfig()
     const pack = makePack([
-      { id: 'code-case', prompt: 'Write code', criteria: 'Works', category: 'coding', scorer: 'llm', tags: [], judge_type: 'llm', max_tokens: undefined },
-      { id: 'math-case', prompt: 'Solve 2+2', criteria: 'Correct', category: 'math', scorer: 'llm', tags: [], judge_type: 'llm', max_tokens: undefined },
-      { id: 'writing-case', prompt: 'Write essay', criteria: 'Good', category: 'writing', scorer: 'llm', tags: [], judge_type: 'llm', max_tokens: undefined },
+      { id: 'code-case', prompt: 'Write code', criteria: 'Works', category: 'coding', scorer: 'llm', tags: [], judge_type: 'llm', judge_style: 'standard', max_tokens: undefined },
+      { id: 'math-case', prompt: 'Solve 2+2', criteria: 'Correct', category: 'math', scorer: 'llm', tags: [], judge_type: 'llm', judge_style: 'standard', max_tokens: undefined },
+      { id: 'writing-case', prompt: 'Write essay', criteria: 'Good', category: 'writing', scorer: 'llm', tags: [], judge_type: 'llm', judge_style: 'standard', max_tokens: undefined },
     ])
 
     vi.mocked(callModel).mockResolvedValue(makeModelResponse('model-a'))
@@ -224,9 +224,9 @@ describe('runEvals', () => {
   it('filters multiple categories', async () => {
     const config = makeConfig()
     const pack = makePack([
-      { id: 'code-case', prompt: 'Write code', criteria: 'Works', category: 'coding', scorer: 'llm', tags: [], judge_type: 'llm', max_tokens: undefined },
-      { id: 'math-case', prompt: 'Solve 2+2', criteria: 'Correct', category: 'math', scorer: 'llm', tags: [], judge_type: 'llm', max_tokens: undefined },
-      { id: 'writing-case', prompt: 'Write essay', criteria: 'Good', category: 'writing', scorer: 'llm', tags: [], judge_type: 'llm', max_tokens: undefined },
+      { id: 'code-case', prompt: 'Write code', criteria: 'Works', category: 'coding', scorer: 'llm', tags: [], judge_type: 'llm', judge_style: 'standard', max_tokens: undefined },
+      { id: 'math-case', prompt: 'Solve 2+2', criteria: 'Correct', category: 'math', scorer: 'llm', tags: [], judge_type: 'llm', judge_style: 'standard', max_tokens: undefined },
+      { id: 'writing-case', prompt: 'Write essay', criteria: 'Good', category: 'writing', scorer: 'llm', tags: [], judge_type: 'llm', judge_style: 'standard', max_tokens: undefined },
     ])
 
     vi.mocked(callModel).mockResolvedValue(makeModelResponse('model-a'))
@@ -248,7 +248,7 @@ describe('runEvals', () => {
       },
     })
     const pack = makePack([
-      { id: 'case-1', prompt: 'Hello', criteria: 'Be polite', scorer: 'llm', tags: [], judge_type: 'llm', max_tokens: undefined },
+      { id: 'case-1', prompt: 'Hello', criteria: 'Be polite', scorer: 'llm', tags: [], judge_type: 'llm', judge_style: 'standard', max_tokens: undefined },
     ])
 
     await expect(runEvals(config, [pack])).rejects.toThrow("Judge model 'nonexistent-model' not found")
@@ -257,7 +257,7 @@ describe('runEvals', () => {
   it('handles model errors gracefully with zero scores', async () => {
     const config = makeConfig()
     const pack = makePack([
-      { id: 'error-case', prompt: 'Test', criteria: 'Test', scorer: 'llm', tags: [], judge_type: 'llm', max_tokens: undefined },
+      { id: 'error-case', prompt: 'Test', criteria: 'Test', scorer: 'llm', tags: [], judge_type: 'llm', judge_style: 'standard', max_tokens: undefined },
     ])
 
     vi.mocked(callModel)
@@ -278,7 +278,7 @@ describe('runEvals', () => {
   it('determines winner from highest scoring model', async () => {
     const config = makeConfig()
     const pack = makePack([
-      { id: 'winner-case', prompt: 'Test', criteria: 'Test', scorer: 'exact', expected: 'correct', tags: [], judge_type: 'llm', max_tokens: undefined },
+      { id: 'winner-case', prompt: 'Test', criteria: 'Test', scorer: 'exact', expected: 'correct', tags: [], judge_type: 'llm', judge_style: 'standard', max_tokens: undefined },
     ])
 
     vi.mocked(callModel)
@@ -293,8 +293,8 @@ describe('runEvals', () => {
   it('computes averages in summary correctly', async () => {
     const config = makeConfig()
     const pack = makePack([
-      { id: 'avg-1', prompt: 'Test 1', criteria: 'Test', scorer: 'llm', tags: [], judge_type: 'llm', max_tokens: undefined },
-      { id: 'avg-2', prompt: 'Test 2', criteria: 'Test', scorer: 'llm', tags: [], judge_type: 'llm', max_tokens: undefined },
+      { id: 'avg-1', prompt: 'Test 1', criteria: 'Test', scorer: 'llm', tags: [], judge_type: 'llm', judge_style: 'standard', max_tokens: undefined },
+      { id: 'avg-2', prompt: 'Test 2', criteria: 'Test', scorer: 'llm', tags: [], judge_type: 'llm', judge_style: 'standard', max_tokens: undefined },
     ])
 
     vi.mocked(callModel).mockResolvedValue(makeModelResponse('model-a'))
@@ -319,7 +319,7 @@ describe('runEvals', () => {
       {
         id: 'tool-case', prompt: 'What is the weather?', criteria: 'Uses tool',
         scorer: 'tool_call', tools, expected_tool: 'get_weather',
-        tags: [], judge_type: 'llm', max_tokens: undefined,
+        tags: [], judge_type: 'llm', judge_style: 'standard', max_tokens: undefined,
       },
     ])
 
@@ -346,7 +346,7 @@ describe('runEvals', () => {
           { role: 'assistant', content: '__model__' },
           { role: 'user', content: 'How are you?' },
         ],
-        tags: [], judge_type: 'llm', max_tokens: undefined,
+        tags: [], judge_type: 'llm', judge_style: 'standard', max_tokens: undefined,
       },
     ])
 

--- a/src/core/preload.ts
+++ b/src/core/preload.ts
@@ -2,6 +2,8 @@ import type { ModelConfig } from '../types/index.js'
 import { callModel } from '../providers/compat.js'
 import chalk from 'chalk'
 
+const progress = (...args: unknown[]) => console.error(...args)
+
 export interface PreloadResult {
   model: string
   success: boolean
@@ -30,10 +32,7 @@ export async function preloadModel(
   try {
     // Make tiny call to load model into memory
     // Using "1+1=?" as minimal prompt (4 tokens)
-    await callModel(model, [{
-      role: 'user',
-      content: '1+1=?'
-    }])
+    await callModel(model, '1+1=?')
     
     const duration = Date.now() - start
     return {
@@ -64,13 +63,13 @@ export async function preloadModels(
   
   if (modelsToLoad.length === 0) {
     if (verbose) {
-      console.log(chalk.dim('  No models need pre-loading'))
+      progress(chalk.dim('  No models need pre-loading'))
     }
     return []
   }
 
-  console.log()
-  console.log(chalk.bold('Pre-loading models...'))
+  progress()
+  progress(chalk.bold('Pre-loading models...'))
   
   const results: PreloadResult[] = []
   
@@ -81,9 +80,9 @@ export async function preloadModels(
     
     if (result.success) {
       const timeStr = (result.duration / 1000).toFixed(1) + 's'
-      console.log(chalk.green('  ✓'), model.id, chalk.dim(`(${timeStr})`))
+      progress(chalk.green('  ✓'), model.id, chalk.dim(`(${timeStr})`))
     } else {
-      console.log(chalk.red('  ✗'), model.id, chalk.dim(`- ${result.error}`))
+      progress(chalk.red('  ✗'), model.id, chalk.dim(`- ${result.error}`))
     }
   }
   
@@ -91,12 +90,12 @@ export async function preloadModels(
   const successful = results.filter(r => r.success).length
   const totalTime = results.reduce((sum, r) => sum + r.duration, 0) / 1000
   
-  console.log()
+  progress()
   if (successful === results.length) {
-    console.log(chalk.green(`All models ready`) + chalk.dim(` (${totalTime.toFixed(1)}s total)`))
+    progress(chalk.green(`All models ready`) + chalk.dim(` (${totalTime.toFixed(1)}s total)`))
   } else {
     const failed = results.length - successful
-    console.log(chalk.yellow(`${successful}/${results.length} models ready`) + chalk.dim(` (${failed} failed)`))
+    progress(chalk.yellow(`${successful}/${results.length} models ready`) + chalk.dim(` (${failed} failed)`))
     
     // Check if any critical failures
     const criticalErrors = results.filter(r => !r.success && (
@@ -106,18 +105,18 @@ export async function preloadModels(
     ))
     
     if (criticalErrors.length > 0) {
-      console.log()
-      console.log(chalk.red('Critical errors:'))
+      progress()
+      progress(chalk.red('Critical errors:'))
       for (const err of criticalErrors) {
-        console.log(chalk.red('  •'), err.model + ':', err.error)
+        progress(chalk.red('  •'), err.model + ':', err.error)
       }
-      console.log()
-      console.log(chalk.yellow('Fix these issues before running evals.'))
-      console.log()
+      progress()
+      progress(chalk.yellow('Fix these issues before running evals.'))
+      progress()
       process.exit(1)
     }
   }
   
-  console.log()
+  progress()
   return results
 }

--- a/src/providers/openclaw.ts
+++ b/src/providers/openclaw.ts
@@ -67,7 +67,9 @@ export async function callOpenClaw(
     return {
       text,
       latency_ms: latency,
-      model: config.model,
+      model_id: config.id,
+      input_tokens: data.usage?.prompt_tokens ?? 0,
+      output_tokens: data.usage?.completion_tokens ?? 0,
       cost_usd: calculateCost(data.usage, config.model),
       metadata: {
         provider: 'openclaw',

--- a/src/providers/subagent.ts
+++ b/src/providers/subagent.ts
@@ -53,7 +53,9 @@ export async function callSubAgent(
     return {
       text: result.message,
       latency_ms: latency,
-      model: config.model,
+      model_id: config.id,
+      input_tokens: 0,
+      output_tokens: 0,
       metadata: {
         provider: 'subagent',
         session_key: spawnResult.childSessionKey,

--- a/src/reporter/__tests__/markdown.test.ts
+++ b/src/reporter/__tests__/markdown.test.ts
@@ -99,6 +99,8 @@ describe('generateMarkdownReport', () => {
         {
           case_id: 'test-case-1',
           prompt: 'What is 2+2?',
+          criteria: 'Answer correctly.',
+          responses: {},
           scores: {
             'model-a': { accuracy: 10, completeness: 10, conciseness: 10, total: 10, reasoning: 'Correct.' },
           },

--- a/src/tui/components/Clickable.tsx
+++ b/src/tui/components/Clickable.tsx
@@ -27,11 +27,7 @@ export function Clickable({ children, onClick, onWheelUp, onWheelDown }: Clickab
   const ref = useRef<DOMElement>(null)
   useOnClick(ref, onClick ?? null)
   useOnWheel(ref, (event) => {
-    // xterm-mouse uses negative deltaY for up, positive for down (scroll down)
-    // The library exposes `.direction` in MouseEvent — fall back to raw button
-    // codes 64 (up) / 65 (down) from SGR mouse protocol.
-    const anyEvent = event as InkMouseEvent & { button?: number; direction?: 'up' | 'down' }
-    const dir = anyEvent.direction ?? (anyEvent.button === 64 ? 'up' : 'down')
+    const dir = event.button === 'wheel-up' ? 'up' : 'down'
     if (dir === 'up') onWheelUp?.()
     else onWheelDown?.()
   })

--- a/src/types/index.ts
+++ b/src/types/index.ts
@@ -28,6 +28,7 @@ export const ModelConfigSchema = z.object({
   cost_per_1m_output: z.number().optional(),
   timeout_ms: z.number().default(120_000),
   max_tokens: z.number().default(1024),
+  temperature: z.number().optional(),
 })
 export type ModelConfig = z.infer<typeof ModelConfigSchema>
 
@@ -124,7 +125,7 @@ export const EvalCaseSchema = z.object({
   context: z.string().optional(),    // Used by faithfulness scorer (RAG source context)
   prompt: z.string().default(''),
   system_prompt: z.string().optional(),
-  criteria: z.string(),
+  criteria: z.string().default(''),
   expected: z.union([z.string(), z.array(z.string())]).optional(),
   tags: z.array(z.string()).default([]),
   // scorer: 'llm' uses LLM judge (default), 'json' parses output as JSON (pass/fail),
@@ -157,6 +158,14 @@ export const EvalCaseSchema = z.object({
   // cot_choices: letter-to-score mapping for cot_classify, e.g. [{letter: "A", score: 0}, ...]
   // Defaults to [A=0, B=2, C=5, D=8, E=10] if not specified
   cot_choices: z.array(CotChoiceSchema).optional(),
+}).superRefine((evalCase, ctx) => {
+  if (evalCase.scorer === 'llm' && evalCase.criteria.trim() === '') {
+    ctx.addIssue({
+      code: z.ZodIssueCode.custom,
+      path: ['criteria'],
+      message: 'Required for llm scorer',
+    })
+  }
 })
 export type EvalCase = z.infer<typeof EvalCaseSchema>
 
@@ -184,6 +193,7 @@ export interface ModelResponse {
   cost_usd?: number
   error?: string
   tool_calls?: ToolCallResult[]
+  metadata?: Record<string, unknown>
 }
 
 export interface JudgeScore {


### PR DESCRIPTION
## Summary

This PR fixes the CLI/eval path issues found while running Verdict locally on the 256GB machine, then rebases the patch onto current `main` and fixes the extra clean-install gates exposed there.

Changes:
- fix Commander usage for `report --result` by using `requiredOption`
- align OpenClaw/subagent provider return objects with `ModelResponse`
- add `temperature` to model config schema
- fix preload to call models with a string prompt
- allow deterministic eval cases to omit `criteria`, while still requiring `criteria` for the default `llm` scorer
- move preload progress to stderr so `--json` stdout stays machine-parseable
- fix `--no-store` handling (`store: false` in Commander)
- make `--no-store` skip persistence side effects, including auto-contribute
- update stale tests for current `EvalCase` and `CaseResult` shapes
- sync `package-lock.json` with current `package.json` so `npm ci` works
- fix current-main typecheck failures in `review.ts` and TUI `Clickable` wheel handling

## Verification

From a clean worktree on current `main` plus this PR branch:
- `rm -rf node_modules && npm ci --no-audit --no-fund`
- `npm run typecheck`
- `npm test` - 21 files, 365 tests passing
- `npm run build`
- clean JSON smoke run with `llama3.3:70b` + `qwen2.5:32b`
- verified `--no-store` emits no `stored:`, `auto-contributing`, or GitHub-token side-effect lines

Earlier local heavy run result:
- `qwen2.5:32b`: 7.73 avg, 8.7s avg latency
- `llama3.3:70b`: 7.67 avg, 11.9s avg latency

Note: the original local working tree had unrelated pre-existing local changes (`autoresearch.sh`, `verdict.yaml`, and several untracked files). This PR branch was rebuilt from `origin/main`; only the PR patch is included.
