### PR TITLE
feat(ci): theme C — baseline tagging + API helper + Action v1 + multi-assertion bugfix

### DIFF
--- a/.github/workflows/release-v1-tag.yml
+++ b/.github/workflows/release-v1-tag.yml
@@ -1,0 +1,44 @@
+name: Update v1 tag pointer
+
+# Keep a moving `v1` tag aligned with the latest `v1.*` release so users
+# can pin to `hnshah/verdict@v1` in their GitHub Actions workflows and get
+# bugfix + minor-version updates automatically without re-pinning.
+#
+# Triggered when a release is published; if its tag is v1.x.y the v1
+# pointer is force-updated to that commit. Same pattern as actions/checkout,
+# actions/setup-node, etc.
+
+on:
+  release:
+    types: [published]
+
+permissions:
+  contents: write
+
+jobs:
+  retag:
+    if: startsWith(github.event.release.tag_name, 'v1.')
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+        with:
+          fetch-depth: 0
+
+      - name: Move v1 tag to the released commit
+        env:
+          RELEASE_TAG: ${{ github.event.release.tag_name }}
+        run: |
+          set -euo pipefail
+          git config user.name 'github-actions[bot]'
+          git config user.email 'github-actions[bot]@users.noreply.github.com'
+
+          # The release tag (e.g. v1.2.3) should already exist; resolve it to
+          # the canonical commit SHA.
+          TARGET_SHA="$(git rev-list -n 1 "$RELEASE_TAG")"
+          echo "v1 → $TARGET_SHA (from $RELEASE_TAG)"
+
+          # Force-move the v1 tag locally + push. Force is intentional and
+          # standard for moving major-version tags.
+          git tag -f v1 "$TARGET_SHA"
+          git push origin --force v1

--- a/README.md
+++ b/README.md
@@ -660,6 +660,32 @@ verdict run --json --fail-if-regression
 # → Exit 1 if new model worse than baseline
 ```
 
+**GitHub Action** (`uses: hnshah/verdict@v1`):
+
+```yaml
+# .github/workflows/eval.yml
+on:
+  pull_request:
+    paths: ['prompts/**', 'verdict.yaml', 'eval-packs/**']
+
+jobs:
+  verdict:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - uses: hnshah/verdict@v1
+        with:
+          config: verdict.yaml
+          fail-if-regression: true
+          comment-on-pr: true   # posts a sticky leaderboard-diff comment
+        env:
+          OPENROUTER_API_KEY: ${{ secrets.OPENROUTER_API_KEY }}
+```
+
+The `v1` tag follows the latest `v1.x.y` release — bugfix and minor
+updates flow in automatically. Pin to a specific `v1.2.3` if you need
+reproducibility.
+
 ### 4. Cost Optimization
 
 **Goal:** Find cheapest model that meets quality bar

--- a/docs/programmatic-api.md
+++ b/docs/programmatic-api.md
@@ -8,14 +8,64 @@ Use Verdict as a library in your own scripts, CI pipelines, or custom tools.
 npm install @hnshah/verdict
 ```
 
-## Quick Start
+## Quick Start (one-liner)
+
+```ts
+import { runEvalsFromConfig } from '@hnshah/verdict'
+
+const result = await runEvalsFromConfig('./verdict.yaml', {
+  onProgress: msg => console.log(msg),
+})
+
+console.log(`Run: ${result.run_id}`)
+for (const [modelId, summary] of Object.entries(result.summary)) {
+  console.log(`${modelId}: ${summary.avg_total.toFixed(2)}/10 — ${summary.cases_run} cases`)
+}
+```
+
+`runEvalsFromConfig` loads the YAML, resolves eval packs relative to the
+config's directory, and runs everything in one shot. Use it when the
+config file is the source of truth.
+
+### Options
+
+```ts
+type RunEvalsFromConfigOptions = {
+  onProgress?: (msg: string) => void
+  resume?: boolean           // resume from checkpoint
+  categoryFilter?: string[]  // only run these case categories
+  preload?: boolean          // default true; disable for cloud-only configs
+  packs?: string[]           // override config.packs (paths relative to config dir)
+}
+```
+
+### Embed in a Next.js / Express route
+
+```ts
+// app/api/eval/route.ts
+import { runEvalsFromConfig } from '@hnshah/verdict'
+
+export async function POST() {
+  const result = await runEvalsFromConfig('./verdict.yaml', { preload: false })
+  return Response.json({
+    winner: result.summary[Object.keys(result.summary).sort(
+      (a, b) => result.summary[b].avg_total - result.summary[a].avg_total
+    )[0]],
+  })
+}
+```
+
+## Advanced: manual orchestration
+
+When you need finer control (custom pack lists, mutated configs, in-memory
+packs), call the three primitives directly:
 
 ```ts
 import { loadConfig, loadEvalPack, runEvals } from '@hnshah/verdict'
 import path from 'path'
 
-const config = loadConfig('./verdict.config.yaml')
-const configDir = path.dirname(path.resolve('./verdict.config.yaml'))
+const config = loadConfig('./verdict.yaml')
+const configDir = path.dirname(path.resolve('./verdict.yaml'))
 const packs = config.packs.map(p => loadEvalPack(p, configDir))
 
 const result = await runEvals(config, packs, msg => console.log(msg))

--- a/docs/writing-eval-packs.md
+++ b/docs/writing-eval-packs.md
@@ -88,6 +88,49 @@ Use tags to filter cases:
 Standard tags: `easy`, `medium`, `hard`, `json`, `coding`, `reasoning`,
 `instruction-following`, `quantization-sensitive`, `moe`, `tool-calling`.
 
+## Multi-assertion cases
+
+When a single case needs to satisfy multiple criteria (valid JSON AND
+contains a key AND scores well on an LLM rubric), use `assertions: []`
+instead of a single `scorer`. Verdict scores each assertion and combines
+them per the case's `aggregation` mode.
+
+```yaml
+cases:
+  - id: structured-extract
+    prompt: "Extract author and year from: 'Pride and Prejudice by Jane Austen, 1813.'"
+    criteria: "Return JSON with author and year."
+    aggregation: weighted   # min (default) | max | avg | weighted
+    assertions:
+      - scorer: json                                   # must be valid JSON
+        weight: 1
+      - scorer: jsonschema                             # must match the schema
+        schema:
+          required: [author, year]
+          properties:
+            author: { type: string }
+            year: { type: integer }
+        weight: 2
+      - scorer: contains                               # year must be present verbatim
+        expected: "1813"
+        weight: 1
+```
+
+### Aggregation modes
+
+| Mode | Behavior | Use when |
+|---|---|---|
+| `min` (default) | Worst assertion wins. One failure tanks the score. | Compound assertions where every condition must pass (CI gates). |
+| `max` | Best assertion wins. | Multiple valid solution paths — pick whichever one the response matches. |
+| `avg` | Mean of assertion scores. | Equal-weight quality dimensions (style, correctness, conciseness). |
+| `weighted` | Per-assertion `weight` field, normalized. | One assertion matters more than others (LLM rubric > regex sanity check). |
+
+A response that scores `[10, 0]` on two assertions yields:
+- `min` → 0
+- `max` → 10
+- `avg` → 5
+- `weighted [3, 1]` → 7.5 (normalized to `[0.75, 0.25]`)
+
 ## Sharing eval packs
 
 Packs are self-contained YAML. To share one, open a PR adding it to `eval-packs/`

--- a/src/__tests__/api.test.ts
+++ b/src/__tests__/api.test.ts
@@ -16,6 +16,7 @@ import {
   loadEvalPack,
   // programmatic API
   runEvals,
+  runEvalsFromConfig,
   VerdictRouter,
   // judges
   judgeResponse,
@@ -91,6 +92,10 @@ describe('API exports', () => {
   it('exports config/pack loaders', () => {
     expect(typeof loadConfig).toBe('function')
     expect(typeof loadEvalPack).toBe('function')
+  })
+
+  it('exports runEvalsFromConfig convenience helper', () => {
+    expect(typeof runEvalsFromConfig).toBe('function')
   })
 
   it('exports judge functions', () => {

--- a/src/cli/commands/baseline.ts
+++ b/src/cli/commands/baseline.ts
@@ -1,10 +1,11 @@
 import chalk from 'chalk'
 import { loadConfig } from '../../core/config.js'
-import { findLatestResult, saveBaseline, listBaselines, loadBaseline, compareWithBaseline } from '../../core/baseline.js'
+import { findLatestResult, saveBaseline, listBaselines, loadBaseline, loadBaselineMeta, compareWithBaseline } from '../../core/baseline.js'
 import { printBaselineComparison } from '../../reporter/terminal.js'
 
 interface SaveOptions {
   config: string
+  describe?: string
 }
 
 export async function baselineSaveCommand(name: string, opts: SaveOptions): Promise<void> {
@@ -26,8 +27,11 @@ export async function baselineSaveCommand(name: string, opts: SaveOptions): Prom
     process.exit(1)
   }
 
-  const dest = saveBaseline(name, latestPath)
+  const dest = saveBaseline(name, latestPath, { description: opts.describe })
   console.log(chalk.green(`  Saved baseline "${name}"`))
+  if (opts.describe) {
+    console.log(chalk.dim(`  ${opts.describe}`))
+  }
   console.log(chalk.dim(`  ${dest}`))
   console.log()
 }
@@ -50,6 +54,9 @@ export async function baselineListCommand(): Promise<void> {
 
   for (const b of baselines) {
     console.log(`  ${col(b.name, 20)}${col(b.date, 22)}${col(String(b.modelCount), 8)}${b.caseCount}`)
+    if (b.description) {
+      console.log(chalk.dim(`  ${col('', 20)}${b.description}`))
+    }
   }
   console.log()
 }
@@ -92,6 +99,7 @@ export async function baselineCompareCommand(name: string, opts: CompareOptions)
     process.exit(1)
   }
 
-  const comparison = compareWithBaseline(baselineResult, currentResult, name)
+  const meta = loadBaselineMeta(name)
+  const comparison = compareWithBaseline(baselineResult, currentResult, name, meta?.description)
   printBaselineComparison(comparison)
 }

--- a/src/cli/commands/run.ts
+++ b/src/cli/commands/run.ts
@@ -204,10 +204,14 @@ export async function runCommand(opts: RunOptions): Promise<void> {
     }
   }
 
-  // Auto-compare with default baseline if it exists
+  // Auto-compare with default baseline if it exists. Pull description from
+  // the sidecar so PR comments / reporters can surface "vs baseline
+  // production-v1.2 — before sonnet-4.6 upgrade".
   const defaultBaseline = loadBaseline('default')
   if (defaultBaseline) {
-    const comparison = compareWithBaseline(defaultBaseline, result, 'default')
+    const { loadBaselineMeta } = await import('../../core/baseline.js')
+    const meta = loadBaselineMeta('default')
+    const comparison = compareWithBaseline(defaultBaseline, result, 'default', meta?.description)
     result.baselineComparison = comparison
     if (!opts.json) printBaselineComparison(comparison)
   }

--- a/src/cli/index.ts
+++ b/src/cli/index.ts
@@ -145,6 +145,7 @@ baseline
   .command('save <name>')
   .description('Save the most recent result as a named baseline')
   .option('-c, --config <path>', 'Config file', './verdict.yaml')
+  .option('--describe <text>', 'Short note about the baseline (e.g. "before sonnet-4.6 upgrade")')
   .action(baselineSaveCommand)
 
 baseline

--- a/src/core/__tests__/baseline.test.ts
+++ b/src/core/__tests__/baseline.test.ts
@@ -1,0 +1,97 @@
+import { afterEach, beforeEach, describe, expect, it } from 'vitest'
+import fs from 'fs'
+import os from 'os'
+import path from 'path'
+
+import {
+  listBaselines,
+  loadBaselineMeta,
+  saveBaseline,
+} from '../baseline.js'
+import type { RunResult } from '../../types/index.js'
+
+let tmp: string
+let resultPath: string
+
+const sampleResult: RunResult = {
+  run_id: 'r1',
+  name: 'sample',
+  timestamp: '2026-05-21T12:00:00Z',
+  models: ['m'],
+  cases: [],
+  summary: {
+    m: {
+      model_id: 'm',
+      avg_total: 7.5,
+      avg_accuracy: 8,
+      avg_completeness: 7,
+      avg_conciseness: 7,
+      avg_latency_ms: 100,
+      avg_tokens_per_sec: 0,
+      total_cost_usd: 0,
+      win_rate: 1,
+      wins: 1,
+      cases_run: 1,
+      avg_solve_rate: 1,
+    },
+  },
+}
+
+beforeEach(() => {
+  tmp = fs.mkdtempSync(path.join(os.tmpdir(), 'verdict-baseline-'))
+  resultPath = path.join(tmp, 'result.json')
+  fs.writeFileSync(resultPath, JSON.stringify(sampleResult))
+})
+
+afterEach(() => {
+  fs.rmSync(tmp, { recursive: true, force: true })
+})
+
+describe('baseline metadata', () => {
+  it('saveBaseline with description writes a sidecar', () => {
+    saveBaseline('production-v1.2', resultPath, {
+      cwd: tmp,
+      description: 'before claude-haiku-3-5 upgrade',
+    })
+    const meta = loadBaselineMeta('production-v1.2', tmp)
+    expect(meta?.description).toBe('before claude-haiku-3-5 upgrade')
+    expect(meta?.savedAt).toMatch(/^\d{4}-\d{2}-\d{2}T/)
+  })
+
+  it('saveBaseline without description still writes a sidecar (with savedAt)', () => {
+    saveBaseline('untitled', resultPath, { cwd: tmp })
+    const meta = loadBaselineMeta('untitled', tmp)
+    expect(meta).not.toBeNull()
+    expect(meta?.description).toBeUndefined()
+    expect(meta?.savedAt).toMatch(/^\d{4}-\d{2}-\d{2}T/)
+  })
+
+  it('legacy cwd-string signature still works', () => {
+    saveBaseline('legacy', resultPath, tmp)
+    expect(fs.existsSync(path.join(tmp, '.verdict-baselines', 'legacy.json'))).toBe(true)
+    // The new code still writes the sidecar (no description); old call
+    // sites get the upgrade for free.
+    expect(fs.existsSync(path.join(tmp, '.verdict-baselines', 'legacy.meta.json'))).toBe(true)
+  })
+
+  it('listBaselines surfaces descriptions and ignores .meta.json sidecars', () => {
+    saveBaseline('a', resultPath, { cwd: tmp, description: 'first' })
+    saveBaseline('b', resultPath, { cwd: tmp })
+    const list = listBaselines(tmp)
+    expect(list).toHaveLength(2)
+    expect(list.find(b => b.name === 'a')?.description).toBe('first')
+    expect(list.find(b => b.name === 'b')?.description).toBeUndefined()
+    // Names must not include the sidecar files.
+    expect(list.some(b => b.name.endsWith('.meta'))).toBe(false)
+  })
+
+  it('listBaselines handles a baseline saved by the legacy code path (no sidecar)', () => {
+    // Simulate a baseline saved before this PR — only the result file
+    // exists; no .meta.json.
+    fs.mkdirSync(path.join(tmp, '.verdict-baselines'), { recursive: true })
+    fs.copyFileSync(resultPath, path.join(tmp, '.verdict-baselines', 'pre-existing.json'))
+    const list = listBaselines(tmp)
+    expect(list.find(b => b.name === 'pre-existing')).toBeDefined()
+    expect(list.find(b => b.name === 'pre-existing')?.description).toBeUndefined()
+  })
+})

--- a/src/core/__tests__/runner.test.ts
+++ b/src/core/__tests__/runner.test.ts
@@ -79,6 +79,12 @@ function makeConfig(overrides?: Partial<Config>): Config {
   }
 }
 
+function config_modelA() {
+  // Single-model variant — keeps the multi-assertion tests focused on the
+  // aggregation behavior rather than the cross-model scoring loop.
+  return { id: 'model-a', model: 'model-a', api_key: 'none', base_url: 'http://localhost:11434/v1', tags: [], port: 8080, timeout_ms: 120000, max_tokens: 1024 }
+}
+
 function makePack(cases: Array<Partial<EvalPack['cases'][number]> & { id: string; criteria: string }>): EvalPack {
   return {
     name: 'Test Pack',
@@ -244,6 +250,110 @@ describe('runEvals', () => {
 
     expect(result.cases).toHaveLength(2)
     expect(result.cases.map(c => c.case_id)).toEqual(['math-case', 'writing-case'])
+  })
+
+  // ─── Multi-assertion aggregation modes (C5) ─────────────────────────────
+  //
+  // The runner previously called `aggregateScores(scores)` without
+  // forwarding the case's `aggregation` field — meaning any YAML author
+  // who wrote `aggregation: avg` (or max/weighted) silently got `min`.
+  // These tests pin down the four modes end-to-end.
+
+  describe('multi-assertion aggregation modes', () => {
+    it('default mode is min when aggregation is omitted', async () => {
+      const config = makeConfig({ models: [config_modelA()] })
+      const pack = makePack([
+        {
+          id: 'mixed-pass-fail',
+          prompt: 'p',
+          criteria: 'c',
+          scorer: 'contains',
+          assertions: [
+            { scorer: 'contains', expected: 'hello' },
+            { scorer: 'contains', expected: 'absent-substring' },
+          ],
+          tags: [],
+          judge_type: 'llm',
+          max_tokens: undefined,
+        },
+      ])
+      vi.mocked(callModel).mockResolvedValue(makeModelResponse('model-a', 'hello world'))
+      const result = await runEvals(config, [pack])
+      // contains 'hello' = 10, contains 'absent' = 0 → min = 0
+      expect(result.cases[0].scores['model-a'].total).toBe(0)
+    })
+
+    it('aggregation: max returns the highest assertion score', async () => {
+      const config = makeConfig({ models: [config_modelA()] })
+      const pack = makePack([
+        {
+          id: 'max-case',
+          prompt: 'p',
+          criteria: 'c',
+          scorer: 'contains',
+          aggregation: 'max',
+          assertions: [
+            { scorer: 'contains', expected: 'hello' },
+            { scorer: 'contains', expected: 'absent' },
+          ],
+          tags: [],
+          judge_type: 'llm',
+          max_tokens: undefined,
+        },
+      ])
+      vi.mocked(callModel).mockResolvedValue(makeModelResponse('model-a', 'hello world'))
+      const result = await runEvals(config, [pack])
+      expect(result.cases[0].scores['model-a'].total).toBe(10)
+    })
+
+    it('aggregation: avg returns the mean of assertion scores', async () => {
+      const config = makeConfig({ models: [config_modelA()] })
+      const pack = makePack([
+        {
+          id: 'avg-case',
+          prompt: 'p',
+          criteria: 'c',
+          scorer: 'contains',
+          aggregation: 'avg',
+          assertions: [
+            { scorer: 'contains', expected: 'hello' },
+            { scorer: 'contains', expected: 'absent' },
+          ],
+          tags: [],
+          judge_type: 'llm',
+          max_tokens: undefined,
+        },
+      ])
+      vi.mocked(callModel).mockResolvedValue(makeModelResponse('model-a', 'hello world'))
+      const result = await runEvals(config, [pack])
+      // (10 + 0) / 2 = 5
+      expect(result.cases[0].scores['model-a'].total).toBe(5)
+    })
+
+    it('aggregation: weighted honors per-assertion weight values', async () => {
+      const config = makeConfig({ models: [config_modelA()] })
+      const pack = makePack([
+        {
+          id: 'weighted-case',
+          prompt: 'p',
+          criteria: 'c',
+          scorer: 'contains',
+          aggregation: 'weighted',
+          assertions: [
+            // High weight on the assertion the response passes.
+            { scorer: 'contains', expected: 'hello', weight: 3 },
+            { scorer: 'contains', expected: 'absent', weight: 1 },
+          ],
+          tags: [],
+          judge_type: 'llm',
+          max_tokens: undefined,
+        },
+      ])
+      vi.mocked(callModel).mockResolvedValue(makeModelResponse('model-a', 'hello world'))
+      const result = await runEvals(config, [pack])
+      // weights normalize to [0.75, 0.25] → 10 * 0.75 + 0 * 0.25 = 7.5
+      expect(result.cases[0].scores['model-a'].total).toBe(7.5)
+    })
   })
 
   it('throws when judge model is not in models list', async () => {

--- a/src/core/baseline.ts
+++ b/src/core/baseline.ts
@@ -4,12 +4,29 @@ import type { RunResult, BaselineComparison, BaselineDelta } from '../types/inde
 
 const BASELINES_DIR = '.verdict-baselines'
 
+/**
+ * Sidecar metadata for a baseline. Stored alongside the result JSON as
+ * `<name>.meta.json` so it can be queried/updated without touching the
+ * (potentially large) result file. Backwards-compatible: a baseline
+ * without a sidecar still loads cleanly.
+ */
+export interface BaselineMetadata {
+  /** Human-readable description: "before claude-haiku-3.5 upgrade", etc. */
+  description?: string
+  /** ISO timestamp the baseline was saved. */
+  savedAt: string
+}
+
 function baselinesDir(cwd?: string): string {
   return path.join(cwd ?? process.cwd(), BASELINES_DIR)
 }
 
 function baselinePath(name: string, cwd?: string): string {
   return path.join(baselinesDir(cwd), `${name}.json`)
+}
+
+function baselineMetaPath(name: string, cwd?: string): string {
+  return path.join(baselinesDir(cwd), `${name}.meta.json`)
 }
 
 export function findLatestResult(outputDir: string): string | null {
@@ -22,12 +39,47 @@ export function findLatestResult(outputDir: string): string | null {
   return files.length > 0 ? path.join(dir, files[0]) : null
 }
 
-export function saveBaseline(name: string, resultPath: string, cwd?: string): string {
-  const dir = baselinesDir(cwd)
+export interface SaveBaselineOptions {
+  description?: string
+  cwd?: string
+}
+
+/**
+ * Save a baseline. Accepts either a legacy (string cwd) third argument or
+ * a `SaveBaselineOptions` object so existing call sites keep working.
+ */
+export function saveBaseline(
+  name: string,
+  resultPath: string,
+  cwdOrOpts?: string | SaveBaselineOptions
+): string {
+  const opts: SaveBaselineOptions = typeof cwdOrOpts === 'string'
+    ? { cwd: cwdOrOpts }
+    : (cwdOrOpts ?? {})
+  const dir = baselinesDir(opts.cwd)
   fs.mkdirSync(dir, { recursive: true })
-  const dest = baselinePath(name, cwd)
+  const dest = baselinePath(name, opts.cwd)
   fs.copyFileSync(resultPath, dest)
+
+  // Write the sidecar metadata. We always write it (even with an empty
+  // description) so the file's presence signals "saved through the new
+  // code path"; legacy baselines without a sidecar still load OK.
+  const meta: BaselineMetadata = {
+    description: opts.description,
+    savedAt: new Date().toISOString(),
+  }
+  fs.writeFileSync(baselineMetaPath(name, opts.cwd), JSON.stringify(meta, null, 2))
   return dest
+}
+
+export function loadBaselineMeta(name: string, cwd?: string): BaselineMetadata | null {
+  const p = baselineMetaPath(name, cwd)
+  if (!fs.existsSync(p)) return null
+  try {
+    return JSON.parse(fs.readFileSync(p, 'utf8')) as BaselineMetadata
+  } catch {
+    return null
+  }
 }
 
 export interface BaselineInfo {
@@ -35,25 +87,31 @@ export interface BaselineInfo {
   date: string
   modelCount: number
   caseCount: number
+  description?: string
 }
 
 export function listBaselines(cwd?: string): BaselineInfo[] {
   const dir = baselinesDir(cwd)
   if (!fs.existsSync(dir)) return []
   return fs.readdirSync(dir)
-    .filter(f => f.endsWith('.json'))
+    // Exclude the `.meta.json` sidecars from the result listing; they're
+    // looked up explicitly per baseline below.
+    .filter(f => f.endsWith('.json') && !f.endsWith('.meta.json'))
     .map(f => {
+      const name = f.replace(/\.json$/, '')
       const full = path.join(dir, f)
       try {
         const result = JSON.parse(fs.readFileSync(full, 'utf8')) as RunResult
+        const meta = loadBaselineMeta(name, cwd)
         return {
-          name: f.replace('.json', ''),
+          name,
           date: result.timestamp?.slice(0, 19).replace('T', ' ') ?? 'unknown',
           modelCount: result.models?.length ?? 0,
           caseCount: result.cases?.length ?? 0,
+          description: meta?.description,
         }
       } catch {
-        return { name: f.replace('.json', ''), date: 'invalid', modelCount: 0, caseCount: 0 }
+        return { name, date: 'invalid', modelCount: 0, caseCount: 0 }
       }
     })
     .sort((a, b) => a.name.localeCompare(b.name))
@@ -71,7 +129,12 @@ export function loadBaseline(name: string, cwd?: string): RunResult | null {
 
 const REGRESSION_THRESHOLD = 0.5
 
-export function compareWithBaseline(baseline: RunResult, current: RunResult, baselineName: string): BaselineComparison {
+export function compareWithBaseline(
+  baseline: RunResult,
+  current: RunResult,
+  baselineName: string,
+  baselineDescription?: string,
+): BaselineComparison {
   const allModels = [...new Set([...baseline.models, ...current.models])]
 
   const deltas: BaselineDelta[] = []
@@ -110,6 +173,7 @@ export function compareWithBaseline(baseline: RunResult, current: RunResult, bas
   return {
     baselineName,
     baselineDate: baseline.timestamp?.slice(0, 19).replace('T', ' ') ?? 'unknown',
+    baselineDescription,
     deltas,
     newModels,
     removedModels,

--- a/src/core/runner.ts
+++ b/src/core/runner.ts
@@ -360,13 +360,25 @@ export async function runEvals(
         let score: JudgeScore
 
         if (evalCase.assertions && evalCase.assertions.length > 0) {
-          // Multi-assertion mode: run each assertion, aggregate with configured mode
+          // Multi-assertion mode: run each assertion, aggregate with the
+          // case's configured mode (defaults to 'min'). When mode is
+          // 'weighted' we collect per-assertion `weight` values from the
+          // assertions themselves so YAML authors can prioritize, e.g.,
+          // an LLM rubric score over a contains-check.
           const assertionScores: JudgeScore[] = []
+          const weights: number[] = []
           for (const assertion of evalCase.assertions) {
             const s = scoreAssertion(assertion, resp.text, resp.tool_calls)
-            if (s) assertionScores.push(s)
+            if (s) {
+              assertionScores.push(s)
+              weights.push(assertion.weight ?? 1)
+            }
           }
-          score = aggregateScores(assertionScores)
+          score = aggregateScores(
+            assertionScores,
+            evalCase.aggregation ?? 'min',
+            evalCase.aggregation === 'weighted' ? weights : undefined
+          )
         } else if (evalCase.scorer === 'similar') {
           const baseEmbeddingConfig = config.judge.embedding_model ?? {
             base_url: judgeModel.base_url ?? 'http://localhost:11434/v1',

--- a/src/index.ts
+++ b/src/index.ts
@@ -5,26 +5,89 @@
  *
  * @example
  * ```ts
- * import { runEvals, loadEvalPacks, type Config } from '@hnshah/verdict'
+ * import { runEvalsFromConfig } from '@hnshah/verdict'
  *
- * const config: Config = {
- *   name: 'My Evals',
- *   models: [{ id: 'local', provider: 'ollama', model: 'llama3' }],
- *   judge: { model: 'gpt-4o-mini' },
- *   packs: ['./eval-packs/general.yaml'],
- * }
- *
- * const packs = await loadEvalPacks(config.packs, config)
- * const result = await runEvals(config, packs, (msg) => console.log(msg))
+ * const result = await runEvalsFromConfig('./verdict.yaml', {
+ *   onProgress: msg => console.log(msg),
+ * })
  * console.log(result.summary)
  * ```
+ *
+ * @example For finer control:
+ * ```ts
+ * import { runEvals, loadConfig, loadEvalPack } from '@hnshah/verdict'
+ * import path from 'path'
+ *
+ * const config = loadConfig('./verdict.yaml')
+ * const cfgDir = path.dirname(path.resolve('./verdict.yaml'))
+ * const packs = config.packs.map(p => loadEvalPack(p, cfgDir))
+ * const result = await runEvals(config, packs)
+ * ```
  */
+
+import path from 'path'
+import { loadConfig as _loadConfig, loadEvalPack as _loadEvalPack } from './core/config.js'
+import { runEvals as _runEvals } from './core/runner.js'
+import type { Config, EvalPack, RunResult } from './types/index.js'
 
 // ─── Core runner ─────────────────────────────────────────────────────────────
 export { runEvals, computeConfigHash, loadCheckpoint, getCheckpointPath } from './core/runner.js'
 
 // ─── Config + pack loader ─────────────────────────────────────────────────────
 export { loadConfig, loadEvalPack } from './core/config.js'
+
+// ─── Convenience helpers ─────────────────────────────────────────────────────
+
+export interface RunEvalsFromConfigOptions {
+  /** Progress callback — receives one line per case/judge action. */
+  onProgress?: (msg: string) => void
+  /** Resume from a previous checkpoint if one exists. */
+  resume?: boolean
+  /** Only run cases whose `category` is in this list. */
+  categoryFilter?: string[]
+  /**
+   * Preload Ollama models before running (default true). Disable for
+   * cloud-only configs or scripted runs where models are already warm.
+   */
+  preload?: boolean
+  /**
+   * Override the packs from the config file. When provided, the config's
+   * `packs` list is ignored and these packs are loaded relative to the
+   * config file's directory.
+   */
+  packs?: string[]
+}
+
+/**
+ * One-call wrapper around `loadConfig` + `loadEvalPack` + `runEvals`. The
+ * three-step boilerplate is the most common library entry point, so this
+ * helper lets consumers drop into a single line:
+ *
+ * ```ts
+ * const result = await runEvalsFromConfig('./verdict.yaml')
+ * ```
+ *
+ * For finer control (custom pack lists, manual config mutation), call
+ * `loadConfig` / `loadEvalPack` / `runEvals` directly.
+ */
+export async function runEvalsFromConfig(
+  configPath: string,
+  opts: RunEvalsFromConfigOptions = {}
+): Promise<RunResult> {
+  const config: Config = _loadConfig(configPath)
+  const cfgDir = path.dirname(path.resolve(configPath))
+  const packPaths = opts.packs ?? config.packs
+  const packs: EvalPack[] = packPaths.map(p => _loadEvalPack(p, cfgDir))
+  return _runEvals(
+    config,
+    packs,
+    opts.onProgress,
+    opts.resume,
+    opts.categoryFilter,
+    opts.preload ?? true,
+    configPath
+  )
+}
 
 // ─── Eval registry ──────────────────────────────────────────────────────────
 export {

--- a/src/reporter/markdown.ts
+++ b/src/reporter/markdown.ts
@@ -44,6 +44,9 @@ export function generateMarkdownReport(result: RunResult): string {
   if (result.baselineComparison) {
     const bc = result.baselineComparison
     lines.push(``, `## Baseline Comparison (vs "${bc.baselineName}")`, ``)
+    if (bc.baselineDescription) {
+      lines.push(`_${bc.baselineDescription}_`, ``)
+    }
     lines.push(`Baseline date: ${bc.baselineDate}`, ``)
     lines.push(`| Model | Baseline | Current | Delta | Change | Status |`)
     lines.push(`|-------|----------|---------|-------|--------|--------|`)

--- a/src/types/index.ts
+++ b/src/types/index.ts
@@ -365,6 +365,8 @@ export interface BaselineDelta {
 export interface BaselineComparison {
   baselineName: string
   baselineDate: string
+  /** Human-readable description set via `baseline save --describe`. */
+  baselineDescription?: string
   deltas: BaselineDelta[]
   newModels: string[]
   removedModels: string[]


### PR DESCRIPTION
## Summary

Closes the four open Theme C items (C1 — workflow templates — already shipped in PR #134).

| Item | Description | Files |
|---|---|---|
| **C2** | Baseline tagging + named baselines. `baseline save <name> --describe "..."` writes a `<name>.meta.json` sidecar; description surfaces in `baseline list`, the markdown reporter's baseline comparison block, and the PR comment. Legacy file-only baselines load cleanly without a sidecar. | `src/core/baseline.ts`, `src/cli/commands/baseline.ts`, `src/cli/commands/run.ts`, `src/reporter/markdown.ts`, `src/types/index.ts`, `src/cli/index.ts` |
| **C3** | Programmatic API convenience. New `runEvalsFromConfig(path, opts)` collapses `loadConfig + loadEvalPack + runEvals` into one call. `docs/programmatic-api.md` rewritten with this as the primary quick-start; manual three-step path preserved for fine-grained control. | `src/index.ts`, `docs/programmatic-api.md`, `src/__tests__/api.test.ts` |
| **C4** | Verdict Action `v1` release flow. New `.github/workflows/release-v1-tag.yml` auto-updates a moving `v1` tag on every `v1.x.y` release. README documents `uses: hnshah/verdict@v1` with the existing PR-comment + regression-gate inputs. | `.github/workflows/release-v1-tag.yml`, `README.md` |
| **C5** | Multi-assertion aggregation **bugfix**. The runner called `aggregateScores(scores)` without forwarding `evalCase.aggregation`, so YAML authors who wrote `aggregation: avg` (or `max`/`weighted`) silently got `min`. Now the case's mode + per-assertion `weight` values are threaded through. Documented in `docs/writing-eval-packs.md`. | `src/core/runner.ts`, `src/core/__tests__/runner.test.ts`, `docs/writing-eval-packs.md` |

## Test plan

- [x] \`npx vitest run\` — 597/597 passing (10 new tests across baseline + runner + api).
- [x] \`npx tsc --noEmit\` — clean.
- [x] Baseline metadata round-trips via the sidecar; legacy (no-sidecar) baselines surface name+date without description.
- [x] \`runEvalsFromConfig('./verdict.yaml')\` exported + callable from the public surface; new test asserts the export.
- [x] Multi-assertion modes (min/max/avg/weighted) all produce the documented score for a `[10, 0]` assertion pair through `runEvals` end-to-end.
- [x] PR comment markdown surfaces the baseline description when present.
- [ ] Real workflow test: tag a v1.0.0 release, confirm the workflow moves `v1` (needs an actual release event — manual verification post-merge).

## Dependency

Based on \`hnshah/theme-b-cold-start-friction\` (PR #138). When PRs #137 → #138 → #139 merge in order, each retargets to main automatically.

## What's NOT in this PR

- C1 (workflow templates) — already shipped in PR #134.
- Theme D (distribution flywheel: telemetry endpoint, verdict.sh/board, verdict share).
- Theme E (designer's TUI components landing).