### PR TITLE
feat(npm): publish as @hnshah/verdict (0.4.0)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,26 @@
 # Changelog
 
+## 0.4.0 (2026-05-19)
+
+### Renamed: now published as `@hnshah/verdict`
+
+The unscoped `verdict` name on npm belongs to a different package
+(an unrelated rules engine). To make `npm install -g verdict` actually
+install **this** Verdict, we've moved to a scoped name.
+
+**Install:**
+```bash
+npm install -g @hnshah/verdict
+```
+
+The CLI binary stays `verdict` — only the package name has changed.
+
+All install snippets, `npx` examples, and programmatic-API import
+paths in the docs (`README.md`, `FAQ.md`, `action.yml`, etc.) have
+been updated to the scoped form.
+
+---
+
 ## 0.3.0 (2026-04-15)
 
 ### `verdict tui` — the full interactive terminal UI

--- a/FAQ.md
+++ b/FAQ.md
@@ -63,8 +63,8 @@ API keys are only needed if you want to test cloud models (OpenAI, Anthropic, et
 **Yes!** Use `npx`:
 
 ```bash
-npx verdict init
-npx verdict run
+npx @hnshah/verdict init
+npx @hnshah/verdict run
 ```
 
 No global install needed. npx downloads and runs Verdict temporarily.
@@ -89,17 +89,17 @@ No global install needed. npx downloads and runs Verdict temporarily.
 
 **Option 1: Global install (recommended)**
 ```bash
-npm install -g verdict
+npm install -g @hnshah/verdict
 ```
 
 **Option 2: npx (no install)**
 ```bash
-npx verdict init
+npx @hnshah/verdict init
 ```
 
 **Option 3: Project dependency**
 ```bash
-npm install verdict
+npm install @hnshah/verdict
 ```
 
 ---
@@ -845,7 +845,7 @@ verdict baseline compare before-finetuning
 **Yes! Use the programmatic API:**
 
 ```typescript
-import { VerdictRunner, VerdictRouter } from 'verdict';
+import { VerdictRunner, VerdictRouter } from '@hnshah/verdict';
 
 // Run evals
 const runner = new VerdictRunner('./verdict.yaml');
@@ -1031,7 +1031,7 @@ settings:
 **Fix:**
 ```bash
 # Option 1: Use npx
-npx verdict init
+npx @hnshah/verdict init
 
 # Option 2: Fix PATH
 echo 'export PATH="$PATH:$(npm config get prefix)/bin"' >> ~/.zshrc

--- a/README.md
+++ b/README.md
@@ -47,9 +47,9 @@ You're choosing between models based on:
 ### Install
 
 ```bash
-npm install -g verdict
+npm install -g @hnshah/verdict
 # or
-npx verdict init
+npx @hnshah/verdict init
 ```
 
 ### Initialize

--- a/ROADMAP.md
+++ b/ROADMAP.md
@@ -213,7 +213,7 @@ Results, dashboards, skipped-model reasons, and regressions should be tracked co
 
 ### MT-4: Export a programmatic API
 
-**Problem:** verdict is CLI-only. No `import { runEvals } from 'verdict'`. Can't be used as a library in CI scripts, custom tools, or other frameworks.
+**Problem:** verdict is CLI-only. No `import { runEvals } from '@hnshah/verdict'`. Can't be used as a library in CI scripts, custom tools, or other frameworks.
 
 **Action:**
 - Add `src/index.ts` that exports: `runEvals`, `loadConfig`, `loadEvalPack`, `judgeResponse`, `scoreDeterministic`, `VerdictRouter`
@@ -337,7 +337,7 @@ promptfoo has `promptfoo view` which launches a full React app.
 > Users need custom scoring logic (e.g., "check that the output is valid Python by running `python -c`"). Add a `javascript` scorer that accepts a file path or inline function: `scorer: javascript`, `scoreFn: "file://score.js"`.
 
 **Issue #9: "Export programmatic API (library mode)"**
-> Verdict is CLI-only. There's no way to `import { runEvals } from 'verdict'`. Add an `src/index.ts` entry point exporting core functions and update `package.json` exports.
+> Verdict is CLI-only. There's no way to `import { runEvals } from '@hnshah/verdict'`. Add an `src/index.ts` entry point exporting core functions and update `package.json` exports.
 
 ### Medium Priority
 
@@ -444,7 +444,7 @@ promptfoo has `promptfoo view` which launches a full React app.
 - **Task-custom eval design** — write your own eval cases for your specific use case vs. fixed academic benchmarks
 - **Real-world model comparison** — focuses on practical "which model for my workload" vs. academic leaderboard scores
 - **Conversational eval** — multi-turn and tool-calling support. lm-eval is single-turn completion oriented
-- **Lightweight** — `npm install -g verdict` vs. complex Python environment setup with optional extras
+- **Lightweight** — `npm install -g @hnshah/verdict` vs. complex Python environment setup with optional extras
 
 ### Scorer Comparison Table
 

--- a/WORKFLOW.md
+++ b/WORKFLOW.md
@@ -101,13 +101,13 @@ cases:
 cd /path/to/verdict
 
 # Run specific eval pack
-npx verdict run --eval-pack eval-packs/my-test.yaml
+npx @hnshah/verdict run --eval-pack eval-packs/my-test.yaml
 
 # Run with specific models
-npx verdict run --eval-pack eval-packs/my-test.yaml --models ollama:phi4,ollama:qwen2.5:7b
+npx @hnshah/verdict run --eval-pack eval-packs/my-test.yaml --models ollama:phi4,ollama:qwen2.5:7b
 
 # Run all eval packs
-npx verdict run --all
+npx @hnshah/verdict run --all
 ```
 
 ### 3. Results Saved to `results/`
@@ -482,7 +482,7 @@ Fix issues, then rebuild.
 
 ### Run Eval
 ```bash
-npx verdict run --eval-pack eval-packs/my-test.yaml
+npx @hnshah/verdict run --eval-pack eval-packs/my-test.yaml
 ```
 
 ### Add to Dashboard

--- a/action.yml
+++ b/action.yml
@@ -94,7 +94,7 @@ runs:
 
     - name: Install Verdict
       shell: bash
-      run: npm install -g verdict@${{ inputs.verdict-version }}
+      run: npm install -g @hnshah/verdict@${{ inputs.verdict-version }}
 
     - name: Run Verdict Evals
       id: run-verdict

--- a/docs/getting-started.md
+++ b/docs/getting-started.md
@@ -8,13 +8,13 @@
 ## Install
 
 ```bash
-npm install -g verdict
+npm install -g @hnshah/verdict
 ```
 
 Or run without installing:
 
 ```bash
-npx verdict init
+npx @hnshah/verdict init
 ```
 
 ## Your first eval run

--- a/docs/programmatic-api.md
+++ b/docs/programmatic-api.md
@@ -5,13 +5,13 @@ Use Verdict as a library in your own scripts, CI pipelines, or custom tools.
 ## Installation
 
 ```bash
-npm install verdict
+npm install @hnshah/verdict
 ```
 
 ## Quick Start
 
 ```ts
-import { loadConfig, loadEvalPack, runEvals } from 'verdict'
+import { loadConfig, loadEvalPack, runEvals } from '@hnshah/verdict'
 import path from 'path'
 
 const config = loadConfig('./verdict.config.yaml')
@@ -33,7 +33,7 @@ for (const [modelId, summary] of Object.entries(result.summary)) {
 Load and validate a Verdict YAML config file. Resolves environment variables and provider shortcuts.
 
 ```ts
-import { loadConfig } from 'verdict'
+import { loadConfig } from '@hnshah/verdict'
 
 const config = loadConfig('./verdict.config.yaml')
 ```
@@ -45,7 +45,7 @@ Throws if the file is missing or the config is invalid.
 Load and validate a YAML eval pack. `configDir` is used to resolve relative pack paths.
 
 ```ts
-import { loadEvalPack } from 'verdict'
+import { loadEvalPack } from '@hnshah/verdict'
 
 const pack = loadEvalPack('./eval-packs/general.yaml', process.cwd())
 ```
@@ -55,7 +55,7 @@ const pack = loadEvalPack('./eval-packs/general.yaml', process.cwd())
 Run evaluations across all models and eval packs.
 
 ```ts
-import { loadConfig, loadEvalPack, runEvals } from 'verdict'
+import { loadConfig, loadEvalPack, runEvals } from '@hnshah/verdict'
 
 const config = loadConfig('./verdict.config.yaml')
 const packs = config.packs.map(p => loadEvalPack(p, '.'))
@@ -83,7 +83,7 @@ const result = await runEvals(
 Score a single response using an LLM judge.
 
 ```ts
-import { judgeResponse } from 'verdict'
+import { judgeResponse } from '@hnshah/verdict'
 
 const score = await judgeResponse(
   judgeModel,   // ModelConfig for the judge
@@ -101,7 +101,7 @@ console.log(`Score: ${score.total}/10 — ${score.reasoning}`)
 Score a response using deterministic (non-LLM) scorers.
 
 ```ts
-import { scoreDeterministic } from 'verdict'
+import { scoreDeterministic } from '@hnshah/verdict'
 
 // Exact match
 scoreDeterministic('exact', 'Paris', 'Paris')       // { total: 10, ... }
@@ -131,7 +131,7 @@ Returns `null` for unknown scorer types.
 Route prompts to the best model based on eval history.
 
 ```ts
-import { VerdictRouter } from 'verdict'
+import { VerdictRouter } from '@hnshah/verdict'
 
 const router = new VerdictRouter('./verdict-router.db')
 const { classification, choice } = await router.route('Explain quantum computing')
@@ -158,5 +158,5 @@ import type {
   CaseResult,
   ModelSummary,
   EvalResult,
-} from 'verdict'
+} from '@hnshah/verdict'
 ```

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
-  "name": "verdict",
-  "version": "0.3.0",
+  "name": "@hnshah/verdict",
+  "version": "0.4.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
-      "name": "verdict",
-      "version": "0.3.0",
+      "name": "@hnshah/verdict",
+      "version": "0.4.0",
       "license": "MIT",
       "dependencies": {
         "@ink-tools/ink-mouse": "^2.1.0",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
-  "name": "verdict",
-  "version": "0.3.0",
+  "name": "@hnshah/verdict",
+  "version": "0.4.0",
   "description": "LLM eval framework. Benchmark local and cloud models with one config file.",
   "type": "module",
   "main": "./dist/index.js",
@@ -73,6 +73,9 @@
     "local-ai"
   ],
   "license": "MIT",
+  "publishConfig": {
+    "access": "public"
+  },
   "repository": {
     "type": "git",
     "url": "git+https://github.com/hnshah/verdict.git"

--- a/skills/openclaw/SKILL.md
+++ b/skills/openclaw/SKILL.md
@@ -14,7 +14,7 @@ corpus_score_projected: "98% (245/250)"
 ## Architecture (Key Facts)
 
 - **Language/Stack:** TypeScript (ESM), Node 18+, built with tsup. ~9,700 LOC across 53 files.
-- **Dual entry:** CLI (`verdict run|init|models|history|route|serve|validate|compare|baseline|daemon|watch`) and programmatic library (`import { runEvals, loadConfig } from 'verdict'`).
+- **Dual entry:** CLI (`verdict run|init|models|history|route|serve|validate|compare|baseline|daemon|watch`) and programmatic library (`import { runEvals, loadConfig } from '@hnshah/verdict'`).
 - **Single provider path:** ALL model providers use OpenAI-compatible HTTP (`POST /v1/chat/completions`) via `src/providers/compat.ts`. No per-provider adapters. Supports Ollama, MLX, LM Studio, OpenRouter, Groq, OpenAI, etc.
 - **Config:** `verdict.yaml` (Zod-validated) defines models, judge, packs, run settings, output formats. Supports `${ENV_VAR:-default}` interpolation.
   - ⚠️ `${UNSET_VAR}` (without `:-default` suffix) resolves to empty string `""` before Zod validation. For `api_key` this becomes `""` which passes string validation but fails at the provider. Always use `${VAR:-default}` syntax for fallbacks.

--- a/skills/verdict-autonomous/SKILL.md
+++ b/skills/verdict-autonomous/SKILL.md
@@ -10,7 +10,7 @@ Run verdict evals on a schedule, detect regressions, and post results to Slack.
 
 ## Setup
 
-1. Install verdict: `npm install -g verdict`
+1. Install verdict: `npm install -g @hnshah/verdict`
 2. Create config: `verdict init`
 3. Save a baseline: `verdict run && verdict baseline save default`
 4. Set environment variables:

--- a/src/cli/commands/run.ts
+++ b/src/cli/commands/run.ts
@@ -297,7 +297,7 @@ export async function runCommand(opts: RunOptions): Promise<void> {
     ping({
       models_count: result.models.length,
       packs_count: packs.length,
-      verdict_version: '0.3.0',
+      verdict_version: '0.4.0',
     })
   } catch { /* never let telemetry affect the user */ }
 

--- a/src/cli/index.ts
+++ b/src/cli/index.ts
@@ -34,7 +34,7 @@ const program = new Command()
 program
   .name('verdict')
   .description(chalk.bold('verdict') + '\nLLM eval framework. Benchmark local and cloud models with one config file.')
-  .version('0.3.0')
+  .version('0.4.0')
 
 program
   .command('tui')
@@ -319,7 +319,7 @@ program
 // custom multi-page dashboard system in dashboard/build/
 //
 // To update the dashboard:
-//   1. Run evals: npx verdict run --eval-pack eval-packs/my-test.yaml
+//   1. Run evals: verdict run --eval-pack eval-packs/my-test.yaml
 //   2. Add to dashboard: ./quick-add-run.sh results/LATEST.json
 //
 // See WORKFLOW.md for complete documentation

--- a/src/core/runner.ts
+++ b/src/core/runner.ts
@@ -15,7 +15,7 @@ import { preloadModels } from './preload.js'
  * Detect environment information
  */
 function detectEnvironment(): { verdict_version: string, node_version: string, provider_versions: { ollama?: string, mlx?: string } } {
-  const verdictVersion = '0.3.0' // TODO: Read from package.json
+  const verdictVersion = '0.4.0' // TODO: Read from package.json
   const nodeVersion = process.version
   
   const providerVersions: { ollama?: string, mlx?: string } = {}

--- a/src/index.ts
+++ b/src/index.ts
@@ -5,7 +5,7 @@
  *
  * @example
  * ```ts
- * import { runEvals, loadEvalPacks, type Config } from 'verdict'
+ * import { runEvals, loadEvalPacks, type Config } from '@hnshah/verdict'
  *
  * const config: Config = {
  *   name: 'My Evals',

--- a/tsup.config.ts
+++ b/tsup.config.ts
@@ -18,7 +18,7 @@ export default defineConfig([
       js: '#!/usr/bin/env node',
     },
   },
-  // Library bundle — programmatic API for `import { runEvals } from 'verdict'`
+  // Library bundle — programmatic API for `import { runEvals } from '@hnshah/verdict'`
   {
     entry: { index: 'src/index.ts' },
     format: ['esm'],

--- a/workflows/01-quick-start.md
+++ b/workflows/01-quick-start.md
@@ -5,7 +5,7 @@ Get up and running with Verdict in 5 minutes.
 ## Step 1: Install
 
 ```bash
-npm install -g verdict
+npm install -g @hnshah/verdict
 ```
 
 ## Step 2: Initialize

--- a/workflows/03-regression-testing.md
+++ b/workflows/03-regression-testing.md
@@ -178,7 +178,7 @@ jobs:
           ollama pull qwen2.5:7b
       
       - name: Install Verdict
-        run: npm install -g verdict
+        run: npm install -g @hnshah/verdict
       
       - name: Run Evals
         run: verdict run --packs production-scenarios


### PR DESCRIPTION
## Why

The unscoped `verdict` name on npm belongs to a different package (an unrelated rules engine), so `npm install -g verdict` from the README does **not** install this Verdict — it installs that other package. Every install claim in our docs is currently false.

This PR moves to a scoped name so the README claim is actually true: `npm install -g @hnshah/verdict`.

## What

- `package.json`: `name → @hnshah/verdict`, `version → 0.4.0`, add `publishConfig.access = public` so scoped publish defaults right
- Update every install / `npx` / programmatic-import snippet across `README.md`, `FAQ.md`, `action.yml`, `ROADMAP.md`, `WORKFLOW.md`, `docs/getting-started.md`, `docs/programmatic-api.md`, `workflows/*`, `skills/*/SKILL.md`, `src/cli/index.ts`, `src/index.ts`, `tsup.config.ts` to the scoped form
- Bump the hardcoded version strings in `src/cli/index.ts`, `src/cli/commands/run.ts`, `src/core/runner.ts` to `0.4.0`
- `CHANGELOG.md`: 0.4.0 entry explaining the rename
- **CLI binary stays `verdict`** — only the package name has changed. Users still type `verdict <cmd>` after install.

## After merge

1. `npm login` (account that owns `@hnshah`)
2. `npm publish` — `publishConfig.access = public` handles the scoped-default-private flag for us
3. README's `npm install -g @hnshah/verdict` becomes a true statement

## Strategy context

`.context/strategy/roadmap.md` Phase 5 bet **B1** — the BLOCKING fix for distribution credibility.

## Test plan

- [ ] CI green (typecheck + tests + build)
- [ ] Manual: `npm pack` to verify the tarball name is `hnshah-verdict-0.4.0.tgz`