### PR TITLE
feat(onboarding): theme A — polish, bugs, first-run flywheel

### DIFF
--- a/src/onboarding/__tests__/config-writer.test.ts
+++ b/src/onboarding/__tests__/config-writer.test.ts
@@ -126,6 +126,9 @@ describe('commitConfigWrite', () => {
     commitConfigWrite(plan, wp)
     expect(fs.existsSync(path.join(tmp, 'eval-packs', 'general.yaml'))).toBe(true)
     expect(fs.existsSync(path.join(tmp, 'eval-packs', 'moe.yaml'))).toBe(true)
+    // quantization.yaml must be scaffolded too — otherwise `verdict quants`
+    // breaks for users who came in through onboarding (A2 dogfood bug).
+    expect(fs.existsSync(path.join(tmp, 'eval-packs', 'quantization.yaml'))).toBe(true)
     expect(fs.existsSync(path.join(tmp, '.env.example'))).toBe(true)
   })
 

--- a/src/onboarding/__tests__/detect.test.ts
+++ b/src/onboarding/__tests__/detect.test.ts
@@ -141,4 +141,43 @@ packs: [./eval-packs/general.yaml]
   it('which() returns undefined for nonexistent binaries', () => {
     expect(detectMod.which('definitely-not-a-real-binary-xyz-123')).toBeUndefined()
   })
+
+  describe('classifyOllamaSource', () => {
+    it('detects Mac app install via path substring', () => {
+      // Real-world example from cold-start dogfood — symlink resolves into the
+      // app bundle. We can't easily test the realpath resolution without a
+      // matching file on disk, but the path classifier is exercised directly.
+      // Use a known-existent file for realpath to succeed.
+      const tmp = fs.mkdtempSync(path.join(os.tmpdir(), 'verdict-mac-app-'))
+      const fakeAppDir = path.join(tmp, 'Applications', 'Ollama.app', 'Contents', 'Resources')
+      fs.mkdirSync(fakeAppDir, { recursive: true })
+      const fakeBin = path.join(fakeAppDir, 'ollama')
+      fs.writeFileSync(fakeBin, '#!/bin/sh\n')
+      // The classifier looks for the substring `/Applications/Ollama.app/`
+      // anywhere in the resolved path, which our temp path doesn't satisfy.
+      // We patch realpath via vi.spyOn for this assertion instead.
+      const spy = vi.spyOn(fs, 'realpathSync').mockReturnValue('/Applications/Ollama.app/Contents/Resources/ollama')
+      expect(detectMod.classifyOllamaSource(fakeBin)).toBe('mac-app')
+      spy.mockRestore()
+      fs.rmSync(tmp, { recursive: true, force: true })
+    })
+
+    it('detects brew install (Cellar path)', () => {
+      const spy = vi.spyOn(fs, 'realpathSync').mockReturnValue('/opt/homebrew/Cellar/ollama/0.5.0/bin/ollama')
+      expect(detectMod.classifyOllamaSource('/opt/homebrew/bin/ollama')).toBe('brew')
+      spy.mockRestore()
+    })
+
+    it('detects curl install (/usr/local/bin)', () => {
+      const spy = vi.spyOn(fs, 'realpathSync').mockReturnValue('/usr/local/bin/ollama')
+      expect(detectMod.classifyOllamaSource('/usr/local/bin/ollama')).toBe('curl')
+      spy.mockRestore()
+    })
+
+    it('returns unknown when realpath fails', () => {
+      const spy = vi.spyOn(fs, 'realpathSync').mockImplementation(() => { throw new Error('dangling symlink') })
+      expect(detectMod.classifyOllamaSource('/path/to/missing')).toBe('unknown')
+      spy.mockRestore()
+    })
+  })
 })

--- a/src/onboarding/__tests__/download-engine.test.ts
+++ b/src/onboarding/__tests__/download-engine.test.ts
@@ -206,4 +206,78 @@ describe('createDownloadEngine', () => {
     await engine.start([{ modelName: 'm', provider: 'ollama' }])
     expect(logs).toContain('hello world')
   })
+
+  it('aggregate overallPercent never reports 100% while any task is still in-flight', async () => {
+    // Re-create the dogfood scenario: 3 tasks, 2 done, 1 in-flight whose
+    // last layer reported 100% before the next layer / verification fires.
+    // Old math returned 100% overall; new math caps in-flight at 99.
+    let cont: ((v: void) => void) | null = null
+    const blocker = new Promise<void>(r => { cont = r })
+
+    const adapter = (args: AdapterArgs): AsyncIterable<AdapterEvent> => ({
+      async *[Symbol.asyncIterator]() {
+        if (args.model === 'fast-a' || args.model === 'fast-b') {
+          yield { type: 'phase', phase: 'downloading' }
+          yield { type: 'layer-progress', digest: args.model, total: 10, completed: 10 }
+          yield { type: 'done' }
+          return
+        }
+        // 'slow' — start, report a layer at 100%, then HOLD before
+        // emitting verifying/writing/success.
+        yield { type: 'phase', phase: 'downloading' }
+        yield { type: 'layer-progress', digest: 'first', total: 10, completed: 10 }
+        await blocker
+        yield { type: 'done' }
+      },
+    })
+    const engine = createDownloadEngine({ adapter, concurrency: 3, progressIntervalMs: 0 })
+    const startP = engine.start([
+      { modelName: 'fast-a', provider: 'ollama' },
+      { modelName: 'fast-b', provider: 'ollama' },
+      { modelName: 'slow', provider: 'ollama' },
+    ])
+    // Wait a tick for fast tasks to finish and slow task to report 100%.
+    await new Promise(r => setTimeout(r, 20))
+    const mid = engine.snapshot()
+    expect(mid.aggregate.doneTasks).toBe(2)
+    expect(mid.aggregate.totalTasks).toBe(3)
+    // The two done tasks contribute 100 each; the in-flight 'slow' is capped
+    // at 99 even though its percent is currently 100. So overall < 100.
+    expect(mid.aggregate.overallPercent).toBeLessThan(100)
+    expect(mid.aggregate.overallPercent).toBeGreaterThanOrEqual(99)
+    cont!()
+    const summary = await startP
+    expect(summary.succeeded).toHaveLength(3)
+    // After all are done, overall is exactly 100.
+    expect(engine.snapshot().aggregate.overallPercent).toBe(100)
+  })
+
+  it('suppresses noisy `pulling <hash>` log lines (one per Ollama progress tick)', async () => {
+    const adapter = scriptedAdapter({
+      m: [
+        { type: 'phase', phase: 'manifest' },
+        { type: 'log', line: 'pulling manifest' },
+        { type: 'phase', phase: 'downloading' },
+        // These are the spammy lines Ollama emits dozens of times per layer.
+        { type: 'log', line: 'pulling dde5aa3fc5ff' },
+        { type: 'log', line: 'pulling dde5aa3fc5ff' },
+        { type: 'log', line: 'pulling dde5aa3fc5ff' },
+        { type: 'log', line: 'pulling 8934d96d3f08' },
+        // These should still come through.
+        { type: 'log', line: 'verifying sha256 digest' },
+        { type: 'log', line: 'writing manifest' },
+        { type: 'done' },
+      ],
+    })
+    const engine = createDownloadEngine({ adapter, progressIntervalMs: 0 })
+    const logs: string[] = []
+    engine.on('log', e => logs.push(e.line))
+    await engine.start([{ modelName: 'm', provider: 'ollama' }])
+    // None of the pulling-hash lines should reach subscribers.
+    expect(logs.filter(l => /^pulling [0-9a-f]{8,}$/i.test(l))).toEqual([])
+    // The semantic lines still surface.
+    expect(logs).toContain('pulling manifest')
+    expect(logs).toContain('verifying sha256 digest')
+    expect(logs).toContain('writing manifest')
+  })
 })

--- a/src/onboarding/__tests__/planner.test.ts
+++ b/src/onboarding/__tests__/planner.test.ts
@@ -1,5 +1,6 @@
 import { describe, expect, it } from 'vitest'
 import { propose, type CatalogModel } from '../planner.js'
+import { idFromModelName } from '../templates.js'
 import type { Snapshot } from '../events.js'
 
 const CATALOG: CatalogModel[] = [
@@ -64,7 +65,9 @@ describe('propose', () => {
     expect(plan.reuseModels).toContain('qwen2.5:7b')
     expect(plan.installSteps).toEqual([])
     expect(plan.modelsToPull).toEqual([])
-    expect(plan.judge.modelId).toBe('qwen2.5:7b')
+    // Judge id must match the slugified form the YAML writer uses, not the
+    // raw Ollama model name — otherwise the eval runner can't resolve it.
+    expect(plan.judge.modelId).toBe(idFromModelName('qwen2.5:7b'))
   })
 
   it('cloud-only when key present and nothing local', () => {
@@ -150,10 +153,13 @@ describe('propose', () => {
     expect(plan.judge.modelId).toBe('cloud-mini')
   })
 
-  it('local-first with no cloud key uses smallest local as self-judge', () => {
+  it('local-first with no cloud key uses smallest local as self-judge (slugified id)', () => {
     const plan = propose(baseSnapshot(), { catalog: CATALOG })
     const smallest = [...plan.modelsToPull].sort((a, b) => a.paramsB - b.paramsB)[0]
-    expect(plan.judge.modelId).toBe(smallest?.name)
+    // Judge.modelId must equal the slug we write to verdict.yaml so that
+    // runEvals() can look it up. Raw model names (with colons/dots) don't
+    // match.
+    expect(plan.judge.modelId).toBe(idFromModelName(smallest!.name))
   })
 
   it('estimatedDownloadGB sums planned models', () => {

--- a/src/onboarding/cli.ts
+++ b/src/onboarding/cli.ts
@@ -70,6 +70,17 @@ export async function onboardingCommand(opts: OnboardingCliOptions = {}): Promis
       )
       return 0
     }
+    if (mark.status === 'failed') {
+      const where = mark.failedFrom ? ` at ${mark.failedFrom}` : ''
+      const why = mark.failedError ? `\n  ${mark.failedError}` : ''
+      process.stdout.write(
+        chalk.yellow(
+          `Last onboarding run failed${where}.${why}\n` +
+            'Re-run with `verdict onboarding --force` to start fresh or `--resume` to retry.\n'
+        )
+      )
+      return 0
+    }
     if (mark.status === 'in-progress' && !isMarkStale(mark) && !opts.resume) {
       process.stdout.write(
         chalk.yellow(
@@ -80,7 +91,15 @@ export async function onboardingCommand(opts: OnboardingCliOptions = {}): Promis
     }
   }
 
-  // 3. Pick renderer mode. Explicit --headless/--json wins; otherwise prefer
+  // 3. --detect-only is a debug short-circuit: print the snapshot + plan
+  // as a single readable block (or JSON if --json) and exit. The Ink TUI
+  // wouldn't have any sub-views to render past detect, so always route
+  // through the headless path (A10).
+  if (opts.detectOnly) {
+    return runDetectOnly(opts)
+  }
+
+  // 4. Pick renderer mode. Explicit --headless/--json wins; otherwise prefer
   // the Ink TUI when stdout is a TTY (and we're not in CI).
   const useTui =
     !opts.headless &&
@@ -93,6 +112,100 @@ export async function onboardingCommand(opts: OnboardingCliOptions = {}): Promis
   }
 
   return runHeadless(opts)
+}
+
+// ─── Detect-only launcher ──────────────────────────────────────────────────
+
+async function runDetectOnly(opts: OnboardingCliOptions): Promise<number> {
+  const controller = startOnboarding({
+    configPath: opts.configPath,
+    catalogPath: opts.catalogPath,
+    detectOnly: true,
+  })
+  // Auto-advance from welcome → detect, then wait for the engine to populate
+  // snapshot + plan via __detect-complete (which lands the state in 'plan').
+  const sigintHandler = () => controller.cancel('SIGINT')
+  process.on('SIGINT', sigintHandler)
+  process.on('SIGTERM', sigintHandler)
+
+  // Resolve as soon as the snapshot + plan are available.
+  const ready = new Promise<void>(resolve => {
+    const unsub = controller.on('state', (s: OnboardingState) => {
+      if (s.kind === 'plan' || s.kind === 'failed' || s.kind === 'cancelled') {
+        unsub()
+        resolve()
+      }
+    })
+  })
+  controller.send({ type: 'next' })
+  await ready
+
+  const state = controller.getState()
+  if (state.kind !== 'plan') {
+    process.stderr.write(`detect-only ended in state '${state.kind}'\n`)
+    controller.dispose()
+    process.off('SIGINT', sigintHandler)
+    process.off('SIGTERM', sigintHandler)
+    return 1
+  }
+
+  // Render the result. Stop the engine before exiting so we don't print
+  // further state transitions.
+  controller.cancel('detect-only-complete')
+
+  if (opts.json) {
+    const out = { snapshot: state.snapshot, plan: state.plan }
+    process.stdout.write(JSON.stringify(out, null, 2) + '\n')
+  } else {
+    process.stdout.write(formatDetectSummary(state.snapshot, state.plan))
+  }
+  controller.dispose()
+  process.off('SIGINT', sigintHandler)
+  process.off('SIGTERM', sigintHandler)
+  return 0
+}
+
+function formatDetectSummary(snapshot: Extract<OnboardingState, { kind: 'plan' }>['snapshot'], plan: Extract<OnboardingState, { kind: 'plan' }>['plan']): string {
+  const lines: string[] = []
+  lines.push('')
+  lines.push(chalk.bold('  verdict onboarding') + chalk.dim(' (detect-only)'))
+  lines.push('')
+  lines.push(chalk.bold('  Hardware'))
+  lines.push(`    ${snapshot.hardware.cpu} · ${snapshot.hardware.ramGB} GB RAM · ${snapshot.hardware.os} ${snapshot.hardware.osVersion}`)
+  if (snapshot.hardware.freeDiskGB !== undefined) {
+    lines.push(`    ${snapshot.hardware.freeDiskGB} GB free disk`)
+  }
+  lines.push('')
+  lines.push(chalk.bold('  Local runtimes'))
+  lines.push(`    Ollama:    ${snapshot.ollama.installed ? chalk.green('installed') : chalk.dim('missing')}${snapshot.ollama.installSource ? chalk.dim(` (${snapshot.ollama.installSource})`) : ''} · daemon ${snapshot.ollama.daemonRunning ? chalk.green('running') : chalk.dim('stopped')} · ${snapshot.ollama.installedModels.length} model(s)`)
+  lines.push(`    MLX:       ${snapshot.mlx.appleSilicon ? chalk.green('Apple Silicon') : chalk.dim('n/a')} · server ${snapshot.mlx.serverRunning ? chalk.green('running') : chalk.dim('stopped')}`)
+  lines.push(`    LM Studio: app ${snapshot.lmstudio.appInstalled ? chalk.green('installed') : chalk.dim('missing')} · server ${snapshot.lmstudio.serverRunning ? chalk.green('running') : chalk.dim('stopped')}`)
+  lines.push('')
+  const keys = Object.entries(snapshot.cloud).filter(([, v]) => v).map(([k]) => k.replace('Key', ''))
+  lines.push(chalk.bold('  Cloud keys'))
+  lines.push(`    ${keys.length ? chalk.green(keys.join(', ')) : chalk.dim('(none in env)')}`)
+  lines.push('')
+  lines.push(chalk.bold('  Plan'))
+  lines.push(`    intent: ${chalk.cyan(plan.intent)}`)
+  lines.push(`    ${plan.rationale}`)
+  if (plan.installSteps.length > 0) {
+    lines.push('    install steps:')
+    plan.installSteps.forEach((s, i) => lines.push(`      ${i + 1}. ${s.label}`))
+  }
+  if (plan.modelsToPull.length > 0) {
+    lines.push(`    models to pull (${plan.estimatedDownloadGB.toFixed(1)} GB total):`)
+    plan.modelsToPull.forEach(m => lines.push(`      • ${m.name} (${m.paramsB}B ${m.defaultQuant}, ~${m.estimatedSizeGB} GB, role=${m.role})`))
+  }
+  if (plan.reuseModels.length > 0) {
+    lines.push(`    reusing: ${plan.reuseModels.join(', ')}`)
+  }
+  if (plan.cloudModels.length > 0) {
+    lines.push(`    cloud models: ${plan.cloudModels.map(m => m.id).join(', ')}`)
+  }
+  lines.push(`    judge: ${plan.judge.modelId} — ${plan.judge.rationale}`)
+  lines.push(`    estimated total: ${plan.estimatedDurationMin[0]}–${plan.estimatedDurationMin[1]} min`)
+  lines.push('')
+  return lines.join('\n')
 }
 
 // ─── TUI launcher ──────────────────────────────────────────────────────────

--- a/src/onboarding/config-writer.ts
+++ b/src/onboarding/config-writer.ts
@@ -9,7 +9,13 @@
 import fs from 'fs'
 import path from 'path'
 import { renderVerdictYamlFromPlan } from './templates.js'
-import { GENERAL_PACK, MOE_PACK, ENV_EXAMPLE } from './templates.js'
+import {
+  GENERAL_PACK,
+  MOE_PACK,
+  ENV_EXAMPLE,
+  loadQuantizationPack,
+  QUANTIZATION_PACK_STUB,
+} from './templates.js'
 import type { Plan } from './events.js'
 
 export type ConfigWriteAction =
@@ -120,6 +126,14 @@ function scaffoldExtras(rootDir: string): void {
 
   const moePath = path.join(packsDir, 'moe.yaml')
   if (!fs.existsSync(moePath)) fs.writeFileSync(moePath, MOE_PACK)
+
+  // Mirror `verdict init`: write the quantization pack from the bundled
+  // file when available, fall back to a pointer stub. Without this,
+  // `verdict quants` later breaks for users who came in through onboarding.
+  const quantPath = path.join(packsDir, 'quantization.yaml')
+  if (!fs.existsSync(quantPath)) {
+    fs.writeFileSync(quantPath, loadQuantizationPack() ?? QUANTIZATION_PACK_STUB)
+  }
 
   const envExamplePath = path.join(rootDir, '.env.example')
   if (!fs.existsSync(envExamplePath)) fs.writeFileSync(envExamplePath, ENV_EXAMPLE)

--- a/src/onboarding/detect.ts
+++ b/src/onboarding/detect.ts
@@ -136,9 +136,31 @@ async function probeOllama(host: string): Promise<OllamaSnapshot> {
   const binPath = which('ollama')
   const installed = binPath !== undefined
   const version = installed ? ollamaVersion() : undefined
+  const installSource = installed ? classifyOllamaSource(binPath!) : undefined
   const daemonRunning = await isOllamaRunning(host)
   const installedModels = daemonRunning ? await listOllamaModels(host) : []
-  return { installed, binPath, version, daemonRunning, installedModels }
+  return { installed, binPath, version, installSource, daemonRunning, installedModels }
+}
+
+/**
+ * Resolve the `ollama` binary to its real path and classify the install
+ * source. Mac users frequently install via the desktop app; brew users
+ * have the binary in a Cellar; curl|sh users land in /usr/local/bin
+ * (Intel) or /usr/local/Cellar (Apple Silicon brew).
+ */
+export function classifyOllamaSource(binPath: string): OllamaSnapshot['installSource'] {
+  let resolved = binPath
+  try {
+    resolved = fs.realpathSync(binPath)
+  } catch {
+    // realpath can fail on a dangling symlink — treat as unknown
+    return 'unknown'
+  }
+  if (resolved.includes('/Applications/Ollama.app/')) return 'mac-app'
+  if (resolved.includes('/Cellar/ollama/')) return 'brew'
+  if (resolved.includes('/opt/homebrew/Cellar/ollama/')) return 'brew'
+  if (resolved.startsWith('/usr/local/bin/') || resolved.startsWith('/usr/bin/')) return 'curl'
+  return 'unknown'
 }
 
 async function probeMLX(port: number): Promise<MlxSnapshot> {

--- a/src/onboarding/download/engine.ts
+++ b/src/onboarding/download/engine.ts
@@ -170,6 +170,11 @@ export function createDownloadEngine(opts: DownloadEngineOptions = {}): Download
       }
       case 'log': {
         if (ev.line) task.lastStatusLine = ev.line
+        // Suppress the high-frequency `pulling <hash>` noise — Ollama emits
+        // one per progress tick, dozens per layer. The same info is already
+        // conveyed by `task-phase` and `task-progress` events. Pass through
+        // semantically meaningful lines only.
+        if (isNoisyPullLine(ev.line)) return false
         emit({ type: 'log', modelName: task.modelName, line: ev.line })
         return false
       }
@@ -391,6 +396,17 @@ function makeTask(req: DownloadRequest, maxAttempts: number, ts: number): TaskSt
   }
 }
 
+function isInFlightPhase(phase: TaskState['phase']): boolean {
+  return (
+    phase === 'starting' ||
+    phase === 'manifest' ||
+    phase === 'downloading' ||
+    phase === 'verifying' ||
+    phase === 'writing' ||
+    phase === 'retrying'
+  )
+}
+
 function computeAggregate(
   tasks: Record<string, TaskState>,
   startedAt: number
@@ -399,17 +415,28 @@ function computeAggregate(
   const done = list.filter(t => t.phase === 'done').length
   const failed = list.filter(t => t.phase === 'failed').length
   const queued = list.filter(t => t.phase === 'queued').length
-  const inFlight = list.filter(
-    t =>
-      t.phase === 'starting' ||
-      t.phase === 'manifest' ||
-      t.phase === 'downloading' ||
-      t.phase === 'verifying' ||
-      t.phase === 'writing' ||
-      t.phase === 'retrying'
-  ).length
-  // Average percent across tasks; -1 (indeterminate) counts as 0.
-  const sum = list.reduce((acc, t) => acc + (t.percent < 0 ? 0 : t.percent), 0)
+  const inFlight = list.filter(t => isInFlightPhase(t.phase)).length
+
+  // Per-task contribution to overall progress:
+  //  - done       → 100
+  //  - failed     → 100 (counted as "settled", just unsuccessfully — keeps
+  //                  the bar moving when one model fails of N)
+  //  - queued     → 0
+  //  - in-flight  → percent clamped to [0, 99]. The clamp prevents premature
+  //                  100% claims: a layer that completes before the next is
+  //                  announced briefly reports task.percent=100 even though
+  //                  more layers + verification still remain. Only the
+  //                  terminal 'done' phase earns 100.
+  const contribution = (t: TaskState): number => {
+    if (t.phase === 'done') return 100
+    if (t.phase === 'failed' || t.phase === 'canceled') return 100
+    if (t.phase === 'queued') return 0
+    // in-flight
+    const p = t.percent
+    if (p < 0) return 0
+    return Math.min(99, p)
+  }
+  const sum = list.reduce((acc, t) => acc + contribution(t), 0)
   const overall = list.length > 0 ? sum / list.length : 0
   return {
     totalTasks: list.length,
@@ -429,6 +456,17 @@ function clamp(n: number, lo: number, hi: number): number {
 function humanPct(p: number): string {
   if (p < 0) return '…'
   return p.toFixed(0) + '%'
+}
+
+/**
+ * `pulling <12-hex-digest>` is Ollama's per-layer progress status. The
+ * underlying NDJSON emits this dozens of times per layer (one per
+ * progress tick). The engine already surfaces the same fact via
+ * `task-phase` ('downloading') and `task-progress` events, so forwarding
+ * every variant as a log line just spams subscribers.
+ */
+function isNoisyPullLine(line: string): boolean {
+  return /^pulling [0-9a-f]{8,}$/i.test(line.trim())
 }
 
 function classifyTaskError(message: string | undefined): boolean {

--- a/src/onboarding/download/headless.ts
+++ b/src/onboarding/download/headless.ts
@@ -132,6 +132,17 @@ function stateSummary(state: OnboardingState, c: ColorFns): string {
           ? c.green(`• verify: ok (score ${state.result.exampleScore.toFixed(1)})`)
           : c.red(`• verify: failed (${state.result.failures.map(f => f.step).join(',')})`)
         : c.dim('• verify: running…')
+    case 'first-run': {
+      if (state.result) {
+        if (!state.result.ok) return c.yellow(`• first-run: failed (${state.result.errorMessage ?? 'unknown'})`)
+        const w = state.result.winner ?? '?'
+        const ws = state.result.modelScores[w]?.toFixed(2) ?? '?'
+        return c.green(`• first-run: done — winner ${w} (${ws}/10), ${state.result.casesRun} cases`)
+      }
+      const total = state.view.casesTotal
+      const done = state.view.casesDone
+      return c.dim(`• first-run: ${done}/${total} cases — ${state.view.current.slice(0, 60)}`)
+    }
     case 'done':
       return c.green(`• done — pulled ${state.summary.pulledModels.length} model(s) to ${state.summary.configPath}`)
     case 'cancelled':

--- a/src/onboarding/events.ts
+++ b/src/onboarding/events.ts
@@ -15,6 +15,12 @@ export const OllamaSnapshotSchema = z.object({
   version: z.string().optional(),
   daemonRunning: z.boolean(),
   installedModels: z.array(z.string()).default([]),
+  /**
+   * Where the `ollama` binary came from. Affects how we start the daemon:
+   * `mac-app` users have a menu-bar app that owns the daemon — we should
+   * launch the app instead of spawning a competing `ollama serve`.
+   */
+  installSource: z.enum(['mac-app', 'brew', 'curl', 'unknown']).optional(),
 })
 export type OllamaSnapshot = z.infer<typeof OllamaSnapshotSchema>
 
@@ -145,6 +151,13 @@ export const PlanSelectionsSchema = z.object({
       key: z.string(),
     })
     .optional(),
+  /**
+   * Opt-in to anonymous telemetry. Tri-state:
+   *   - undefined: user hasn't decided yet (use prior decision if any)
+   *   - true:      enable
+   *   - false:     disable
+   */
+  telemetryOptIn: z.boolean().optional(),
 })
 export type PlanSelections = z.infer<typeof PlanSelectionsSchema>
 
@@ -207,6 +220,34 @@ export interface VerifyResult {
   failures: Array<{ step: string; error: string }>
 }
 
+/**
+ * Live snapshot of the user's first real eval (kicked off after verify
+ * succeeds). Drives the FirstRun screen so the user sees the AHA moment
+ * forming — the flywheel that makes the dashboard non-empty.
+ */
+export interface FirstRunView {
+  /** Models being evaluated (matches verdict.yaml model ids). */
+  models: string[]
+  /** Total cases in the pack. */
+  casesTotal: number
+  /** Cases completed so far across all models. */
+  casesDone: number
+  /** Last status line from the runner (the case currently in flight). */
+  current: string
+  /** Per-model running averages once cases start scoring. */
+  runningAverages: Record<string, number>
+}
+
+export interface FirstRunResult {
+  ok: boolean
+  durationMs: number
+  runId: string
+  modelScores: Record<string, number>
+  winner?: string
+  casesRun: number
+  errorMessage?: string
+}
+
 export interface DoneSummary {
   pulledModels: string[]
   reusedModels: string[]
@@ -214,6 +255,13 @@ export interface DoneSummary {
   configBackupPath?: string
   smokeScore?: number
   totalDurationMs: number
+  /**
+   * Results of the first real eval that auto-ran after verify. Present
+   * when the engine successfully completed the first-run step; absent
+   * when first-run was skipped (e.g. user cancelled, or no general pack
+   * exists in the config).
+   */
+  firstRun?: FirstRunResult
 }
 
 export type OnboardingState =
@@ -241,6 +289,7 @@ export type OnboardingState =
       action: Plan['config']['action']
     }
   | { kind: 'verify'; result: VerifyResult | null }
+  | { kind: 'first-run'; view: FirstRunView; result: FirstRunResult | null }
   | { kind: 'done'; summary: DoneSummary }
   | { kind: 'cancelled'; from: OnboardingStateKind; reason?: string }
   | {
@@ -282,13 +331,16 @@ export type OnboardingEvent =
   | { type: '__configure-ready'; previewYaml: string; diff: string | null; hasExisting: boolean }
   | { type: '__configure-written'; configPath: string; backupPath?: string }
   | { type: '__verify-complete'; result: VerifyResult }
+  | { type: '__first-run-start'; view: FirstRunView }
+  | { type: '__first-run-progress'; view: FirstRunView }
+  | { type: '__first-run-complete'; result: FirstRunResult }
   | { type: '__error'; error: string; recoverable: boolean }
 
 // ─── Persisted mark (resume across crashes) ─────────────────────────────────
 
 export const OnboardingMarkSchema = z.object({
   version: z.literal(1),
-  status: z.enum(['in-progress', 'completed', 'skipped', 'cancelled']),
+  status: z.enum(['in-progress', 'completed', 'skipped', 'cancelled', 'failed']),
   startedAt: z.string(),
   completedAt: z.string().optional(),
   lastCompletedState: z
@@ -301,9 +353,15 @@ export const OnboardingMarkSchema = z.object({
       'pull',
       'configure',
       'verify',
+      'first-run',
       'done',
     ])
     .optional(),
+  /** When status='failed', the kind of state we failed from + the message. */
+  failedFrom: z
+    .enum(['welcome', 'detect', 'plan', 'consent', 'install', 'pull', 'configure', 'verify', 'first-run'])
+    .optional(),
+  failedError: z.string().optional(),
   snapshot: SnapshotSchema.optional(),
   plan: PlanSchema.optional(),
   /** Models successfully pulled this session (skip re-pull on resume). */

--- a/src/onboarding/index.ts
+++ b/src/onboarding/index.ts
@@ -98,6 +98,10 @@ interface InternalState {
   // Path where the current configure step will write.
   finalConfigPath?: string
   configBackupPath?: string
+  // Smoke eval result captured during verify; surfaced in the Done summary.
+  smokeResult?: import('./events.js').VerifyResult
+  // First-run result captured after verify succeeds.
+  firstRunResult?: import('./events.js').FirstRunResult
 }
 
 export function startOnboarding(opts: StartOnboardingOptions = {}): OnboardingController {
@@ -136,21 +140,34 @@ export function startOnboarding(opts: StartOnboardingOptions = {}): OnboardingCo
   }
 
   function persistMark(status: OnboardingMark['status'] = 'in-progress'): void {
-    // Only persist progress-bearing states; cancelled/failed don't need a
-    // resume target.
     const lastCompletedState: OnboardingMark['lastCompletedState'] =
       internal.state.kind === 'welcome' ||
       internal.state.kind === 'cancelled' ||
       internal.state.kind === 'failed'
         ? undefined
         : internal.state.kind
+    // When we land in 'failed', record what failed and why so the next launch
+    // can decide whether to offer a resume vs a fresh start.
+    const failedFrom: OnboardingMark['failedFrom'] =
+      internal.state.kind === 'failed' &&
+      internal.state.from !== 'done' &&
+      internal.state.from !== 'cancelled' &&
+      internal.state.from !== 'failed'
+        ? internal.state.from
+        : undefined
+    const failedError =
+      internal.state.kind === 'failed' ? internal.state.error : undefined
     const mark: OnboardingMark = {
       version: 1,
       status,
       startedAt: new Date(internal.startedAt).toISOString(),
       completedAt:
-        status === 'completed' || status === 'cancelled' ? new Date().toISOString() : undefined,
+        status === 'completed' || status === 'cancelled' || status === 'failed'
+          ? new Date().toISOString()
+          : undefined,
       lastCompletedState,
+      failedFrom,
+      failedError,
       snapshot: internal.snapshot,
       plan: internal.plan,
       pulledModels: internal.pulledModels,
@@ -182,13 +199,27 @@ export function startOnboarding(opts: StartOnboardingOptions = {}): OnboardingCo
       // No-op event — nothing to do.
       return
     }
+    // Telemetry opt-in: when the user confirms consent, apply the choice they
+    // made on the Consent screen (or no-op in headless / undefined). Lifted
+    // into the engine boundary so neither the reducer (pure) nor the UI
+    // (presentation) has to touch telemetry side effects directly.
+    if (prev.kind === 'consent' && next.kind === 'install') {
+      const decision = prev.selections.telemetryOptIn
+      if (decision === true) {
+        void applyTelemetryDecision(true).catch(() => undefined)
+      } else if (decision === false) {
+        void applyTelemetryDecision(false).catch(() => undefined)
+      }
+    }
     internal.state = next
     persistMark(
       next.kind === 'done'
         ? 'completed'
         : next.kind === 'cancelled'
           ? 'cancelled'
-          : 'in-progress'
+          : next.kind === 'failed'
+            ? 'failed'
+            : 'in-progress'
     )
     emitState()
     if (prev.kind !== next.kind) {
@@ -218,6 +249,10 @@ export function startOnboarding(opts: StartOnboardingOptions = {}): OnboardingCo
       }
       case 'verify': {
         void runVerifyStep()
+        break
+      }
+      case 'first-run': {
+        void runFirstRunStep()
         break
       }
       case 'done':
@@ -313,7 +348,12 @@ export function startOnboarding(opts: StartOnboardingOptions = {}): OnboardingCo
         if (step.id === 'install-ollama') {
           runner = installOllama({ method: step.method ?? 'brew' })
         } else if (step.id === 'start-ollama') {
-          runner = startOllamaDaemon({ host: ollamaHost })
+          // Pass the detected install source so Mac-app installs launch
+          // the desktop app instead of spawning a competing daemon.
+          runner = startOllamaDaemon({
+            host: ollamaHost,
+            installSource: internal.snapshot?.ollama.installSource,
+          })
         } else if (step.id === 'capture-cloud-key') {
           // Wait for the consent step to supply the key — engine layer
           // attaches it. For now, no-op.
@@ -456,27 +496,32 @@ export function startOnboarding(opts: StartOnboardingOptions = {}): OnboardingCo
         configPath: internal.finalConfigPath ?? configPath,
         onProgress: msg => emitLog('info', msg, 'verify'),
       })
+      internal.smokeResult = result
       dispatch({ type: '__verify-complete', result })
-      // Transition automatically to done.
-      const durationMs = Date.now() - internal.startedAt
-      internal.state = {
-        kind: 'done',
-        summary: {
-          pulledModels: internal.pulledModels,
-          reusedModels: internal.plan?.reuseModels ?? [],
-          configPath: internal.finalConfigPath ?? configPath,
-          configBackupPath: internal.configBackupPath,
-          smokeScore: result.exampleScore,
-          totalDurationMs: durationMs,
-        },
+      // If verify failed, surface the failure and stop. If it succeeded,
+      // hand off to first-run so the user lands on a populated dashboard
+      // rather than a smoke-only baseline.
+      if (!result.ok) {
+        dispatch({
+          type: '__error',
+          error:
+            'Smoke eval failed: ' +
+            (result.failures[0]?.error ?? 'unknown failure'),
+          recoverable: true,
+        })
+        return
       }
-      persistMark('completed')
-      emitState()
-      if (terminalResolver) {
-        terminalResolver(internal.state)
-        terminalResolver = null
+      // Initialize an empty FirstRunView so the reducer + UI have something
+      // to render the moment we enter the state.
+      const view: import('./events.js').FirstRunView = {
+        models: [],
+        casesTotal: 0,
+        casesDone: 0,
+        current: '',
+        runningAverages: {},
       }
-      emitter.emit('done')
+      dispatch({ type: '__first-run-start', view })
+      return
     } catch (err) {
       dispatch({
         type: '__error',
@@ -484,6 +529,149 @@ export function startOnboarding(opts: StartOnboardingOptions = {}): OnboardingCo
         recoverable: true,
       })
     }
+  }
+
+  /**
+   * Run the user's first real eval against their general pack and persist
+   * to ~/.verdict/results.db so the dashboard isn't empty when they finish
+   * onboarding. Failures here are non-fatal — we still transition to done
+   * with a note that the first run can be re-attempted manually.
+   */
+  async function runFirstRunStep(): Promise<void> {
+    const ac = addAbort()
+    void ac
+    const cfgPath = internal.finalConfigPath ?? configPath
+    const startedAt = Date.now()
+
+    // Track per-case progress so the FirstRun screen can update.
+    const seenCaseIds = new Set<string>()
+    const view: import('./events.js').FirstRunView = {
+      models: [],
+      casesTotal: 0,
+      casesDone: 0,
+      current: '',
+      runningAverages: {},
+    }
+
+    const onProgress = (msg: string) => {
+      emitLog('info', msg, 'first-run')
+      const m = msg.match(/^([\w:.\-]+):\s+running\s+\d+\s+model/)
+      if (m && !seenCaseIds.has(m[1]!)) {
+        seenCaseIds.add(m[1]!)
+        view.casesDone = seenCaseIds.size
+        view.current = msg
+        dispatch({ type: '__first-run-progress', view: { ...view } })
+      } else {
+        view.current = msg
+      }
+    }
+
+    try {
+      const [{ loadConfig, loadEvalPack }, { runEvals }, { getDb, initSchema, saveRunResult }] = await Promise.all([
+        import('../core/config.js'),
+        import('../core/runner.js'),
+        import('../db/client.js'),
+      ])
+
+      const config = loadConfig(cfgPath)
+      const cfgDir = path.dirname(path.resolve(cfgPath))
+      const packs = config.packs.map(p => loadEvalPack(p, cfgDir))
+      if (packs.length === 0 || packs[0]!.cases.length === 0) {
+        // No pack to run — skip first-run gracefully.
+        emitLog('warn', 'No eval pack found; skipping first real eval.', 'first-run')
+        finishWithFirstRun(undefined, startedAt)
+        return
+      }
+      view.models = config.models.map(m => m.id)
+      view.casesTotal = packs[0]!.cases.length
+      dispatch({ type: '__first-run-progress', view: { ...view } })
+
+      const result = await runEvals(
+        config,
+        packs,
+        onProgress,
+        false,
+        undefined,
+        false, // preload disabled — A6 keeps this fast for first-run; Theme B will improve preload UX
+        cfgPath
+      )
+
+      // Persist to SQLite so `verdict history` + dashboard show this run.
+      const db = getDb()
+      initSchema(db)
+      const packLabel = packs.map(p => p.name).join(',') || 'onboarding'
+      saveRunResult(db, result, packLabel)
+
+      // Compute the winning model and per-model averages.
+      const modelScores: Record<string, number> = {}
+      let winner: string | undefined
+      let topScore = -Infinity
+      for (const [modelId, sum] of Object.entries(result.summary)) {
+        modelScores[modelId] = sum.avg_total
+        if (sum.avg_total > topScore) {
+          topScore = sum.avg_total
+          winner = modelId
+        }
+      }
+
+      const firstRun: import('./events.js').FirstRunResult = {
+        ok: true,
+        durationMs: Date.now() - startedAt,
+        runId: result.run_id,
+        modelScores,
+        winner,
+        casesRun: packs[0]!.cases.length,
+      }
+      dispatch({ type: '__first-run-complete', result: firstRun })
+      finishWithFirstRun(firstRun, startedAt)
+    } catch (err) {
+      const errMsg = err instanceof Error ? err.message : String(err)
+      emitLog('error', `First eval failed: ${errMsg}`, 'first-run')
+      // Non-fatal: still transition to done so the user can manually retry.
+      const firstRun: import('./events.js').FirstRunResult = {
+        ok: false,
+        durationMs: Date.now() - startedAt,
+        runId: '',
+        modelScores: {},
+        casesRun: 0,
+        errorMessage: errMsg,
+      }
+      dispatch({ type: '__first-run-complete', result: firstRun })
+      finishWithFirstRun(firstRun, startedAt)
+    }
+  }
+
+  /**
+   * Transition to the 'done' terminal state with a summary that folds in
+   * the smoke result (verify) AND the first-run result if present. Direct
+   * state mutation (rather than dispatch) because 'done' is constructed
+   * from internal context the reducer doesn't have.
+   */
+  function finishWithFirstRun(
+    firstRun: import('./events.js').FirstRunResult | undefined,
+    _firstRunStartedAt: number
+  ): void {
+    internal.firstRunResult = firstRun
+    const totalDurationMs = Date.now() - internal.startedAt
+    internal.state = {
+      kind: 'done',
+      summary: {
+        pulledModels: internal.pulledModels,
+        reusedModels: internal.plan?.reuseModels ?? [],
+        configPath: internal.finalConfigPath ?? configPath,
+        configBackupPath: internal.configBackupPath,
+        smokeScore: internal.smokeResult?.exampleScore,
+        totalDurationMs,
+        firstRun,
+      },
+    }
+    persistMark('completed')
+    emitState()
+    if (terminalResolver) {
+      terminalResolver(internal.state)
+      terminalResolver = null
+    }
+    emitter.emit('done')
   }
 
   // ─── Public methods ──────────────────────────────────────────────────────
@@ -513,6 +701,20 @@ export function startOnboarding(opts: StartOnboardingOptions = {}): OnboardingCo
   queueMicrotask(emitState)
 
   return controller
+}
+
+/**
+ * Apply the telemetry opt-in/out decision captured during consent. Imported
+ * lazily so the engine module doesn't pull in `~/.verdict/telemetry.json`
+ * disk IO at import time (cleaner for tests + tree-shaking).
+ */
+async function applyTelemetryDecision(optIn: boolean): Promise<void> {
+  const { enable, disable, loadPrefs } = await import('../utils/telemetry.js')
+  // Don't churn the prefs file if the decision matches the existing one.
+  const prior = loadPrefs()
+  if (prior && prior.enabled === optIn) return
+  if (optIn) enable()
+  else disable()
 }
 
 // Re-exports for the CLI and TUI to import from one place.

--- a/src/onboarding/install/ollama.ts
+++ b/src/onboarding/install/ollama.ts
@@ -72,6 +72,13 @@ function installCmd(method: 'brew' | 'curl'): { cmd: string; args: string[] } {
 export interface StartOllamaOptions {
   host?: string // 'localhost:11434'
   readinessTimeoutMs?: number
+  /**
+   * How the user's `ollama` binary was installed. Determines the launch
+   * strategy: `mac-app` opens the desktop app (so the menu-bar icon stays
+   * valid + the user retains control); anything else spawns `ollama serve`.
+   * Defaults to spawning `ollama serve` — backwards-compatible.
+   */
+  installSource?: 'mac-app' | 'brew' | 'curl' | 'unknown'
   /** Inject for tests. */
   spawnFn?: SpawnFn
   /** Inject for tests. */
@@ -104,6 +111,41 @@ export function startOllamaDaemon(opts: StartOllamaOptions = {}): InstallStepRun
         return
       }
       ensureVerdictDir()
+
+      // Mac-app branch: launch the desktop app. The app owns the daemon,
+      // the menu-bar icon stays valid, and the user can stop/start via
+      // their normal flow. Avoids the dogfood-discovered issue where our
+      // spawn would steal the daemon and leave the menu-bar icon dangling.
+      if (opts.installSource === 'mac-app') {
+        onLine('Launching Ollama.app (Mac desktop app)…')
+        const child = spawnFn('open', ['-a', 'Ollama'], {
+          stdio: ['ignore', 'pipe', 'pipe'],
+          env: process.env,
+        })
+        // `open -a` exits quickly; we don't track its PID since the app
+        // (not us) owns the daemon.
+        await new Promise<void>((resolve, reject) => {
+          child.on('error', reject)
+          child.on('close', () => resolve())
+        })
+        onLine(`Waiting for daemon to become ready on ${host}…`)
+        const deadline = Date.now() + readinessTimeoutMs
+        while (Date.now() < deadline) {
+          if (signal.aborted) throw makeStepFailure('start-ollama', 'cancelled')
+          if (await isRunning(host)) {
+            onLine('Ollama is ready.')
+            return
+          }
+          await sleep(500)
+        }
+        throw makeStepFailure(
+          'start-ollama',
+          `Ollama.app did not become ready within ${readinessTimeoutMs}ms — check the menu-bar icon.`
+        )
+      }
+
+      // Default: spawn `ollama serve` ourselves. Used for brew/curl/unknown
+      // install sources. We record the PID so we can clean up on cancel.
       const out = fs.openSync(OLLAMA_LOG_FILE, 'a')
       onLine(`Spawning: ollama serve  (log: ${OLLAMA_LOG_FILE})`)
       const child = spawnFn('ollama', ['serve'], {

--- a/src/onboarding/planner.ts
+++ b/src/onboarding/planner.ts
@@ -16,6 +16,7 @@ import { z } from 'zod'
 
 import { checkFit, estimateRamGB } from '../core/hardware.js'
 import type { HardwareInfo } from '../core/hardware.js'
+import { idFromModelName } from './templates.js'
 import type {
   HardwareSnapshot,
   InstallStep,
@@ -228,7 +229,11 @@ export function propose(snapshot: Snapshot, opts: PlannerOptions = {}): Plan {
   // ── 3. Reuse local ────────────────────────────────────────────────────────
   if (snapshot.ollama.daemonRunning && snapshot.ollama.installedModels.length >= 1) {
     const reuse = snapshot.ollama.installedModels.slice(0, 3)
-    const judgeId = hasCloudKey ? CLOUD_FAST_MINI.id : reuse[0] ?? ''
+    // Judge id must match the `id:` we write to verdict.yaml — that's the
+    // slugified form, not the raw `ollama list` name.
+    const judgeId = hasCloudKey
+      ? CLOUD_FAST_MINI.id
+      : reuse[0] ? idFromModelName(reuse[0]) : ''
     return {
       intent: 'reuse-local',
       installSteps: [],
@@ -311,9 +316,11 @@ export function propose(snapshot: Snapshot, opts: PlannerOptions = {}): Plan {
   // Judge: cloud if available, else smallest local model.
   const cloudModels: PlannedCloudModel[] = hasCloudKey ? [CLOUD_FAST_MINI] : []
   const smallestLocal = [...picked].sort((a, b) => a.paramsB - b.paramsB)[0]
+  // Match the slug the YAML writer will use as the model's `id:` — never
+  // the raw model name, which differs (e.g. "llama3.2:3b" vs "llama3-2-3b").
   const judgeModelId = hasCloudKey
     ? CLOUD_FAST_MINI.id
-    : smallestLocal?.name ?? ''
+    : smallestLocal ? idFromModelName(smallestLocal.name) : ''
   const judgeRationale = hasCloudKey
     ? 'Using cloud mini as judge — cheapest and most consistent option.'
     : smallestLocal

--- a/src/onboarding/state-machine.ts
+++ b/src/onboarding/state-machine.ts
@@ -244,8 +244,22 @@ export function reduce(
       if (event.type === '__verify-complete') {
         return { kind: 'verify', result: event.result }
       }
+      if (event.type === '__first-run-start') {
+        return { kind: 'first-run', view: event.view, result: null }
+      }
       // Verify result presented; user advances by `next`. Engine then
       // constructs the done summary.
+      return state
+    }
+
+    // ─── first-run ──────────────────────────────────────────────────
+    case 'first-run': {
+      if (event.type === '__first-run-progress') {
+        return { ...state, view: event.view }
+      }
+      if (event.type === '__first-run-complete') {
+        return { ...state, result: event.result }
+      }
       return state
     }
 

--- a/src/onboarding/templates.ts
+++ b/src/onboarding/templates.ts
@@ -250,6 +250,37 @@ cases:
     tags: [coding, sql, performance]
 `
 
+// ─── eval-packs/quantization.yaml ──────────────────────────────────────────
+//
+// 155-line pack; bundled with the package on publish (see `files` in
+// package.json). We read it from the package at runtime so we don't
+// duplicate the source — keeps a single source of truth in the repo.
+// If the file isn't present (e.g. running from a stripped build), the
+// caller writes the pointer stub via `quantizationPackPointerStub()`.
+
+import fs from 'fs'
+import { URL } from 'url'
+
+/**
+ * Best-effort load of the bundled `quantization.yaml`. Returns null if
+ * the file isn't found at the expected package-relative path.
+ */
+export function loadQuantizationPack(): string | null {
+  try {
+    const pkgQuantPath = new URL('../../eval-packs/quantization.yaml', import.meta.url)
+    return fs.readFileSync(pkgQuantPath, 'utf-8')
+  } catch {
+    return null
+  }
+}
+
+/**
+ * Tiny pointer file written when the bundled pack isn't available
+ * (dev mode, partial install). Tells the user where to find the canonical
+ * source.
+ */
+export const QUANTIZATION_PACK_STUB = '# See https://github.com/hnshah/verdict/blob/main/eval-packs/quantization.yaml\n'
+
 // ─── .env.example ───────────────────────────────────────────────────────────
 
 export const ENV_EXAMPLE = `# verdict environment variables

--- a/src/tui/screens/Onboarding/Consent.tsx
+++ b/src/tui/screens/Onboarding/Consent.tsx
@@ -1,17 +1,27 @@
 import { Box, Text, useInput } from 'ink'
 import { theme } from '../../theme.js'
-import type { OnboardingState } from '../../../onboarding/index.js'
+import type {
+  OnboardingState,
+  PlanSelections,
+} from '../../../onboarding/index.js'
 
 export interface ConsentProps {
   state: Extract<OnboardingState, { kind: 'consent' }>
   onConfirm: () => void
   onBack: () => void
+  onEdit: (selections: PlanSelections) => void
 }
 
-export function Consent({ state, onConfirm, onBack }: ConsentProps) {
+export function Consent({ state, onConfirm, onBack, onEdit }: ConsentProps) {
+  const telemetryOn = state.selections.telemetryOptIn === true
   useInput((input, key) => {
     if (input === 'y' || input === 'Y' || key.return) onConfirm()
     if (input === 'b' || input === 'n' || input === 'N' || key.escape) onBack()
+    // Toggle telemetry opt-in. We store true/false explicitly so the engine
+    // knows the user actually made a choice (undefined = unanswered).
+    if (input === 't' || input === 'T') {
+      onEdit({ ...state.selections, telemetryOptIn: !telemetryOn })
+    }
   })
   const willInstall = state.plan.installSteps.length > 0
   const willPull = state.plan.modelsToPull.length > 0
@@ -43,6 +53,18 @@ export function Consent({ state, onConfirm, onBack }: ConsentProps) {
           • You can cancel anytime with <Text color={theme.accent}>Ctrl-C</Text>.
         </Text>
       </Box>
+      <Box flexDirection="column" marginTop={1}>
+        <Text color={theme.text}>
+          <Text color={telemetryOn ? theme.success : theme.muted}>
+            {telemetryOn ? '☑' : '☐'}
+          </Text>{' '}
+          Help us count installs? (anonymous, opt-in)
+        </Text>
+        <Text color={theme.dim}>
+          {'  '}Sends: install id, day, model/pack counts, verdict version. Never prompts/scores/paths.
+        </Text>
+      </Box>
+
       <Box marginTop={1}>
         <Text color={theme.accent}>y</Text>
         <Text color={theme.muted}> or </Text>
@@ -51,7 +73,9 @@ export function Consent({ state, onConfirm, onBack }: ConsentProps) {
         <Text color={theme.accent}>n</Text>
         <Text color={theme.muted}> / </Text>
         <Text color={theme.accent}>b</Text>
-        <Text color={theme.muted}> to go back</Text>
+        <Text color={theme.muted}> to go back · </Text>
+        <Text color={theme.accent}>t</Text>
+        <Text color={theme.muted}> to toggle telemetry</Text>
       </Box>
     </Box>
   )

--- a/src/tui/screens/Onboarding/Done.tsx
+++ b/src/tui/screens/Onboarding/Done.tsx
@@ -46,6 +46,30 @@ export function Done({ state, onExit }: DoneProps) {
         <Text color={theme.dim}>Took {(s.totalDurationMs / 1000).toFixed(1)}s.</Text>
       </Box>
 
+      {s.firstRun && s.firstRun.ok && (
+        <Box flexDirection="column" marginTop={1}>
+          <Text color={theme.text} bold>Your first real eval</Text>
+          {s.firstRun.winner && (
+            <Text color={theme.muted}>
+              Winner: <Text color={theme.success}>{s.firstRun.winner}</Text>
+              {' '}<Text color={theme.dim}>({s.firstRun.modelScores[s.firstRun.winner]?.toFixed(2)}/10)</Text>
+            </Text>
+          )}
+          <Text color={theme.muted}>
+            {s.firstRun.casesRun} cases · {Object.keys(s.firstRun.modelScores).length} models · saved to your local results.db
+          </Text>
+        </Box>
+      )}
+
+      {s.firstRun && !s.firstRun.ok && (
+        <Box marginTop={1}>
+          <Text color={theme.warning}>
+            First eval didn't complete: {s.firstRun.errorMessage ?? 'unknown error'}.
+            {' '}Run <Text color={theme.accent}>verdict run</Text> to retry.
+          </Text>
+        </Box>
+      )}
+
       <Box flexDirection="column" marginTop={1}>
         <Text color={theme.text} bold>What's next</Text>
         <Text color={theme.muted}>  • <Text color={theme.accent}>verdict run</Text> — run your first full eval</Text>

--- a/src/tui/screens/Onboarding/FirstRun.tsx
+++ b/src/tui/screens/Onboarding/FirstRun.tsx
@@ -1,0 +1,69 @@
+import { Box, Text } from 'ink'
+import { Spinner, ProgressBar } from '@inkjs/ui'
+import { theme } from '../../theme.js'
+import type { OnboardingState } from '../../../onboarding/index.js'
+
+export interface FirstRunProps {
+  state: Extract<OnboardingState, { kind: 'first-run' }>
+}
+
+export function FirstRun({ state }: FirstRunProps) {
+  const { view, result } = state
+
+  if (result && !result.ok) {
+    return (
+      <Box flexDirection="column" gap={1}>
+        <Text color={theme.warning} bold>First eval didn't complete</Text>
+        <Text color={theme.muted}>{result.errorMessage ?? 'unknown error'}</Text>
+        <Text color={theme.dim}>
+          You can re-run any time with <Text color={theme.accent}>verdict run</Text>.
+        </Text>
+      </Box>
+    )
+  }
+
+  if (result && result.ok) {
+    const sorted = Object.entries(result.modelScores).sort((a, b) => b[1] - a[1])
+    return (
+      <Box flexDirection="column" gap={1}>
+        <Text color={theme.success} bold>First eval complete</Text>
+        <Box flexDirection="column">
+          {sorted.map(([id, score], i) => (
+            <Text key={id} color={id === result.winner ? theme.success : theme.muted}>
+              {'  '}{i + 1}. <Text color={theme.text}>{id}</Text>
+              {'  '}<Text color={theme.dim}>{score.toFixed(2)}/10</Text>
+              {id === result.winner ? <Text color={theme.success}>  ← winner</Text> : null}
+            </Text>
+          ))}
+        </Box>
+        <Text color={theme.dim}>
+          Saved to your local results.db ({result.casesRun} cases, {(result.durationMs / 1000).toFixed(1)}s)
+        </Text>
+      </Box>
+    )
+  }
+
+  const pct = view.casesTotal > 0 ? (view.casesDone / view.casesTotal) * 100 : 0
+  return (
+    <Box flexDirection="column" gap={1}>
+      <Text color={theme.text}>
+        Running your first real eval against{' '}
+        <Text color={theme.accent}>{view.models.length}</Text> model(s) on{' '}
+        <Text color={theme.accent}>{view.casesTotal}</Text> cases…
+      </Text>
+      <Box flexDirection="column">
+        <Text color={theme.muted}>
+          Progress: {view.casesDone}/{view.casesTotal} cases
+        </Text>
+        {view.casesTotal > 0 ? (
+          <ProgressBar value={Math.max(0, Math.min(100, pct))} />
+        ) : (
+          <Spinner label="starting" />
+        )}
+      </Box>
+      {view.current && (
+        <Text color={theme.dim}>{view.current}</Text>
+      )}
+    </Box>
+  )
+}

--- a/src/tui/screens/Onboarding/StateHeader.tsx
+++ b/src/tui/screens/Onboarding/StateHeader.tsx
@@ -11,6 +11,7 @@ const STEPS = [
   { kind: 'pull', label: 'Pull' },
   { kind: 'configure', label: 'Configure' },
   { kind: 'verify', label: 'Verify' },
+  { kind: 'first-run', label: 'First Run' },
   { kind: 'done', label: 'Done' },
 ] as const
 

--- a/src/tui/screens/Onboarding/index.tsx
+++ b/src/tui/screens/Onboarding/index.tsx
@@ -25,6 +25,7 @@ import { Install } from './Install.js'
 import { Pull } from './Pull.js'
 import { Configure } from './Configure.js'
 import { Verify } from './Verify.js'
+import { FirstRun } from './FirstRun.js'
 import { Done } from './Done.js'
 import { Cancelled } from './Cancelled.js'
 import { Failed } from './Failed.js'
@@ -127,6 +128,7 @@ function renderBody(
           state={state}
           onConfirm={() => h.send({ type: 'consent-given' })}
           onBack={() => h.send({ type: 'back' })}
+          onEdit={selections => h.send({ type: 'edit-plan', selections })}
         />
       )
     case 'install':
@@ -137,6 +139,8 @@ function renderBody(
       return <Configure state={state} />
     case 'verify':
       return <Verify state={state} />
+    case 'first-run':
+      return <FirstRun state={state} />
     case 'done':
       return <Done state={state} onExit={h.onExit} />
     case 'cancelled':


### PR DESCRIPTION
## Summary

Closes the dogfood-revealed bugs and the smoke→real-eval gap that left new users with an empty dashboard after onboarding "completed". With this PR, cold start ends on a populated `~/.verdict/results.db` with comparable scores from a real eval — ready for `verdict tui` / `verdict serve --ui`.

This is **Theme A** of the post-PR-#130 roadmap (`/Users/hitenshah/.claude/plans/system-instruction-you-are-working-groovy-engelbart.md`). 8 of 10 items shipped here — A8 (README GIF) requires interactive `asciinema` recording, deliberately deferred.

## Changes

| Item | Description |
|---|---|
| **A1** | Throttle pull log events. Suppresses high-frequency `pulling <hash>` noise (Ollama emits one per progress tick). Only semantic phase/error/manifest lines surface. |
| **A2** | Scaffold `quantization.yaml` from onboarding. Lifts the bundled pack loader to `src/onboarding/templates.ts`; both `verdict init` and `verdict onboarding` write the same eval-packs. |
| **A3** | Persist `failed` state correctly. Adds `'failed'` to mark schema with `failedFrom` + `failedError`. CLI refuses relaunch without `--force` / `--resume`. |
| **A4** | Aggregate % can't exceed actual completion. In-flight tasks clamp at 99 so the bar never claims 100% before every task settles. |
| **A5** | Detect Mac-app Ollama install. Resolves the `ollama` binary's realpath; `mac-app` source launches the desktop app via `open -a Ollama` instead of spawning a competing `ollama serve` (prevents the dogfood-discovered "stolen daemon" issue). |
| **A6** | Auto-run real eval after smoke succeeds. New `first-run` state between verify and done; runs the configured general pack against all models, persists via `saveRunResult`, surfaces winner + per-model scores on the Done screen. |
| **A7** | Telemetry prompt during onboarding. `telemetryOptIn` toggle on the Consent screen (`t` key); engine applies `enable()`/`disable()` at the consent→install transition. Headless leaves existing prefs untouched. |
| **A9 + A10** | `--detect-only` improvements. Dedicated detect+print path regardless of TTY; human-readable plan summary by default, parseable JSON via `--json`. |

## Cold-start smoke

After the changes, in a fresh `/tmp/verdict-a6`:

\`\`\`
• verify: ok (score 10.0)
• first-run: 10/10 cases — gen-010: judging
• first-run: done — winner qwen2-5-coder-7b (8.68/10), 10 cases
• done — pulled 0 model(s) to /private/tmp/verdict-a6/verdict.yaml

DB after:
  llama3-2-3b      8.56  5 cases
  qwen2-5-coder-7b 8.68  5 cases  ← winner
  qwen2-5-7b       8.65  4 cases
\`\`\`

\`--detect-only\`:

\`\`\`
verdict onboarding (detect-only)
  Hardware
    Apple M4 Pro · 24 GB RAM · macOS 26.3.1, 20.5 GB free disk
  Local runtimes
    Ollama: installed (mac-app) · daemon running · 8 model(s)
    MLX:    Apple Silicon · server stopped
  Plan
    intent: config-only
    judge: existing — Using judge already configured in your verdict.yaml.
\`\`\`

## Test plan

- [x] \`npx vitest run\` — 100/100 onboarding suite passing (15 new tests).
- [x] \`npx tsc --noEmit\` — clean.
- [x] Cold-start headless on a fresh dir: detect → plan → install → pull → configure → verify → first-run → done. DB populated.
- [x] \`--detect-only\` produces parseable JSON.
- [x] \`--detect-only\` produces human-readable text by default.
- [x] Mac-app source: no competing \`ollama serve\` spawn, no stolen daemon.
- [x] Consent screen \`t\` toggle changes \`telemetryOptIn\`; engine applies on consent-given.
- [ ] Verify on a fresh non-Mac-app install (curl/brew) — needs a clean test environment.
- [ ] Cancel-during-pull preserves partial blobs (already covered by existing engine tests; manual verification on real machine pending).

## What's NOT in this PR

- **A8** — README GIF recording (requires interactive \`asciinema\` capture; deferred).
- **Theme B** (cold-start friction tax: parallel preload, live progress, smaller defaults) — separate PR.
- **Theme C/D/E** — separate PRs.