### PR TITLE
feat(run): per-run reproducibility receipts (B6)

### DIFF
--- a/src/cli/commands/run.ts
+++ b/src/cli/commands/run.ts
@@ -14,6 +14,7 @@ import { setLogLevel } from '../../utils/logger.js'
 import { humanizeProviderError, formatHumanError } from '../../utils/errors.js'
 import { contributeCommand } from './contribute.js'
 import { resolveTier, listTierNames } from '../../core/tiers.js'
+import { computeReceipt, buildReproCommand } from '../../core/receipt.js'
 
 interface RunOptions {
   config: string
@@ -268,6 +269,26 @@ export async function runCommand(opts: RunOptions): Promise<void> {
   const base = path.join(config.output.dir, `${ts}-${result.run_id}`)
 
   fs.writeFileSync(`${base}.json`, JSON.stringify(result, null, 2))
+
+  // Reproducibility receipt — additive, never fails the run.
+  try {
+    const receipt = computeReceipt({
+      config,
+      packs,
+      runId: result.run_id,
+      verdictVersion: '0.4.0',
+      reproCommand: buildReproCommand(opts.config, {
+        pack: opts.pack,
+        models: opts.models,
+        tier: opts.tier,
+        category: opts.category,
+      }),
+    })
+    fs.writeFileSync(`${base}-receipt.json`, JSON.stringify(receipt, null, 2))
+    log(chalk.dim(`  receipt: ${base}-receipt.json`))
+  } catch (err) {
+    console.warn(chalk.yellow(`  warning: failed to write receipt: ${err instanceof Error ? err.message : err}`))
+  }
 
   // Persist to SQLite unless --no-store
   if (opts.noStore !== true && opts.store !== false) {

--- a/src/core/__tests__/receipt.test.ts
+++ b/src/core/__tests__/receipt.test.ts
@@ -1,0 +1,194 @@
+import { describe, it, expect } from 'vitest'
+import { computeReceipt, buildReproCommand, RECEIPT_VERSION } from '../receipt.js'
+import type { Config, EvalPack } from '../../types/index.js'
+
+function makeConfig(overrides: Partial<Config> = {}): Config {
+  return {
+    name: 'Test',
+    models: [
+      { id: 'm1', model: 'qwen2.5:7b', provider: 'ollama', base_url: 'http://localhost:11434/v1', api_key: 'none', port: 8080, tags: [], timeout_ms: 120000, max_tokens: 1024 },
+      { id: 'm2', model: 'llama3.1:8b', provider: 'ollama', base_url: 'http://localhost:11434/v1', api_key: 'none', port: 8080, tags: [], timeout_ms: 120000, max_tokens: 1024 },
+    ],
+    judge: { model: 'qwen2.5:7b', blind: true, strategy: 'single', rubric: { accuracy: 0.4, completeness: 0.4, conciseness: 0.2 } },
+    packs: ['./eval-packs/general.yaml'],
+    run: { concurrency: 3, retries: 2, cache: true },
+    output: { dir: './results', formats: ['json', 'markdown'], delta: true },
+    ...overrides,
+  } as Config
+}
+
+function makePack(name: string, cases: Array<{ id: string; prompt: string; criteria?: string }>): EvalPack {
+  return {
+    name,
+    cases: cases.map(c => ({
+      id: c.id,
+      prompt: c.prompt,
+      criteria: c.criteria ?? '',
+    })),
+  } as unknown as EvalPack
+}
+
+describe('receipt', () => {
+  describe('computeReceipt', () => {
+    it('produces a well-formed receipt with all required fields', () => {
+      const config = makeConfig()
+      const packs = [makePack('p1', [{ id: 'c1', prompt: 'hi' }])]
+      const r = computeReceipt({
+        config,
+        packs,
+        runId: 'test-run-1',
+        verdictVersion: '0.4.0',
+        reproCommand: 'verdict run',
+      })
+
+      expect(r.receipt_version).toBe(RECEIPT_VERSION)
+      expect(r.run_id).toBe('test-run-1')
+      expect(r.verdict_version).toBe('0.4.0')
+      expect(r.generated_at).toMatch(/^\d{4}-\d{2}-\d{2}T/)
+      expect(r.case_count).toBe(1)
+      expect(r.models.length).toBe(2)
+      expect(r.judge.model).toBe('qwen2.5:7b')
+      expect(r.hashes.config).toMatch(/^[0-9a-f]{12}$/)
+      expect(r.hashes.dataset).toMatch(/^[0-9a-f]{12}$/)
+      expect(r.hashes.judge).toMatch(/^[0-9a-f]{12}$/)
+      expect(r.hashes.models['m1']).toMatch(/^[0-9a-f]{12}$/)
+      expect(r.hardware.platform).toBeTruthy()
+      expect(r.hardware.cpu_count).toBeGreaterThan(0)
+      expect(r.hardware.total_memory_gb).toBeGreaterThan(0)
+    })
+
+    it('hashes are stable across identical inputs (modulo timestamp)', () => {
+      const a = computeReceipt({
+        config: makeConfig(),
+        packs: [makePack('p', [{ id: 'c1', prompt: 'hello' }])],
+        runId: 'r1',
+        verdictVersion: '0.4.0',
+        reproCommand: 'verdict run',
+      })
+      const b = computeReceipt({
+        config: makeConfig(),
+        packs: [makePack('p', [{ id: 'c1', prompt: 'hello' }])],
+        runId: 'r2', // different run id, but hashes should match
+        verdictVersion: '0.4.0',
+        reproCommand: 'verdict run',
+      })
+      expect(a.hashes.config).toBe(b.hashes.config)
+      expect(a.hashes.dataset).toBe(b.hashes.dataset)
+      expect(a.hashes.judge).toBe(b.hashes.judge)
+      expect(a.hashes.models['m1']).toBe(b.hashes.models['m1'])
+    })
+
+    it('dataset hash is stable across case-order permutations (sorted by id)', () => {
+      const a = computeReceipt({
+        config: makeConfig(),
+        packs: [makePack('p', [
+          { id: 'c1', prompt: 'hello' },
+          { id: 'c2', prompt: 'world' },
+        ])],
+        runId: 'r1',
+        verdictVersion: '0.4.0',
+        reproCommand: 'verdict run',
+      })
+      const b = computeReceipt({
+        config: makeConfig(),
+        packs: [makePack('p', [
+          { id: 'c2', prompt: 'world' },
+          { id: 'c1', prompt: 'hello' },
+        ])],
+        runId: 'r2',
+        verdictVersion: '0.4.0',
+        reproCommand: 'verdict run',
+      })
+      expect(a.hashes.dataset).toBe(b.hashes.dataset)
+    })
+
+    it('dataset hash CHANGES when a case prompt changes', () => {
+      const a = computeReceipt({
+        config: makeConfig(),
+        packs: [makePack('p', [{ id: 'c1', prompt: 'hello' }])],
+        runId: 'r1',
+        verdictVersion: '0.4.0',
+        reproCommand: 'verdict run',
+      })
+      const b = computeReceipt({
+        config: makeConfig(),
+        packs: [makePack('p', [{ id: 'c1', prompt: 'goodbye' }])],
+        runId: 'r1',
+        verdictVersion: '0.4.0',
+        reproCommand: 'verdict run',
+      })
+      expect(a.hashes.dataset).not.toBe(b.hashes.dataset)
+    })
+
+    it('model hash CHANGES when provider or base_url changes', () => {
+      const baseConfig = makeConfig()
+      const modConfig = makeConfig({
+        models: [
+          { ...baseConfig.models[0], provider: 'mlx', base_url: 'http://localhost:8080/v1' },
+          baseConfig.models[1],
+        ],
+      })
+
+      const a = computeReceipt({
+        config: baseConfig,
+        packs: [makePack('p', [{ id: 'c1', prompt: 'hello' }])],
+        runId: 'r1',
+        verdictVersion: '0.4.0',
+        reproCommand: 'verdict run',
+      })
+      const b = computeReceipt({
+        config: modConfig,
+        packs: [makePack('p', [{ id: 'c1', prompt: 'hello' }])],
+        runId: 'r1',
+        verdictVersion: '0.4.0',
+        reproCommand: 'verdict run',
+      })
+      expect(a.hashes.models['m1']).not.toBe(b.hashes.models['m1'])
+      expect(a.hashes.config).not.toBe(b.hashes.config)
+    })
+
+    it('judge hash CHANGES when rubric weights change', () => {
+      const baseConfig = makeConfig()
+      const modConfig = makeConfig({
+        judge: { ...baseConfig.judge, rubric: { accuracy: 0.6, completeness: 0.3, conciseness: 0.1 } },
+      })
+      const a = computeReceipt({
+        config: baseConfig,
+        packs: [makePack('p', [{ id: 'c1', prompt: 'hello' }])],
+        runId: 'r1',
+        verdictVersion: '0.4.0',
+        reproCommand: 'verdict run',
+      })
+      const b = computeReceipt({
+        config: modConfig,
+        packs: [makePack('p', [{ id: 'c1', prompt: 'hello' }])],
+        runId: 'r1',
+        verdictVersion: '0.4.0',
+        reproCommand: 'verdict run',
+      })
+      expect(a.hashes.judge).not.toBe(b.hashes.judge)
+    })
+  })
+
+  describe('buildReproCommand', () => {
+    it('emits a minimal command with just --config', () => {
+      expect(buildReproCommand('verdict.yaml', {})).toBe('verdict run -c verdict.yaml')
+    })
+
+    it('includes --pack when provided', () => {
+      expect(buildReproCommand('v.yaml', { pack: 'foo' })).toContain('--pack foo')
+    })
+
+    it('includes --tier when provided', () => {
+      expect(buildReproCommand('v.yaml', { tier: '24gb' })).toContain('--tier 24gb')
+    })
+
+    it('quotes --models since it can contain commas', () => {
+      expect(buildReproCommand('v.yaml', { models: 'a,b' })).toContain('--models "a,b"')
+    })
+
+    it('joins --category with spaces (commander accepts repeatable)', () => {
+      expect(buildReproCommand('v.yaml', { category: ['a', 'b'] })).toContain('--category a b')
+    })
+  })
+})

--- a/src/core/receipt.ts
+++ b/src/core/receipt.ts
@@ -1,0 +1,163 @@
+/**
+ * Reproducibility receipts.
+ *
+ * After a successful run, verdict writes a `receipt.json` next to the result
+ * JSON. The receipt is a small, hashable bundle that captures everything
+ * needed to verify or reproduce a run:
+ *   - which models (id + provider + model name + base_url + cost rates)
+ *   - which judge (model + rubric)
+ *   - which dataset (hash of all eval-pack case prompts + criteria)
+ *   - hardware (platform + arch + node + CPU + RAM)
+ *   - verdict version
+ *   - the exact `verdict run …` command that produced this result
+ *
+ * Receipts are intentionally additive — no other code paths depend on them,
+ * and an unwritable output dir is logged as a warning rather than failing
+ * the run.
+ */
+
+import crypto from 'crypto'
+import os from 'os'
+import type { Config, EvalPack } from '../types/index.js'
+
+export const RECEIPT_VERSION = 1 as const
+
+export interface ReproReceipt {
+  receipt_version: typeof RECEIPT_VERSION
+  generated_at: string                                       // ISO-8601
+  verdict_version: string
+  run_id: string
+  hashes: {
+    config: string                                           // models + judge + packs
+    dataset: string                                          // all pack cases (prompt + criteria + scorer + expected)
+    judge: string                                            // judge model + rubric
+    models: Record<string, string>                           // per-model: provider+model+base_url+cost
+  }
+  models: Array<{
+    id: string
+    model: string
+    provider?: string
+    base_url?: string
+    cost_per_1m_input?: number
+    cost_per_1m_output?: number
+  }>
+  judge: { model: string; rubric?: unknown }
+  packs: string[]
+  case_count: number
+  hardware: {
+    platform: NodeJS.Platform
+    arch: string
+    node_version: string
+    cpu_count: number
+    total_memory_gb: number
+  }
+  repro_command: string
+}
+
+/** Stable 12-char SHA-256 prefix. */
+function shortHash(value: unknown): string {
+  const json = JSON.stringify(value)
+  return crypto.createHash('sha256').update(json).digest('hex').slice(0, 12)
+}
+
+function hashModel(m: Config['models'][number]): string {
+  return shortHash({
+    provider: m.provider,
+    model: m.model,
+    base_url: m.base_url,
+    cost_per_1m_input: m.cost_per_1m_input,
+    cost_per_1m_output: m.cost_per_1m_output,
+  })
+}
+
+function hashDataset(packs: EvalPack[]): string {
+  // Sort cases by id within each pack so output is stable regardless of
+  // case ordering. Include the bits that affect *what* is measured.
+  const slim = packs.map(p => ({
+    name: p.name,
+    cases: [...p.cases]
+      .sort((a, b) => a.id.localeCompare(b.id))
+      .map(c => ({
+        id: c.id,
+        prompt: c.prompt,
+        criteria: c.criteria,
+        scorer: c.scorer,
+        expected: c.expected,
+      })),
+  }))
+  return shortHash(slim)
+}
+
+function hashJudge(judge: Config['judge']): string {
+  return shortHash({
+    model: judge.model,
+    rubric: judge.rubric,
+    strategy: judge.strategy,
+  })
+}
+
+export function buildReproCommand(
+  configPath: string,
+  options: { pack?: string; models?: string; tier?: string; category?: string[] }
+): string {
+  const parts = ['verdict', 'run', '-c', configPath]
+  if (options.pack) parts.push('--pack', options.pack)
+  if (options.tier) parts.push('--tier', options.tier)
+  if (options.models) parts.push('--models', `"${options.models}"`)
+  if (options.category && options.category.length > 0) {
+    parts.push('--category', options.category.join(' '))
+  }
+  return parts.join(' ')
+}
+
+export function computeReceipt(args: {
+  config: Config
+  packs: EvalPack[]
+  runId: string
+  verdictVersion: string
+  reproCommand: string
+}): ReproReceipt {
+  const { config, packs, runId, verdictVersion, reproCommand } = args
+
+  const totalMemoryGb = +(os.totalmem() / 1e9).toFixed(1)
+  const modelHashes: Record<string, string> = {}
+  for (const m of config.models) modelHashes[m.id] = hashModel(m)
+
+  const configHash = shortHash({
+    models: config.models.map(m => ({ id: m.id, h: modelHashes[m.id] })),
+    judge: hashJudge(config.judge),
+    packs: config.packs,
+  })
+
+  return {
+    receipt_version: RECEIPT_VERSION,
+    generated_at: new Date().toISOString(),
+    verdict_version: verdictVersion,
+    run_id: runId,
+    hashes: {
+      config: configHash,
+      dataset: hashDataset(packs),
+      judge: hashJudge(config.judge),
+      models: modelHashes,
+    },
+    models: config.models.map(m => ({
+      id: m.id,
+      model: m.model,
+      provider: m.provider,
+      base_url: m.base_url,
+      cost_per_1m_input: m.cost_per_1m_input,
+      cost_per_1m_output: m.cost_per_1m_output,
+    })),
+    judge: { model: config.judge.model, rubric: config.judge.rubric },
+    packs: config.packs,
+    case_count: packs.reduce((s, p) => s + p.cases.length, 0),
+    hardware: {
+      platform: process.platform,
+      arch: process.arch,
+      node_version: process.version,
+      cpu_count: os.cpus().length,
+      total_memory_gb: totalMemoryGb,
+    },
+    repro_command: reproCommand,
+  }
+}


### PR DESCRIPTION
## Summary

After every successful run, verdict now writes a \`<run>-receipt.json\` next to the result JSON. Closes **B6** in the Phase 5 roadmap.

## What's in a receipt

\`\`\`json
{
  \"receipt_version\": 1,
  \"generated_at\": \"2026-05-21T…\",
  \"verdict_version\": \"0.4.0\",
  \"run_id\": \"2026-05-21T04-14-47\",
  \"hashes\": {
    \"config\":  \"a1b2c3d4e5f6\",
    \"dataset\": \"f6e5d4c3b2a1\",
    \"judge\":   \"112233445566\",
    \"models\":  { \"m1\": \"…\", \"m2\": \"…\" }
  },
  \"models\":     [ { id, model, provider, base_url, cost_per_1m_… } ],
  \"judge\":      { \"model\": \"…\", \"rubric\": {…} },
  \"packs\":      [ \"./eval-packs/general.yaml\" ],
  \"case_count\": 10,
  \"hardware\":   { platform, arch, node_version, cpu_count, total_memory_gb },
  \"repro_command\": \"verdict run -c verdict.yaml --pack general --tier 24gb\"
}
\`\`\`

## Why these particular hashes

- **\`config\`** — flips when models, judge, or pack-paths change. \"Same evaluation?\"
- **\`dataset\`** — sorted-by-id SHA over every case's prompt + criteria + scorer + expected. Stable across case-order permutations, **flips** if any prompt changes by a character. \"Was the test the same?\"
- **\`judge\`** — model + rubric + strategy. \"Was the grader the same?\"
- **\`models\`** — per-model hash of provider + model name + base_url + cost rates. Lets you spot when the same id was pointed at a different backend.

## Design choices

- **Additive only.** Receipt write is in a \`try/catch\`; a failure logs a warning and the run is otherwise unaffected. No other code path depends on the receipt file.
- **No PII.** The receipt contains config + hashes + hardware specs, no prompts/responses (those are already in the result JSON).
- **Reproducible by construction.** The \`repro_command\` field is the exact CLI invocation that produced the run — copy/paste to re-run.

## Test plan

- [ ] \`npm test\` — 568 tests pass (was 557, +11 new receipt tests)
- [ ] Real run produces \`<base>-receipt.json\` alongside \`<base>.json\` and \`<base>.md\`
- [ ] Hash stability: same config + dataset → identical hashes across runs
- [ ] Hash sensitivity: changing prompt / rubric / provider → different hash

## Strategy context

\`.context/strategy/roadmap.md\` Phase 5 bet **B6** — audit-credibility for free, without becoming an enterprise product. Pairs naturally with the upcoming **B4** (\`verdict share\`): a shared snapshot will travel with its receipt so the recipient sees a fully-reproducible run.