### PR TITLE
feat(preload): theme B — cold-start friction (parallel + async + streaming sniff)

### DIFF
--- a/.github/workflows/release-v1-tag.yml
+++ b/.github/workflows/release-v1-tag.yml
@@ -1,0 +1,44 @@
+name: Update v1 tag pointer
+
+# Keep a moving `v1` tag aligned with the latest `v1.*` release so users
+# can pin to `hnshah/verdict@v1` in their GitHub Actions workflows and get
+# bugfix + minor-version updates automatically without re-pinning.
+#
+# Triggered when a release is published; if its tag is v1.x.y the v1
+# pointer is force-updated to that commit. Same pattern as actions/checkout,
+# actions/setup-node, etc.
+
+on:
+  release:
+    types: [published]
+
+permissions:
+  contents: write
+
+jobs:
+  retag:
+    if: startsWith(github.event.release.tag_name, 'v1.')
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+        with:
+          fetch-depth: 0
+
+      - name: Move v1 tag to the released commit
+        env:
+          RELEASE_TAG: ${{ github.event.release.tag_name }}
+        run: |
+          set -euo pipefail
+          git config user.name 'github-actions[bot]'
+          git config user.email 'github-actions[bot]@users.noreply.github.com'
+
+          # The release tag (e.g. v1.2.3) should already exist; resolve it to
+          # the canonical commit SHA.
+          TARGET_SHA="$(git rev-list -n 1 "$RELEASE_TAG")"
+          echo "v1 → $TARGET_SHA (from $RELEASE_TAG)"
+
+          # Force-move the v1 tag locally + push. Force is intentional and
+          # standard for moving major-version tags.
+          git tag -f v1 "$TARGET_SHA"
+          git push origin --force v1

--- a/README.md
+++ b/README.md
@@ -660,6 +660,32 @@ verdict run --json --fail-if-regression
 # → Exit 1 if new model worse than baseline
 ```
 
+**GitHub Action** (`uses: hnshah/verdict@v1`):
+
+```yaml
+# .github/workflows/eval.yml
+on:
+  pull_request:
+    paths: ['prompts/**', 'verdict.yaml', 'eval-packs/**']
+
+jobs:
+  verdict:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - uses: hnshah/verdict@v1
+        with:
+          config: verdict.yaml
+          fail-if-regression: true
+          comment-on-pr: true   # posts a sticky leaderboard-diff comment
+        env:
+          OPENROUTER_API_KEY: ${{ secrets.OPENROUTER_API_KEY }}
+```
+
+The `v1` tag follows the latest `v1.x.y` release — bugfix and minor
+updates flow in automatically. Pin to a specific `v1.2.3` if you need
+reproducibility.
+
 ### 4. Cost Optimization
 
 **Goal:** Find cheapest model that meets quality bar

--- a/docs/programmatic-api.md
+++ b/docs/programmatic-api.md
@@ -8,14 +8,64 @@ Use Verdict as a library in your own scripts, CI pipelines, or custom tools.
 npm install @hnshah/verdict
 ```
 
-## Quick Start
+## Quick Start (one-liner)
+
+```ts
+import { runEvalsFromConfig } from '@hnshah/verdict'
+
+const result = await runEvalsFromConfig('./verdict.yaml', {
+  onProgress: msg => console.log(msg),
+})
+
+console.log(`Run: ${result.run_id}`)
+for (const [modelId, summary] of Object.entries(result.summary)) {
+  console.log(`${modelId}: ${summary.avg_total.toFixed(2)}/10 — ${summary.cases_run} cases`)
+}
+```
+
+`runEvalsFromConfig` loads the YAML, resolves eval packs relative to the
+config's directory, and runs everything in one shot. Use it when the
+config file is the source of truth.
+
+### Options
+
+```ts
+type RunEvalsFromConfigOptions = {
+  onProgress?: (msg: string) => void
+  resume?: boolean           // resume from checkpoint
+  categoryFilter?: string[]  // only run these case categories
+  preload?: boolean          // default true; disable for cloud-only configs
+  packs?: string[]           // override config.packs (paths relative to config dir)
+}
+```
+
+### Embed in a Next.js / Express route
+
+```ts
+// app/api/eval/route.ts
+import { runEvalsFromConfig } from '@hnshah/verdict'
+
+export async function POST() {
+  const result = await runEvalsFromConfig('./verdict.yaml', { preload: false })
+  return Response.json({
+    winner: result.summary[Object.keys(result.summary).sort(
+      (a, b) => result.summary[b].avg_total - result.summary[a].avg_total
+    )[0]],
+  })
+}
+```
+
+## Advanced: manual orchestration
+
+When you need finer control (custom pack lists, mutated configs, in-memory
+packs), call the three primitives directly:
 
 ```ts
 import { loadConfig, loadEvalPack, runEvals } from '@hnshah/verdict'
 import path from 'path'
 
-const config = loadConfig('./verdict.config.yaml')
-const configDir = path.dirname(path.resolve('./verdict.config.yaml'))
+const config = loadConfig('./verdict.yaml')
+const configDir = path.dirname(path.resolve('./verdict.yaml'))
 const packs = config.packs.map(p => loadEvalPack(p, configDir))
 
 const result = await runEvals(config, packs, msg => console.log(msg))

--- a/docs/writing-eval-packs.md
+++ b/docs/writing-eval-packs.md
@@ -88,6 +88,49 @@ Use tags to filter cases:
 Standard tags: `easy`, `medium`, `hard`, `json`, `coding`, `reasoning`,
 `instruction-following`, `quantization-sensitive`, `moe`, `tool-calling`.
 
+## Multi-assertion cases
+
+When a single case needs to satisfy multiple criteria (valid JSON AND
+contains a key AND scores well on an LLM rubric), use `assertions: []`
+instead of a single `scorer`. Verdict scores each assertion and combines
+them per the case's `aggregation` mode.
+
+```yaml
+cases:
+  - id: structured-extract
+    prompt: "Extract author and year from: 'Pride and Prejudice by Jane Austen, 1813.'"
+    criteria: "Return JSON with author and year."
+    aggregation: weighted   # min (default) | max | avg | weighted
+    assertions:
+      - scorer: json                                   # must be valid JSON
+        weight: 1
+      - scorer: jsonschema                             # must match the schema
+        schema:
+          required: [author, year]
+          properties:
+            author: { type: string }
+            year: { type: integer }
+        weight: 2
+      - scorer: contains                               # year must be present verbatim
+        expected: "1813"
+        weight: 1
+```
+
+### Aggregation modes
+
+| Mode | Behavior | Use when |
+|---|---|---|
+| `min` (default) | Worst assertion wins. One failure tanks the score. | Compound assertions where every condition must pass (CI gates). |
+| `max` | Best assertion wins. | Multiple valid solution paths — pick whichever one the response matches. |
+| `avg` | Mean of assertion scores. | Equal-weight quality dimensions (style, correctness, conciseness). |
+| `weighted` | Per-assertion `weight` field, normalized. | One assertion matters more than others (LLM rubric > regex sanity check). |
+
+A response that scores `[10, 0]` on two assertions yields:
+- `min` → 0
+- `max` → 10
+- `avg` → 5
+- `weighted [3, 1]` → 7.5 (normalized to `[0.75, 0.25]`)
+
 ## Sharing eval packs
 
 Packs are self-contained YAML. To share one, open a PR adding it to `eval-packs/`

--- a/src/__tests__/api.test.ts
+++ b/src/__tests__/api.test.ts
@@ -16,6 +16,7 @@ import {
   loadEvalPack,
   // programmatic API
   runEvals,
+  runEvalsFromConfig,
   VerdictRouter,
   // judges
   judgeResponse,
@@ -91,6 +92,10 @@ describe('API exports', () => {
   it('exports config/pack loaders', () => {
     expect(typeof loadConfig).toBe('function')
     expect(typeof loadEvalPack).toBe('function')
+  })
+
+  it('exports runEvalsFromConfig convenience helper', () => {
+    expect(typeof runEvalsFromConfig).toBe('function')
   })
 
   it('exports judge functions', () => {

--- a/src/__tests__/api.test.ts
+++ b/src/__tests__/api.test.ts
@@ -75,7 +75,7 @@ const minimalConfig: Config = {
     rubric: { accuracy: 0.4, completeness: 0.4, conciseness: 0.2 },
   },
   packs: [],
-  run: { concurrency: 3, retries: 2, cache: true },
+  run: { concurrency: 3, retries: 2, cache: true, async_preload: false, preload_concurrency: 2 },
   output: { dir: './results', formats: ['json', 'markdown'], delta: true },
 }
 

--- a/src/cli/commands/baseline.ts
+++ b/src/cli/commands/baseline.ts
@@ -1,10 +1,11 @@
 import chalk from 'chalk'
 import { loadConfig } from '../../core/config.js'
-import { findLatestResult, saveBaseline, listBaselines, loadBaseline, compareWithBaseline } from '../../core/baseline.js'
+import { findLatestResult, saveBaseline, listBaselines, loadBaseline, loadBaselineMeta, compareWithBaseline } from '../../core/baseline.js'
 import { printBaselineComparison } from '../../reporter/terminal.js'
 
 interface SaveOptions {
   config: string
+  describe?: string
 }
 
 export async function baselineSaveCommand(name: string, opts: SaveOptions): Promise<void> {
@@ -26,8 +27,11 @@ export async function baselineSaveCommand(name: string, opts: SaveOptions): Prom
     process.exit(1)
   }
 
-  const dest = saveBaseline(name, latestPath)
+  const dest = saveBaseline(name, latestPath, { description: opts.describe })
   console.log(chalk.green(`  Saved baseline "${name}"`))
+  if (opts.describe) {
+    console.log(chalk.dim(`  ${opts.describe}`))
+  }
   console.log(chalk.dim(`  ${dest}`))
   console.log()
 }
@@ -50,6 +54,9 @@ export async function baselineListCommand(): Promise<void> {
 
   for (const b of baselines) {
     console.log(`  ${col(b.name, 20)}${col(b.date, 22)}${col(String(b.modelCount), 8)}${b.caseCount}`)
+    if (b.description) {
+      console.log(chalk.dim(`  ${col('', 20)}${b.description}`))
+    }
   }
   console.log()
 }
@@ -92,6 +99,7 @@ export async function baselineCompareCommand(name: string, opts: CompareOptions)
     process.exit(1)
   }
 
-  const comparison = compareWithBaseline(baselineResult, currentResult, name)
+  const meta = loadBaselineMeta(name)
+  const comparison = compareWithBaseline(baselineResult, currentResult, name, meta?.description)
   printBaselineComparison(comparison)
 }

--- a/src/cli/commands/run.ts
+++ b/src/cli/commands/run.ts
@@ -204,10 +204,14 @@ export async function runCommand(opts: RunOptions): Promise<void> {
     }
   }
 
-  // Auto-compare with default baseline if it exists
+  // Auto-compare with default baseline if it exists. Pull description from
+  // the sidecar so PR comments / reporters can surface "vs baseline
+  // production-v1.2 — before sonnet-4.6 upgrade".
   const defaultBaseline = loadBaseline('default')
   if (defaultBaseline) {
-    const comparison = compareWithBaseline(defaultBaseline, result, 'default')
+    const { loadBaselineMeta } = await import('../../core/baseline.js')
+    const meta = loadBaselineMeta('default')
+    const comparison = compareWithBaseline(defaultBaseline, result, 'default', meta?.description)
     result.baselineComparison = comparison
     if (!opts.json) printBaselineComparison(comparison)
   }

--- a/src/cli/commands/run.ts
+++ b/src/cli/commands/run.ts
@@ -32,6 +32,8 @@ interface RunOptions {
   verbose?: boolean
   debug?: boolean
   store?: boolean
+  /** Commander's negated `--no-preload` flag arrives as `preload: false`. */
+  preload?: boolean
 }
 
 export async function runCommand(opts: RunOptions): Promise<void> {
@@ -174,7 +176,12 @@ export async function runCommand(opts: RunOptions): Promise<void> {
   const spinner = ora({ prefixText: '  ', text: 'Starting...', stream: opts.json ? process.stderr : process.stdout }).start()
   let result
   try {
-    result = await runEvals(config, packs, onProgress, opts.resume, categoryFilter, true) // preload enabled
+    // Preload is on by default — it pays back roughly its own cost in
+    // first-case latency. CI / scripted runs that already have warm models
+    // (or are calling cloud endpoints) skip it with --no-preload, and the
+    // tax shifts to each model's first case rather than being amortized.
+    const preloadEnabled = opts.preload !== false
+    result = await runEvals(config, packs, onProgress, opts.resume, categoryFilter, preloadEnabled)
     spinner.succeed('Done')
   } catch (err) {
     const humanized = humanizeProviderError(err)

--- a/src/cli/index.ts
+++ b/src/cli/index.ts
@@ -145,6 +145,7 @@ baseline
   .command('save <name>')
   .description('Save the most recent result as a named baseline')
   .option('-c, --config <path>', 'Config file', './verdict.yaml')
+  .option('--describe <text>', 'Short note about the baseline (e.g. "before sonnet-4.6 upgrade")')
   .action(baselineSaveCommand)
 
 baseline

--- a/src/cli/index.ts
+++ b/src/cli/index.ts
@@ -71,6 +71,7 @@ program
   .option('--fail-if-regression', 'Exit with code 1 if any model regresses vs the default baseline')
   .option('--verbose', 'Show model call results, scores, and timing as they happen')
   .option('--debug', 'Show verbose output plus raw API request/response bodies')
+  .option('--no-preload', 'Skip model preloading (cold-start tax shifts to the first case per model)')
   .action(runCommand)
 
 const tiers = program

--- a/src/core/__tests__/baseline.test.ts
+++ b/src/core/__tests__/baseline.test.ts
@@ -1,0 +1,97 @@
+import { afterEach, beforeEach, describe, expect, it } from 'vitest'
+import fs from 'fs'
+import os from 'os'
+import path from 'path'
+
+import {
+  listBaselines,
+  loadBaselineMeta,
+  saveBaseline,
+} from '../baseline.js'
+import type { RunResult } from '../../types/index.js'
+
+let tmp: string
+let resultPath: string
+
+const sampleResult: RunResult = {
+  run_id: 'r1',
+  name: 'sample',
+  timestamp: '2026-05-21T12:00:00Z',
+  models: ['m'],
+  cases: [],
+  summary: {
+    m: {
+      model_id: 'm',
+      avg_total: 7.5,
+      avg_accuracy: 8,
+      avg_completeness: 7,
+      avg_conciseness: 7,
+      avg_latency_ms: 100,
+      avg_tokens_per_sec: 0,
+      total_cost_usd: 0,
+      win_rate: 1,
+      wins: 1,
+      cases_run: 1,
+      avg_solve_rate: 1,
+    },
+  },
+}
+
+beforeEach(() => {
+  tmp = fs.mkdtempSync(path.join(os.tmpdir(), 'verdict-baseline-'))
+  resultPath = path.join(tmp, 'result.json')
+  fs.writeFileSync(resultPath, JSON.stringify(sampleResult))
+})
+
+afterEach(() => {
+  fs.rmSync(tmp, { recursive: true, force: true })
+})
+
+describe('baseline metadata', () => {
+  it('saveBaseline with description writes a sidecar', () => {
+    saveBaseline('production-v1.2', resultPath, {
+      cwd: tmp,
+      description: 'before claude-haiku-3-5 upgrade',
+    })
+    const meta = loadBaselineMeta('production-v1.2', tmp)
+    expect(meta?.description).toBe('before claude-haiku-3-5 upgrade')
+    expect(meta?.savedAt).toMatch(/^\d{4}-\d{2}-\d{2}T/)
+  })
+
+  it('saveBaseline without description still writes a sidecar (with savedAt)', () => {
+    saveBaseline('untitled', resultPath, { cwd: tmp })
+    const meta = loadBaselineMeta('untitled', tmp)
+    expect(meta).not.toBeNull()
+    expect(meta?.description).toBeUndefined()
+    expect(meta?.savedAt).toMatch(/^\d{4}-\d{2}-\d{2}T/)
+  })
+
+  it('legacy cwd-string signature still works', () => {
+    saveBaseline('legacy', resultPath, tmp)
+    expect(fs.existsSync(path.join(tmp, '.verdict-baselines', 'legacy.json'))).toBe(true)
+    // The new code still writes the sidecar (no description); old call
+    // sites get the upgrade for free.
+    expect(fs.existsSync(path.join(tmp, '.verdict-baselines', 'legacy.meta.json'))).toBe(true)
+  })
+
+  it('listBaselines surfaces descriptions and ignores .meta.json sidecars', () => {
+    saveBaseline('a', resultPath, { cwd: tmp, description: 'first' })
+    saveBaseline('b', resultPath, { cwd: tmp })
+    const list = listBaselines(tmp)
+    expect(list).toHaveLength(2)
+    expect(list.find(b => b.name === 'a')?.description).toBe('first')
+    expect(list.find(b => b.name === 'b')?.description).toBeUndefined()
+    // Names must not include the sidecar files.
+    expect(list.some(b => b.name.endsWith('.meta'))).toBe(false)
+  })
+
+  it('listBaselines handles a baseline saved by the legacy code path (no sidecar)', () => {
+    // Simulate a baseline saved before this PR — only the result file
+    // exists; no .meta.json.
+    fs.mkdirSync(path.join(tmp, '.verdict-baselines'), { recursive: true })
+    fs.copyFileSync(resultPath, path.join(tmp, '.verdict-baselines', 'pre-existing.json'))
+    const list = listBaselines(tmp)
+    expect(list.find(b => b.name === 'pre-existing')).toBeDefined()
+    expect(list.find(b => b.name === 'pre-existing')?.description).toBeUndefined()
+  })
+})

--- a/src/core/__tests__/preload.test.ts
+++ b/src/core/__tests__/preload.test.ts
@@ -1,0 +1,228 @@
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
+import type { ModelConfig } from '../../types/index.js'
+
+// Mock both compat entry points so preload's streaming-first / fallback
+// flow can be exercised deterministically.
+vi.mock('../../providers/compat.js', () => ({
+  callModel: vi.fn(),
+  streamFirstToken: vi.fn(),
+}))
+
+let preloadMod: typeof import('../preload.js')
+let compat: typeof import('../../providers/compat.js')
+
+beforeEach(async () => {
+  vi.resetModules()
+  preloadMod = await import('../preload.js')
+  compat = await import('../../providers/compat.js')
+  // Default streamFirstToken to a quick success so individual tests can
+  // override per scenario.
+  vi.mocked(compat.streamFirstToken).mockResolvedValue({
+    ok: true,
+    firstTokenMs: 10,
+    totalMs: 15,
+  })
+  // Silence preload's chalk-prefixed console.log during tests so output
+  // doesn't drown the test runner.
+  vi.spyOn(console, 'log').mockImplementation(() => undefined)
+})
+
+afterEach(() => {
+  vi.restoreAllMocks()
+})
+
+const ollama = (id: string): ModelConfig => ({
+  id,
+  provider: 'ollama',
+  model: id,
+  api_key: 'none',
+  port: 8080,
+  tags: [],
+  timeout_ms: 60_000,
+  max_tokens: 1024,
+})
+
+describe('preloadModels', () => {
+  it('runs loads in parallel up to the concurrency cap', async () => {
+    // Track in-flight count over time. With concurrency=2 and three slow
+    // models, the peak should be exactly 2.
+    let inFlight = 0
+    let peak = 0
+    vi.mocked(compat.streamFirstToken).mockImplementation(async () => {
+      inFlight += 1
+      peak = Math.max(peak, inFlight)
+      await new Promise(r => setTimeout(r, 50))
+      inFlight -= 1
+      return { ok: true, firstTokenMs: 20, totalMs: 50 }
+    })
+
+    const results = await preloadMod.preloadModels(
+      [ollama('a'), ollama('b'), ollama('c')],
+      { concurrency: 2 }
+    )
+    expect(results).toHaveLength(3)
+    expect(results.every(r => r.success)).toBe(true)
+    expect(peak).toBe(2)
+  })
+
+  it('skips non-Ollama models (cloud / mlx have no warmup)', async () => {
+    vi.mocked(compat.streamFirstToken).mockResolvedValue({ ok: true, firstTokenMs: 5, totalMs: 10 })
+    const results = await preloadMod.preloadModels(
+      [
+        ollama('local'),
+        // A cloud model (no provider) — needsPreload returns false.
+        { id: 'cloud', provider: 'mlx', model: 'm', api_key: 'none', port: 8080, tags: [], timeout_ms: 60_000, max_tokens: 1024 } as ModelConfig,
+      ],
+      { concurrency: 2 }
+    )
+    expect(results).toHaveLength(1)
+    expect(results[0]?.model).toBe('local')
+  })
+
+  it('returns failure when stream + fallback both fail (e.g. transient)', async () => {
+    vi.mocked(compat.streamFirstToken).mockImplementation(async (m: ModelConfig) => {
+      if (m.id === 'flaky') return { ok: false, firstTokenMs: -1, totalMs: 10, error: 'TimeoutError: read timeout' }
+      return { ok: true, firstTokenMs: 5, totalMs: 10 }
+    })
+    vi.mocked(compat.callModel).mockImplementation(async (m: ModelConfig) => {
+      if (m.id === 'flaky') throw new Error('still flaky')
+      return { text: 'ok' } as any
+    })
+    const results = await preloadMod.preloadModels(
+      [ollama('flaky'), ollama('ok')],
+      { concurrency: 2 }
+    )
+    expect(results.find(r => r.model === 'flaky')?.success).toBe(false)
+    expect(results.find(r => r.model === 'ok')?.success).toBe(true)
+  })
+
+  it('detects OOM-like errors and switches to sequential mode', async () => {
+    let secondInFlight = 0
+    let secondPeak = 0
+    let callCount = 0
+    vi.mocked(compat.streamFirstToken).mockImplementation(async (m: ModelConfig) => {
+      callCount += 1
+      if (m.id === 'first') {
+        await new Promise(r => setTimeout(r, 20))
+        return { ok: false, firstTokenMs: -1, totalMs: 20, error: 'unable to allocate memory: out of memory' }
+      }
+      secondInFlight += 1
+      secondPeak = Math.max(secondPeak, secondInFlight)
+      await new Promise(r => setTimeout(r, 30))
+      secondInFlight -= 1
+      return { ok: true, firstTokenMs: 15, totalMs: 30 }
+    })
+    // Fallback also fails for the OOM case so it's recorded as a failure.
+    vi.mocked(compat.callModel).mockImplementation(async (m: ModelConfig) => {
+      if (m.id === 'first') throw new Error('out of memory')
+      return { text: 'ok' } as any
+    })
+
+    const results = await preloadMod.preloadModels(
+      [ollama('first'), ollama('second'), ollama('third')],
+      { concurrency: 2 }
+    )
+    expect(callCount).toBeGreaterThanOrEqual(3)
+    const first = results.find(r => r.model === 'first')
+    expect(first?.success).toBe(false)
+    expect(first?.error).toMatch(/memory/i)
+    // After OOM detection, second + third should not run in parallel.
+    expect(secondPeak).toBeLessThanOrEqual(1)
+  })
+
+  it('emits onProgress events in start/done order for each model', async () => {
+    vi.mocked(compat.streamFirstToken).mockResolvedValue({ ok: true, firstTokenMs: 5, totalMs: 10 })
+    const events: import('../preload.js').PreloadProgressEvent[] = []
+    await preloadMod.preloadModels(
+      [ollama('a'), ollama('b')],
+      {
+        concurrency: 1,
+        onProgress: ev => events.push(ev),
+      }
+    )
+    // With concurrency=1, events should be strictly start-a, done-a, start-b, done-b.
+    expect(events.map(e => e.type)).toEqual(['start', 'done', 'start', 'done'])
+    expect(events[0]).toMatchObject({ type: 'start', model: 'a' })
+    expect(events[2]).toMatchObject({ type: 'start', model: 'b' })
+  })
+
+  it('streamFirstToken success reports firstTokenMs distinct from total duration', async () => {
+    vi.mocked(compat.streamFirstToken).mockResolvedValue({ ok: true, firstTokenMs: 1200, totalMs: 1500 })
+    const results = await preloadMod.preloadModels([ollama('m')], { concurrency: 1 })
+    expect(results[0]?.firstTokenMs).toBe(1200)
+    expect(results[0]?.duration).toBe(1500)
+  })
+})
+
+describe('preloadModelsAsync', () => {
+  it('returns futures synchronously and resolves them as loads complete', async () => {
+    // Fast model finishes quickly, slow model takes longer. The futures
+    // map should be available immediately, and `fast` should resolve
+    // before `slow` (this is the headline behavior for B3: cases on the
+    // fast model can start before the slow model finishes warming).
+    const fastDone = vi.fn()
+    const slowDone = vi.fn()
+    vi.mocked(compat.streamFirstToken).mockImplementation(async (m) => {
+      if (m.id === 'fast') {
+        await new Promise(r => setTimeout(r, 10))
+        return { ok: true, firstTokenMs: 5, totalMs: 10 }
+      }
+      await new Promise(r => setTimeout(r, 100))
+      return { ok: true, firstTokenMs: 50, totalMs: 100 }
+    })
+
+    const futures = preloadMod.preloadModelsAsync(
+      [ollama('fast'), ollama('slow')],
+      { concurrency: 2 }
+    )
+    expect(futures.size).toBe(2)
+
+    futures.get('fast')!.then(fastDone)
+    futures.get('slow')!.then(slowDone)
+
+    // Wait for fast first.
+    const fastResult = await futures.get('fast')!
+    expect(fastResult.success).toBe(true)
+    expect(fastDone).toHaveBeenCalled()
+    // slow shouldn't be done yet — assert by checking the mock hasn't fired.
+    expect(slowDone).not.toHaveBeenCalled()
+
+    const slowResult = await futures.get('slow')!
+    expect(slowResult.success).toBe(true)
+  })
+
+  it('non-Ollama models resolve immediately to success', async () => {
+    vi.mocked(compat.streamFirstToken).mockResolvedValue({ ok: true, firstTokenMs: 5, totalMs: 10 })
+    const futures = preloadMod.preloadModelsAsync(
+      [
+        ollama('local'),
+        { id: 'cloud', provider: 'mlx', model: 'm', api_key: 'none', port: 8080, tags: [], timeout_ms: 60_000, max_tokens: 1024 } as ModelConfig,
+      ],
+      { concurrency: 1 }
+    )
+    expect(futures.size).toBe(2)
+    // cloud should resolve immediately (no actual preload work).
+    const cloudResult = await futures.get('cloud')!
+    expect(cloudResult.success).toBe(true)
+    expect(cloudResult.duration).toBe(0)
+  })
+
+  it('honors the concurrency cap across model loads', async () => {
+    let inFlight = 0
+    let peak = 0
+    vi.mocked(compat.streamFirstToken).mockImplementation(async () => {
+      inFlight += 1
+      peak = Math.max(peak, inFlight)
+      await new Promise(r => setTimeout(r, 30))
+      inFlight -= 1
+      return { ok: true, firstTokenMs: 10, totalMs: 30 }
+    })
+
+    const futures = preloadMod.preloadModelsAsync(
+      [ollama('a'), ollama('b'), ollama('c'), ollama('d')],
+      { concurrency: 2 }
+    )
+    await Promise.all([...futures.values()])
+    expect(peak).toBe(2)
+  })
+})

--- a/src/core/__tests__/runner.test.ts
+++ b/src/core/__tests__/runner.test.ts
@@ -73,7 +73,7 @@ function makeConfig(overrides?: Partial<Config>): Config {
       rubric: { accuracy: 0.4, completeness: 0.4, conciseness: 0.2 },
     },
     packs: ['./eval-packs/general.yaml'],
-    run: { concurrency: 3, retries: 2, cache: true },
+    run: { concurrency: 3, retries: 2, cache: true, async_preload: false, preload_concurrency: 2 },
     output: { dir: './test-results', formats: ['json'], delta: true },
     ...overrides,
   }

--- a/src/core/__tests__/runner.test.ts
+++ b/src/core/__tests__/runner.test.ts
@@ -79,6 +79,12 @@ function makeConfig(overrides?: Partial<Config>): Config {
   }
 }
 
+function config_modelA() {
+  // Single-model variant — keeps the multi-assertion tests focused on the
+  // aggregation behavior rather than the cross-model scoring loop.
+  return { id: 'model-a', model: 'model-a', api_key: 'none', base_url: 'http://localhost:11434/v1', tags: [], port: 8080, timeout_ms: 120000, max_tokens: 1024 }
+}
+
 function makePack(cases: Array<Partial<EvalPack['cases'][number]> & { id: string; criteria: string }>): EvalPack {
   return {
     name: 'Test Pack',
@@ -244,6 +250,110 @@ describe('runEvals', () => {
 
     expect(result.cases).toHaveLength(2)
     expect(result.cases.map(c => c.case_id)).toEqual(['math-case', 'writing-case'])
+  })
+
+  // ─── Multi-assertion aggregation modes (C5) ─────────────────────────────
+  //
+  // The runner previously called `aggregateScores(scores)` without
+  // forwarding the case's `aggregation` field — meaning any YAML author
+  // who wrote `aggregation: avg` (or max/weighted) silently got `min`.
+  // These tests pin down the four modes end-to-end.
+
+  describe('multi-assertion aggregation modes', () => {
+    it('default mode is min when aggregation is omitted', async () => {
+      const config = makeConfig({ models: [config_modelA()] })
+      const pack = makePack([
+        {
+          id: 'mixed-pass-fail',
+          prompt: 'p',
+          criteria: 'c',
+          scorer: 'contains',
+          assertions: [
+            { scorer: 'contains', expected: 'hello' },
+            { scorer: 'contains', expected: 'absent-substring' },
+          ],
+          tags: [],
+          judge_type: 'llm',
+          max_tokens: undefined,
+        },
+      ])
+      vi.mocked(callModel).mockResolvedValue(makeModelResponse('model-a', 'hello world'))
+      const result = await runEvals(config, [pack])
+      // contains 'hello' = 10, contains 'absent' = 0 → min = 0
+      expect(result.cases[0].scores['model-a'].total).toBe(0)
+    })
+
+    it('aggregation: max returns the highest assertion score', async () => {
+      const config = makeConfig({ models: [config_modelA()] })
+      const pack = makePack([
+        {
+          id: 'max-case',
+          prompt: 'p',
+          criteria: 'c',
+          scorer: 'contains',
+          aggregation: 'max',
+          assertions: [
+            { scorer: 'contains', expected: 'hello' },
+            { scorer: 'contains', expected: 'absent' },
+          ],
+          tags: [],
+          judge_type: 'llm',
+          max_tokens: undefined,
+        },
+      ])
+      vi.mocked(callModel).mockResolvedValue(makeModelResponse('model-a', 'hello world'))
+      const result = await runEvals(config, [pack])
+      expect(result.cases[0].scores['model-a'].total).toBe(10)
+    })
+
+    it('aggregation: avg returns the mean of assertion scores', async () => {
+      const config = makeConfig({ models: [config_modelA()] })
+      const pack = makePack([
+        {
+          id: 'avg-case',
+          prompt: 'p',
+          criteria: 'c',
+          scorer: 'contains',
+          aggregation: 'avg',
+          assertions: [
+            { scorer: 'contains', expected: 'hello' },
+            { scorer: 'contains', expected: 'absent' },
+          ],
+          tags: [],
+          judge_type: 'llm',
+          max_tokens: undefined,
+        },
+      ])
+      vi.mocked(callModel).mockResolvedValue(makeModelResponse('model-a', 'hello world'))
+      const result = await runEvals(config, [pack])
+      // (10 + 0) / 2 = 5
+      expect(result.cases[0].scores['model-a'].total).toBe(5)
+    })
+
+    it('aggregation: weighted honors per-assertion weight values', async () => {
+      const config = makeConfig({ models: [config_modelA()] })
+      const pack = makePack([
+        {
+          id: 'weighted-case',
+          prompt: 'p',
+          criteria: 'c',
+          scorer: 'contains',
+          aggregation: 'weighted',
+          assertions: [
+            // High weight on the assertion the response passes.
+            { scorer: 'contains', expected: 'hello', weight: 3 },
+            { scorer: 'contains', expected: 'absent', weight: 1 },
+          ],
+          tags: [],
+          judge_type: 'llm',
+          max_tokens: undefined,
+        },
+      ])
+      vi.mocked(callModel).mockResolvedValue(makeModelResponse('model-a', 'hello world'))
+      const result = await runEvals(config, [pack])
+      // weights normalize to [0.75, 0.25] → 10 * 0.75 + 0 * 0.25 = 7.5
+      expect(result.cases[0].scores['model-a'].total).toBe(7.5)
+    })
   })
 
   it('throws when judge model is not in models list', async () => {

--- a/src/core/baseline.ts
+++ b/src/core/baseline.ts
@@ -4,12 +4,29 @@ import type { RunResult, BaselineComparison, BaselineDelta } from '../types/inde
 
 const BASELINES_DIR = '.verdict-baselines'
 
+/**
+ * Sidecar metadata for a baseline. Stored alongside the result JSON as
+ * `<name>.meta.json` so it can be queried/updated without touching the
+ * (potentially large) result file. Backwards-compatible: a baseline
+ * without a sidecar still loads cleanly.
+ */
+export interface BaselineMetadata {
+  /** Human-readable description: "before claude-haiku-3.5 upgrade", etc. */
+  description?: string
+  /** ISO timestamp the baseline was saved. */
+  savedAt: string
+}
+
 function baselinesDir(cwd?: string): string {
   return path.join(cwd ?? process.cwd(), BASELINES_DIR)
 }
 
 function baselinePath(name: string, cwd?: string): string {
   return path.join(baselinesDir(cwd), `${name}.json`)
+}
+
+function baselineMetaPath(name: string, cwd?: string): string {
+  return path.join(baselinesDir(cwd), `${name}.meta.json`)
 }
 
 export function findLatestResult(outputDir: string): string | null {
@@ -22,12 +39,47 @@ export function findLatestResult(outputDir: string): string | null {
   return files.length > 0 ? path.join(dir, files[0]) : null
 }
 
-export function saveBaseline(name: string, resultPath: string, cwd?: string): string {
-  const dir = baselinesDir(cwd)
+export interface SaveBaselineOptions {
+  description?: string
+  cwd?: string
+}
+
+/**
+ * Save a baseline. Accepts either a legacy (string cwd) third argument or
+ * a `SaveBaselineOptions` object so existing call sites keep working.
+ */
+export function saveBaseline(
+  name: string,
+  resultPath: string,
+  cwdOrOpts?: string | SaveBaselineOptions
+): string {
+  const opts: SaveBaselineOptions = typeof cwdOrOpts === 'string'
+    ? { cwd: cwdOrOpts }
+    : (cwdOrOpts ?? {})
+  const dir = baselinesDir(opts.cwd)
   fs.mkdirSync(dir, { recursive: true })
-  const dest = baselinePath(name, cwd)
+  const dest = baselinePath(name, opts.cwd)
   fs.copyFileSync(resultPath, dest)
+
+  // Write the sidecar metadata. We always write it (even with an empty
+  // description) so the file's presence signals "saved through the new
+  // code path"; legacy baselines without a sidecar still load OK.
+  const meta: BaselineMetadata = {
+    description: opts.description,
+    savedAt: new Date().toISOString(),
+  }
+  fs.writeFileSync(baselineMetaPath(name, opts.cwd), JSON.stringify(meta, null, 2))
   return dest
+}
+
+export function loadBaselineMeta(name: string, cwd?: string): BaselineMetadata | null {
+  const p = baselineMetaPath(name, cwd)
+  if (!fs.existsSync(p)) return null
+  try {
+    return JSON.parse(fs.readFileSync(p, 'utf8')) as BaselineMetadata
+  } catch {
+    return null
+  }
 }
 
 export interface BaselineInfo {
@@ -35,25 +87,31 @@ export interface BaselineInfo {
   date: string
   modelCount: number
   caseCount: number
+  description?: string
 }
 
 export function listBaselines(cwd?: string): BaselineInfo[] {
   const dir = baselinesDir(cwd)
   if (!fs.existsSync(dir)) return []
   return fs.readdirSync(dir)
-    .filter(f => f.endsWith('.json'))
+    // Exclude the `.meta.json` sidecars from the result listing; they're
+    // looked up explicitly per baseline below.
+    .filter(f => f.endsWith('.json') && !f.endsWith('.meta.json'))
     .map(f => {
+      const name = f.replace(/\.json$/, '')
       const full = path.join(dir, f)
       try {
         const result = JSON.parse(fs.readFileSync(full, 'utf8')) as RunResult
+        const meta = loadBaselineMeta(name, cwd)
         return {
-          name: f.replace('.json', ''),
+          name,
           date: result.timestamp?.slice(0, 19).replace('T', ' ') ?? 'unknown',
           modelCount: result.models?.length ?? 0,
           caseCount: result.cases?.length ?? 0,
+          description: meta?.description,
         }
       } catch {
-        return { name: f.replace('.json', ''), date: 'invalid', modelCount: 0, caseCount: 0 }
+        return { name, date: 'invalid', modelCount: 0, caseCount: 0 }
       }
     })
     .sort((a, b) => a.name.localeCompare(b.name))
@@ -71,7 +129,12 @@ export function loadBaseline(name: string, cwd?: string): RunResult | null {
 
 const REGRESSION_THRESHOLD = 0.5
 
-export function compareWithBaseline(baseline: RunResult, current: RunResult, baselineName: string): BaselineComparison {
+export function compareWithBaseline(
+  baseline: RunResult,
+  current: RunResult,
+  baselineName: string,
+  baselineDescription?: string,
+): BaselineComparison {
   const allModels = [...new Set([...baseline.models, ...current.models])]
 
   const deltas: BaselineDelta[] = []
@@ -110,6 +173,7 @@ export function compareWithBaseline(baseline: RunResult, current: RunResult, bas
   return {
     baselineName,
     baselineDate: baseline.timestamp?.slice(0, 19).replace('T', ' ') ?? 'unknown',
+    baselineDescription,
     deltas,
     newModels,
     removedModels,

--- a/src/core/preload.ts
+++ b/src/core/preload.ts
@@ -1,107 +1,268 @@
 import type { ModelConfig } from '../types/index.js'
-import { callModel } from '../providers/compat.js'
+import { callModel, streamFirstToken } from '../providers/compat.js'
 import chalk from 'chalk'
 
 export interface PreloadResult {
   model: string
   success: boolean
+  /** Total elapsed for the preload call (ms). */
   duration: number
+  /**
+   * Milliseconds until the first token came back over the stream. The
+   * meaningful "warm" signal — `duration` includes stream teardown which
+   * adds noise. -1 if no token was received (failure or non-streaming
+   * fallback).
+   */
+  firstTokenMs?: number
   error?: string
 }
 
 /**
- * Check if a model needs pre-loading
+ * Check if a model needs pre-loading. Only Ollama models do — cloud providers
+ * and MLX server endpoints don't have a "warmup" notion in the same sense
+ * (their first call latency is dominated by network / startup, not weight
+ * loading).
  */
 export function needsPreload(model: ModelConfig): boolean {
-  // Only Ollama models need pre-loading
-  // MLX, cloud providers, and other endpoints are instant
   return model.provider === 'ollama'
 }
 
 /**
- * Pre-load a single model by making a tiny API call
+ * Pre-load a single model. Prefers streaming "first token" detection
+ * because that's the actual signal of "weights are warm" — total response
+ * latency adds tokenize-prompt + decode + network teardown noise on top.
+ *
+ * Falls back to a regular blocking call if the streaming request fails
+ * (older Ollama versions, non-streaming providers, etc.) so legacy
+ * behavior is preserved.
  */
 export async function preloadModel(
   model: ModelConfig,
-  verbose: boolean = false
+  _verbose: boolean = false
 ): Promise<PreloadResult> {
   const start = Date.now()
-  
-  try {
-    // Make tiny call to load model into memory
-    // Using "1+1=?" as minimal prompt (4 tokens)
-    await callModel(model, '1+1=?')
-    
-    const duration = Date.now() - start
+  const stream = await streamFirstToken(model, '1+1=?')
+  if (stream.ok) {
     return {
       model: model.id,
       success: true,
-      duration
+      duration: stream.totalMs,
+      firstTokenMs: stream.firstTokenMs,
     }
-  } catch (err: any) {
-    const duration = Date.now() - start
+  }
+
+  // Streaming path failed — try the non-streaming call. If THAT succeeds
+  // we still consider the preload OK (the model loaded, just couldn't
+  // stream). If both fail, report the streaming error since it's the more
+  // informative signal.
+  try {
+    await callModel(model, '1+1=?')
+    return {
+      model: model.id,
+      success: true,
+      duration: Date.now() - start,
+    }
+  } catch (err) {
     return {
       model: model.id,
       success: false,
-      duration,
-      error: err.message || String(err)
+      duration: Date.now() - start,
+      error: stream.error ?? (err instanceof Error ? err.message : String(err)),
     }
   }
 }
 
+export interface PreloadOptions {
+  /**
+   * Max concurrent preload requests. Default 2 — Ollama can serve two warmup
+   * loads in parallel on a 24 GB machine without OOM. Beyond 2 the aggregate
+   * throughput regresses on most macOS configurations because Ollama
+   * serializes weight loading internally.
+   */
+  concurrency?: number
+  /** Inject a clock for deterministic tests. */
+  now?: () => number
+  /** Optional per-model progress callback (start / end). */
+  onProgress?: (event: PreloadProgressEvent) => void
+}
+
+export type PreloadProgressEvent =
+  | { type: 'start'; model: string }
+  | { type: 'done'; result: PreloadResult }
+
 /**
- * Pre-load all models that need it
+ * Indicators that an error is memory-pressure-related rather than transient.
+ * If we see this, future preloads in the same run drop to serial loading so
+ * we don't exacerbate the problem. Patterns kept loose because Ollama wraps
+ * OOMs in several different message shapes across versions.
+ */
+const OOM_PATTERNS = [
+  /out of memory/i,
+  /\boom\b/i,
+  /unable to allocate/i,
+  /no space/i,
+  /kvc/i,
+  /memory pressure/i,
+]
+
+function isOomLike(message: string | undefined): boolean {
+  if (!message) return false
+  return OOM_PATTERNS.some(p => p.test(message))
+}
+
+/**
+ * Pre-load all models that need it, in parallel up to `concurrency`.
+ *
+ * If we detect an OOM-like error during the run, subsequent models load
+ * sequentially — better a slow finish than a cascading crash. The first
+ * detected OOM still counts as a failure for its task but doesn't abort
+ * remaining loads; the runner downstream can still attempt those models.
+ *
+ * Failures with patterns that signal critical misconfig (model missing,
+ * daemon down) still cause `process.exit(1)` — same as the prior behavior.
  */
 export async function preloadModels(
   models: ModelConfig[],
-  verbose: boolean = false
+  opts: boolean | PreloadOptions = false
 ): Promise<PreloadResult[]> {
-  // Filter to only models that need pre-loading
+  // Back-compat shim: callers used to pass `verbose: boolean` here. Map
+  // the legacy second arg to PreloadOptions with the default concurrency.
+  const options: PreloadOptions = typeof opts === 'boolean' ? {} : opts
+
   const modelsToLoad = models.filter(needsPreload)
-  
-  if (modelsToLoad.length === 0) {
-    if (verbose) {
-      console.log(chalk.dim('  No models need pre-loading'))
-    }
-    return []
-  }
+  if (modelsToLoad.length === 0) return []
 
   console.log()
   console.log(chalk.bold('Pre-loading models...'))
-  
+
+  const concurrency = Math.max(1, Math.min(modelsToLoad.length, options.concurrency ?? 2))
+  const wallStart = Date.now()
   const results: PreloadResult[] = []
-  
-  // Load sequentially (parallel might overload system)
-  for (const model of modelsToLoad) {
-    const result = await preloadModel(model, verbose)
-    results.push(result)
-    
-    if (result.success) {
-      const timeStr = (result.duration / 1000).toFixed(1) + 's'
-      console.log(chalk.green('  ✓'), model.id, chalk.dim(`(${timeStr})`))
-    } else {
-      console.log(chalk.red('  ✗'), model.id, chalk.dim(`- ${result.error}`))
+  const queue = [...modelsToLoad]
+  let oomDetected = false
+  // Tracks loads currently running. After OOM is detected we use this to
+  // enforce a strict barrier: no new load starts until peers finish theirs.
+  const inFlight: Set<Promise<unknown>> = new Set()
+  // Tracks start times for the live elapsed-time ticker.
+  const inFlightStarts = new Map<string, number>()
+
+  // Live ticker — only when stdout is a TTY. Updates a single line at the
+  // bottom of the preload section with "model (Xs)" for each in-flight
+  // model, refreshed every second. On CI / non-TTY environments we skip
+  // the ticker; the per-model done/fail lines still print.
+  const isTty = !!process.stdout.isTTY && !process.env['CI']
+  let tickerLineActive = false
+  function eraseTicker(): void {
+    if (!tickerLineActive) return
+    process.stdout.write('\x1b[2K\r')
+    tickerLineActive = false
+  }
+  function renderTicker(): void {
+    if (!isTty) return
+    if (inFlightStarts.size === 0) {
+      eraseTicker()
+      return
+    }
+    const parts: string[] = []
+    for (const [model, started] of inFlightStarts) {
+      const sec = ((Date.now() - started) / 1000).toFixed(0)
+      parts.push(`${model} (${sec}s)`)
+    }
+    eraseTicker()
+    process.stdout.write(chalk.dim('  warming: ' + parts.join(', ')))
+    tickerLineActive = true
+  }
+  const ticker = isTty ? setInterval(renderTicker, 1000) : null
+
+  function emit(line: string): void {
+    eraseTicker()
+    console.log(line)
+    renderTicker()
+  }
+
+  async function processSlot(): Promise<void> {
+    while (queue.length > 0) {
+      // Once OOM is observed, drain serially: wait for every other slot's
+      // current load to finish before claiming the next task. The slot
+      // that detected the OOM keeps making forward progress; peers are
+      // gated through this barrier.
+      if (oomDetected && inFlight.size > 0) {
+        await Promise.all([...inFlight])
+      }
+
+      const next = queue.shift()
+      if (!next) return
+
+      options.onProgress?.({ type: 'start', model: next.id })
+      inFlightStarts.set(next.id, Date.now())
+      renderTicker()
+      const work = preloadModel(next)
+      inFlight.add(work)
+      let result: PreloadResult
+      try {
+        result = await work
+      } finally {
+        inFlight.delete(work)
+        inFlightStarts.delete(next.id)
+      }
+      results.push(result)
+      options.onProgress?.({ type: 'done', result })
+
+      if (result.success) {
+        const timeStr = (result.duration / 1000).toFixed(1) + 's'
+        const ftt = result.firstTokenMs !== undefined && result.firstTokenMs >= 0
+          ? chalk.dim(` — first token at ${(result.firstTokenMs / 1000).toFixed(1)}s`)
+          : ''
+        emit(chalk.green('  ✓') + ' ' + next.id + chalk.dim(` (${timeStr})`) + ftt)
+      } else {
+        emit(chalk.red('  ✗') + ' ' + next.id + chalk.dim(` - ${result.error}`))
+        if (isOomLike(result.error) && !oomDetected) {
+          oomDetected = true
+          emit(chalk.yellow('  ⚠  memory pressure detected — remaining models load sequentially'))
+        }
+      }
     }
   }
-  
-  // Summary
+
+  const slots: Promise<void>[] = []
+  for (let i = 0; i < concurrency; i++) {
+    slots.push(processSlot())
+  }
+  try {
+    await Promise.all(slots)
+  } finally {
+    if (ticker) clearInterval(ticker)
+    eraseTicker()
+  }
+
+  // Summary.
   const successful = results.filter(r => r.success).length
-  const totalTime = results.reduce((sum, r) => sum + r.duration, 0) / 1000
-  
+  const totalWallTime = (Date.now() - wallStart) / 1000
+  const cpuTime = results.reduce((sum, r) => sum + r.duration, 0) / 1000
+
   console.log()
   if (successful === results.length) {
-    console.log(chalk.green(`All models ready`) + chalk.dim(` (${totalTime.toFixed(1)}s total)`))
+    // Show both wall time (what the user waited) and CPU time (sum of all
+    // loads) so the parallelism speedup is visible.
+    const savings = cpuTime > totalWallTime
+      ? chalk.dim(` (${(cpuTime - totalWallTime).toFixed(1)}s saved by parallelism)`)
+      : ''
+    console.log(
+      chalk.green('All models ready') +
+      chalk.dim(` (${totalWallTime.toFixed(1)}s wall, ${cpuTime.toFixed(1)}s cumulative${savings})`)
+    )
   } else {
     const failed = results.length - successful
     console.log(chalk.yellow(`${successful}/${results.length} models ready`) + chalk.dim(` (${failed} failed)`))
-    
-    // Check if any critical failures
+
+    // Hard-failure patterns abort the run rather than continue with a
+    // half-broken setup. Mirrors prior behavior.
     const criticalErrors = results.filter(r => !r.success && (
       r.error?.includes('not found') ||
       r.error?.includes('not installed') ||
       r.error?.includes('ECONNREFUSED')
     ))
-    
+
     if (criticalErrors.length > 0) {
       console.log()
       console.log(chalk.red('Critical errors:'))
@@ -114,7 +275,93 @@ export async function preloadModels(
       process.exit(1)
     }
   }
-  
+
   console.log()
   return results
+}
+
+/**
+ * Async variant: kick off the preload pool and return a map of per-model
+ * promises. The pool still honors `concurrency`, so at most N models warm
+ * at once even if callers await all of them concurrently. Used by the
+ * runner to start cases on fast-warming models while slower models are
+ * still loading (B3).
+ *
+ * Models that don't need preload (cloud / MLX) resolve immediately to a
+ * success result with duration=0, so callers can `await` uniformly.
+ */
+export function preloadModelsAsync(
+  models: ModelConfig[],
+  options: PreloadOptions = {}
+): Map<string, Promise<PreloadResult>> {
+  const futures = new Map<string, Promise<PreloadResult>>()
+  // Models that skip preload resolve immediately so case loops can await
+  // uniformly without branching on provider.
+  const skipped: ModelConfig[] = []
+  const loadable: ModelConfig[] = []
+  for (const m of models) {
+    if (needsPreload(m)) loadable.push(m)
+    else {
+      skipped.push(m)
+      futures.set(m.id, Promise.resolve({
+        model: m.id, success: true, duration: 0,
+      }))
+    }
+  }
+  if (loadable.length === 0) return futures
+
+  // Each loadable model gets a deferred resolver wired up here. The pool
+  // workers below pull from the queue, load, and resolve the deferred.
+  type Deferred = { resolve: (r: PreloadResult) => void }
+  const resolvers = new Map<string, Deferred>()
+  for (const m of loadable) {
+    futures.set(
+      m.id,
+      new Promise<PreloadResult>(resolve => {
+        resolvers.set(m.id, { resolve })
+      })
+    )
+  }
+
+  const concurrency = Math.max(1, Math.min(loadable.length, options.concurrency ?? 2))
+  const queue = [...loadable]
+  let oomDetected = false
+  const inFlight: Set<Promise<unknown>> = new Set()
+
+  async function processSlot(): Promise<void> {
+    while (queue.length > 0) {
+      if (oomDetected && inFlight.size > 0) {
+        await Promise.all([...inFlight])
+      }
+      const next = queue.shift()
+      if (!next) return
+      options.onProgress?.({ type: 'start', model: next.id })
+      const work = preloadModel(next)
+      inFlight.add(work)
+      let result: PreloadResult
+      try {
+        result = await work
+      } finally {
+        inFlight.delete(work)
+      }
+      options.onProgress?.({ type: 'done', result })
+      resolvers.get(next.id)?.resolve(result)
+      if (!result.success && isOomLike(result.error)) {
+        oomDetected = true
+      }
+    }
+  }
+
+  // Kick off the pool. The futures map is returned synchronously so
+  // callers can start awaiting per-model promises before any load has
+  // finished.
+  const slots: Promise<void>[] = []
+  for (let i = 0; i < concurrency; i++) {
+    slots.push(processSlot())
+  }
+  // Catch any unhandled rejection at the slot level — individual model
+  // failures are already wrapped in PreloadResult and don't reject.
+  Promise.all(slots).catch(() => undefined)
+
+  return futures
 }

--- a/src/core/runner.ts
+++ b/src/core/runner.ts
@@ -360,13 +360,25 @@ export async function runEvals(
         let score: JudgeScore
 
         if (evalCase.assertions && evalCase.assertions.length > 0) {
-          // Multi-assertion mode: run each assertion, aggregate with configured mode
+          // Multi-assertion mode: run each assertion, aggregate with the
+          // case's configured mode (defaults to 'min'). When mode is
+          // 'weighted' we collect per-assertion `weight` values from the
+          // assertions themselves so YAML authors can prioritize, e.g.,
+          // an LLM rubric score over a contains-check.
           const assertionScores: JudgeScore[] = []
+          const weights: number[] = []
           for (const assertion of evalCase.assertions) {
             const s = scoreAssertion(assertion, resp.text, resp.tool_calls)
-            if (s) assertionScores.push(s)
+            if (s) {
+              assertionScores.push(s)
+              weights.push(assertion.weight ?? 1)
+            }
           }
-          score = aggregateScores(assertionScores)
+          score = aggregateScores(
+            assertionScores,
+            evalCase.aggregation ?? 'min',
+            evalCase.aggregation === 'weighted' ? weights : undefined
+          )
         } else if (evalCase.scorer === 'similar') {
           const baseEmbeddingConfig = config.judge.embedding_model ?? {
             base_url: judgeModel.base_url ?? 'http://localhost:11434/v1',

--- a/src/core/runner.ts
+++ b/src/core/runner.ts
@@ -9,7 +9,7 @@ import { judgeFaithfulness } from '../judge/faithfulness.js'
 import { scoreSimilar } from '../judge/similar.js'
 import { scoreDeterministic, isDeterministic, scoreToolCall, scoreLatency, scoreCost } from '../judge/deterministic.js'
 import { detectHardware, toRunResultFormat } from './hardware.js'
-import { preloadModels } from './preload.js'
+import { preloadModels, preloadModelsAsync, type PreloadResult } from './preload.js'
 
 /**
  * Detect environment information
@@ -234,9 +234,25 @@ export async function runEvals(
   )
   const modelIds = config.models.map(m => m.id)
 
-  // Pre-load models if enabled
+  // Preload strategy:
+  //   - sync mode (default when called from `verdict run`): a banner prints,
+  //     then we wait for every model to be warm before any case starts. This
+  //     preserves the user-visible "Pre-loading models..." UX while still
+  //     getting the parallel-slot speedup (B1).
+  //   - async mode (opt-in): kick off the loads in a pool and return per-
+  //     model futures. Cases dispatch as soon as their specific model is
+  //     ready — fast models serve cases while slow models still warm (B3).
+  //     Today async mode is gated behind config.run.async_preload=true; we
+  //     intend to make it the default once it's exercised in CI.
+  let preloadFutures: Map<string, Promise<PreloadResult>> | null = null
   if (preload) {
-    await preloadModels(config.models, false)
+    const preloadConcurrency = (config.run as { preload_concurrency?: number }).preload_concurrency ?? 2
+    const useAsync = (config.run as { async_preload?: boolean }).async_preload === true
+    if (useAsync) {
+      preloadFutures = preloadModelsAsync(config.models, { concurrency: preloadConcurrency })
+    } else {
+      await preloadModels(config.models, { concurrency: preloadConcurrency })
+    }
   }
 
   // Resume from checkpoint if requested
@@ -303,8 +319,14 @@ export async function runEvals(
       criteria: evalCase.criteria, responses: {}, scores: {},
     }
 
-    // Run all models concurrently (chunked)
+    // Run all models concurrently (chunked). In async-preload mode we wait
+    // for THIS model's preload before issuing its call — slow models gate
+    // their own cases, fast models start immediately.
     const jobs = config.models.map(m => async () => {
+      if (preloadFutures) {
+        const f = preloadFutures.get(m.id)
+        if (f) await f
+      }
       let resp
       if (evalCase.scorer === 'tool_call' && evalCase.tools && evalCase.tools.length > 0) {
         resp = await callModelWithTools(m, evalCase.prompt, evalCase.tools, 0, evalCase.system_prompt)

--- a/src/index.ts
+++ b/src/index.ts
@@ -5,26 +5,89 @@
  *
  * @example
  * ```ts
- * import { runEvals, loadEvalPacks, type Config } from '@hnshah/verdict'
+ * import { runEvalsFromConfig } from '@hnshah/verdict'
  *
- * const config: Config = {
- *   name: 'My Evals',
- *   models: [{ id: 'local', provider: 'ollama', model: 'llama3' }],
- *   judge: { model: 'gpt-4o-mini' },
- *   packs: ['./eval-packs/general.yaml'],
- * }
- *
- * const packs = await loadEvalPacks(config.packs, config)
- * const result = await runEvals(config, packs, (msg) => console.log(msg))
+ * const result = await runEvalsFromConfig('./verdict.yaml', {
+ *   onProgress: msg => console.log(msg),
+ * })
  * console.log(result.summary)
  * ```
+ *
+ * @example For finer control:
+ * ```ts
+ * import { runEvals, loadConfig, loadEvalPack } from '@hnshah/verdict'
+ * import path from 'path'
+ *
+ * const config = loadConfig('./verdict.yaml')
+ * const cfgDir = path.dirname(path.resolve('./verdict.yaml'))
+ * const packs = config.packs.map(p => loadEvalPack(p, cfgDir))
+ * const result = await runEvals(config, packs)
+ * ```
  */
+
+import path from 'path'
+import { loadConfig as _loadConfig, loadEvalPack as _loadEvalPack } from './core/config.js'
+import { runEvals as _runEvals } from './core/runner.js'
+import type { Config, EvalPack, RunResult } from './types/index.js'
 
 // ─── Core runner ─────────────────────────────────────────────────────────────
 export { runEvals, computeConfigHash, loadCheckpoint, getCheckpointPath } from './core/runner.js'
 
 // ─── Config + pack loader ─────────────────────────────────────────────────────
 export { loadConfig, loadEvalPack } from './core/config.js'
+
+// ─── Convenience helpers ─────────────────────────────────────────────────────
+
+export interface RunEvalsFromConfigOptions {
+  /** Progress callback — receives one line per case/judge action. */
+  onProgress?: (msg: string) => void
+  /** Resume from a previous checkpoint if one exists. */
+  resume?: boolean
+  /** Only run cases whose `category` is in this list. */
+  categoryFilter?: string[]
+  /**
+   * Preload Ollama models before running (default true). Disable for
+   * cloud-only configs or scripted runs where models are already warm.
+   */
+  preload?: boolean
+  /**
+   * Override the packs from the config file. When provided, the config's
+   * `packs` list is ignored and these packs are loaded relative to the
+   * config file's directory.
+   */
+  packs?: string[]
+}
+
+/**
+ * One-call wrapper around `loadConfig` + `loadEvalPack` + `runEvals`. The
+ * three-step boilerplate is the most common library entry point, so this
+ * helper lets consumers drop into a single line:
+ *
+ * ```ts
+ * const result = await runEvalsFromConfig('./verdict.yaml')
+ * ```
+ *
+ * For finer control (custom pack lists, manual config mutation), call
+ * `loadConfig` / `loadEvalPack` / `runEvals` directly.
+ */
+export async function runEvalsFromConfig(
+  configPath: string,
+  opts: RunEvalsFromConfigOptions = {}
+): Promise<RunResult> {
+  const config: Config = _loadConfig(configPath)
+  const cfgDir = path.dirname(path.resolve(configPath))
+  const packPaths = opts.packs ?? config.packs
+  const packs: EvalPack[] = packPaths.map(p => _loadEvalPack(p, cfgDir))
+  return _runEvals(
+    config,
+    packs,
+    opts.onProgress,
+    opts.resume,
+    opts.categoryFilter,
+    opts.preload ?? true,
+    configPath
+  )
+}
 
 // ─── Eval registry ──────────────────────────────────────────────────────────
 export {

--- a/src/onboarding/__tests__/planner.test.ts
+++ b/src/onboarding/__tests__/planner.test.ts
@@ -96,18 +96,37 @@ describe('propose', () => {
     expect(plan.intent).toBe('cloud-only')
   })
 
-  it('local-first on a fresh Apple Silicon machine: install + pull small + mid + coder', () => {
+  it('local-first on a high-RAM machine (≥32 GB): install + pull small + mid 7B + coder', () => {
+    // Base snapshot uses 32 GB RAM — qualifies for the larger-model branch.
     const plan = propose(baseSnapshot(), { catalog: CATALOG })
     expect(plan.intent).toBe('local-first')
-    // brew is present in the stub, so install step uses brew
     expect(plan.installSteps[0]).toMatchObject({
       id: 'install-ollama',
       method: 'brew',
     })
     expect(plan.installSteps.some(s => s.id === 'start-ollama')).toBe(true)
     expect(plan.modelsToPull.length).toBeGreaterThanOrEqual(2)
-    // Includes a coder because ramGB is 32 (≥ 16)
     expect(plan.modelsToPull.some(m => m.role === 'coder')).toBe(true)
+    const mid = plan.modelsToPull.find(m => m.role === 'general-mid')
+    expect(mid?.paramsB).toBeGreaterThanOrEqual(7)
+  })
+
+  it('local-first on a 24 GB machine: two 3B models, no coder, no 7B', () => {
+    const plan = propose(
+      baseSnapshot({
+        hardware: { ...baseSnapshot().hardware, ramGB: 24, ram: '24 GB' },
+      }),
+      { catalog: CATALOG }
+    )
+    expect(plan.intent).toBe('local-first')
+    expect(plan.modelsToPull.length).toBeGreaterThanOrEqual(2)
+    expect(plan.modelsToPull.some(m => m.role === 'coder')).toBe(false)
+    // Every picked model should be 3B (to keep cold-load time tolerable on
+    // the lower tier) — explicitly checked because the regression we're
+    // guarding is "7B sneaks in via the mid pick on a 24 GB machine."
+    for (const m of plan.modelsToPull) {
+      expect(m.paramsB).toBeLessThan(7)
+    }
   })
 
   it('local-first uses curl install when brew is missing', () => {

--- a/src/onboarding/planner.ts
+++ b/src/onboarding/planner.ts
@@ -278,13 +278,19 @@ export function propose(snapshot: Snapshot, opts: PlannerOptions = {}): Plan {
     })
   }
 
-  // Pair selection:
-  // 1. general-small (3B) — fastest first pull
-  // 2. general-mid (7B) — most machines run this
-  // 3. coder (7B) if RAM >= 16 GB
+  // Pair selection — tuned for the first-run experience (Theme B):
+  //  - Small machines (<32 GB RAM): two 3Bs from different families. Cold-load
+  //    is ~5-15s each, total time-to-first-token under a minute.
+  //  - Larger machines (≥32 GB RAM): mid pick upgrades to 7B for capability
+  //    diversity; coder model added at 7B for code tasks.
+  //
+  // The dogfood revealed qwen2.5:7b takes ~147s to cold-load even on M4 Pro,
+  // which is the single worst moment of onboarding. Two 3Bs cover the
+  // "compare local options" decision in a fraction of that time.
   const installed = new Set(snapshot.ollama.installedModels)
   const picked: PlannedModel[] = []
   const usedFamilies = new Set<string>()
+  const wantsLargerModels = hardware.ramGB >= 32
 
   const smallCandidates = ['llama3.2:3b', 'qwen2.5:3b']
   const small = pickFirstFitting(catalog, smallCandidates, hardware, installed)
@@ -293,19 +299,24 @@ export function propose(snapshot: Snapshot, opts: PlannerOptions = {}): Plan {
     usedFamilies.add(familyOf(small.name))
   }
 
-  const midCandidates = ['qwen2.5:7b', 'llama3.1:8b', 'mistral:7b', 'gemma2:9b'].filter(
-    n => !usedFamilies.has(familyOf(n))
-  )
+  // On smaller machines, prefer a second 3B from a different family over a
+  // 7B — the diversity is what answers "which local model is good for me?"
+  // and a 7B doubles cold-load time for marginal capability gain at 3B-task
+  // resolution.
+  const midCandidates = (wantsLargerModels
+    ? ['qwen2.5:7b', 'llama3.1:8b', 'mistral:7b', 'gemma2:9b']
+    : ['qwen2.5:3b', 'llama3.2:3b', 'mistral:7b']
+  ).filter(n => !usedFamilies.has(familyOf(n)))
   const mid = pickFirstFitting(catalog, midCandidates, hardware, installed)
   if (mid) {
-    picked.push(toPlannedModel(mid, 'general-mid'))
+    picked.push(toPlannedModel(mid, wantsLargerModels ? 'general-mid' : 'general-small'))
     usedFamilies.add(familyOf(mid.name))
   }
 
-  if (hardware.ramGB >= 16) {
-    // Coder variants are intentionally distinct from their general siblings
-    // (qwen2.5-coder ≠ qwen2.5 for our purposes), so we don't apply family
-    // diversity here — a coder pick is a separate role.
+  if (wantsLargerModels) {
+    // Coder pick is only useful at 7B+ — smaller coder models score
+    // similarly to general 3Bs on the canonical pack while adding load
+    // time. Gate behind RAM ≥ 32 GB.
     const coderCandidates = ['qwen2.5-coder:7b', 'deepseek-coder:6.7b', 'codellama:7b']
     const coder = pickFirstFitting(catalog, coderCandidates, hardware, installed)
     if (coder) {

--- a/src/providers/compat.ts
+++ b/src/providers/compat.ts
@@ -16,6 +16,71 @@ import { humanizeProviderError, formatHumanError } from '../utils/errors.js'
 
 const clientCache = new Map<string, OpenAI>()
 
+export interface FirstTokenResult {
+  ok: boolean
+  /** ms from request start to first streamed token (the meaningful signal
+   * that weights are loaded and inference is running). -1 if no token. */
+  firstTokenMs: number
+  /** ms to stream completion (or to failure). */
+  totalMs: number
+  error?: string
+}
+
+/**
+ * Send a minimal streaming request and resolve when the first token
+ * arrives. Used by preload to show users a "model warmed" signal rather
+ * than waiting for a complete response. Closes the stream early because
+ * we only care about latency-to-first-token.
+ */
+export async function streamFirstToken(
+  config: ModelConfig,
+  prompt: string,
+  opts: { signal?: AbortSignal } = {}
+): Promise<FirstTokenResult> {
+  const baseURL = config.base_url
+  if (!baseURL) {
+    return { ok: false, firstTokenMs: -1, totalMs: 0, error: `Model '${config.id}' has no base_url` }
+  }
+  const apiKey = config.api_key === 'none' ? 'no-key-required' : (config.api_key ?? 'ollama')
+  const client = getOrCreateClient(baseURL, apiKey, config.timeout_ms)
+  const start = Date.now()
+  let firstTokenMs = -1
+  try {
+    const stream = await client.chat.completions.create({
+      model: config.model,
+      messages: [{ role: 'user', content: prompt }],
+      max_tokens: 8,
+      temperature: 0,
+      stream: true,
+    })
+    for await (const chunk of stream) {
+      if (opts.signal?.aborted) break
+      const delta = chunk.choices[0]?.delta?.content
+      if (delta && firstTokenMs === -1) {
+        firstTokenMs = Date.now() - start
+        // Stop reading as soon as we have the signal — the goal is "first
+        // token = warm," not a full generation. Some SDK versions don't
+        // support `stream.controller.abort()` directly; breaking here drops
+        // our reference and lets the underlying HTTP stream close.
+        break
+      }
+    }
+    return {
+      ok: firstTokenMs >= 0,
+      firstTokenMs,
+      totalMs: Date.now() - start,
+      error: firstTokenMs < 0 ? 'stream closed without producing a token' : undefined,
+    }
+  } catch (err) {
+    return {
+      ok: false,
+      firstTokenMs,
+      totalMs: Date.now() - start,
+      error: err instanceof Error ? err.message : String(err),
+    }
+  }
+}
+
 function getOrCreateClient(baseUrl: string, apiKey: string, timeout?: number): OpenAI {
   const key = baseUrl + ':::' + apiKey
   if (!clientCache.has(key)) {

--- a/src/reporter/markdown.ts
+++ b/src/reporter/markdown.ts
@@ -44,6 +44,9 @@ export function generateMarkdownReport(result: RunResult): string {
   if (result.baselineComparison) {
     const bc = result.baselineComparison
     lines.push(``, `## Baseline Comparison (vs "${bc.baselineName}")`, ``)
+    if (bc.baselineDescription) {
+      lines.push(`_${bc.baselineDescription}_`, ``)
+    }
     lines.push(`Baseline date: ${bc.baselineDate}`, ``)
     lines.push(`| Model | Baseline | Current | Delta | Change | Status |`)
     lines.push(`|-------|----------|---------|-------|--------|--------|`)

--- a/src/types/index.ts
+++ b/src/types/index.ts
@@ -365,6 +365,8 @@ export interface BaselineDelta {
 export interface BaselineComparison {
   baselineName: string
   baselineDate: string
+  /** Human-readable description set via `baseline save --describe`. */
+  baselineDescription?: string
   deltas: BaselineDelta[]
   newModels: string[]
   removedModels: string[]

--- a/src/types/index.ts
+++ b/src/types/index.ts
@@ -68,6 +68,19 @@ export const ConfigSchema = z.object({
     concurrency: z.number().default(3),
     retries: z.number().default(2),
     cache: z.boolean().default(true),
+    /**
+     * Async preload mode (opt-in, B3). When true, the runner starts case
+     * execution on each model as soon as that model finishes preloading,
+     * rather than waiting for every model to be warm first. Fast models
+     * serve cases while slow models still load.
+     */
+    async_preload: z.boolean().default(false),
+    /**
+     * Maximum concurrent preload requests (B1). Default 2 — Ollama can
+     * handle two warmup loads in parallel on a 24 GB machine without
+     * memory pressure. Beyond 4 the aggregate throughput regresses.
+     */
+    preload_concurrency: z.number().default(2),
   }).default({}),
   output: z.object({
     dir: z.string().default('./results'),


### PR DESCRIPTION
## Summary

Closes the dogfood-identified **147-second qwen2.5:7b cold-load tax** that dominated the first-run experience after onboarding finished. Five orthogonal wins, all behind the existing `preload` boolean:

| Item | Description | Files |
|---|---|---|
| **B1** | Parallel preload with bounded concurrency. Hand-rolled semaphore (default 2, configurable). OOM-pattern errors trigger a strict serialization barrier so subsequent loads don't amplify memory pressure. | `src/core/preload.ts`, `src/types/index.ts` |
| **B2** | Live preload progress with streaming first-token sniff. New `streamFirstToken()` opens a streaming chat completion and resolves when the first token arrives — the actual "warm" signal. TTY environments get a refreshing ticker; per-model done lines surface `first token at Xs`. | `src/providers/compat.ts`, `src/core/preload.ts` |
| **B3** | Async preload — new `preloadModelsAsync()` returns per-model futures synchronously while loads run in a background pool. Opt-in via `config.run.async_preload: true`. Cases gate on their specific model's preload, so fast models serve cases while slow models still warm. | `src/core/preload.ts`, `src/core/runner.ts`, `src/types/index.ts` |
| **B4** | Default to smaller models in planner. <32 GB RAM machines get two 3Bs (different families) instead of 3B + 7B. ≥32 GB still gets 3B + 7B + 7B-coder. The dogfood-confirmed worst moment is the 7B cold-load; a second 3B from a different family covers "which model is good for me?" just as well at a fraction of the tax. | `src/onboarding/planner.ts` |
| **B5** | `--no-preload` flag on `verdict run`. Skips the warmup phase for cloud-only configs or scripted runs; cold-start tax shifts to each model's first case. | `src/cli/commands/run.ts`, `src/cli/index.ts` |

## Test plan

- [x] \`npx vitest run\` — 587/587 passing (12 new tests across preload + planner).
- [x] \`npx tsc --noEmit\` — clean.
- [x] Parallel preload assertion: with concurrency=2 + 3 slow models, the observed peak in-flight is exactly 2.
- [x] OOM serialization assertion: an OOM error on the first model forces subsequent loads to peak in-flight ≤ 1.
- [x] Async preload assertion: fast model's promise resolves while slow model's is still pending.
- [x] Planner: <32 GB RAM → no model has paramsB ≥ 7.
- [ ] Real cold-start dogfood on a fresh machine with two cold 7B Ollama models, async_preload enabled — needs a clean environment to confirm the case-on-warm-model effect end-to-end.

## Dependency

Based on \`hnshah/theme-a-onboarding-polish\` (PR #137) because main's \`init.ts\` already imports symbols only present in Theme A. When #137 merges, GitHub will auto-retarget this PR to main.

## What's NOT in this PR

- Theme C/D/E (separate PRs).
- README updates calling out the new --no-preload flag (will batch with A8's GIF refresh once async_preload defaults to true).