### PR TITLE
Add Gemma 4 local dogfood configs

### DIFF
--- a/configs/examples/gemma4-dogfood-self-judge.yaml
+++ b/configs/examples/gemma4-dogfood-self-judge.yaml
@@ -1,0 +1,37 @@
+version: "1.0"
+name: "Gemma 4 Dogfood Self-Judge"
+
+models:
+  - id: gemma4:e4b
+    provider: ollama
+    model: gemma4:e4b
+    host: "${OLLAMA_HOST:-localhost:11434}"
+    tags: [local, free, gemma, general, reasoning, coding, multimodal, judge]
+    timeout_ms: 180000
+    max_tokens: 2048
+
+judge:
+  model: gemma4:e4b
+  blind: true
+  rubric:
+    accuracy: 0.4
+    completeness: 0.4
+    conciseness: 0.2
+  embedding_model:
+    base_url: "http://${OLLAMA_HOST:-localhost:11434}/v1"
+    api_key: "none"
+    model: nomic-embed-text
+
+packs:
+  - ../../eval-packs/general.yaml
+  - ../../eval-packs/format-compliance.yaml
+  - ../../eval-packs/integration-test.yaml
+
+run:
+  concurrency: 1
+  retries: 1
+  cache: false
+
+output:
+  dir: ./results
+  formats: [json, markdown]

--- a/configs/examples/gemma4-dogfood.yaml
+++ b/configs/examples/gemma4-dogfood.yaml
@@ -1,0 +1,53 @@
+version: "1.0"
+name: "Gemma 4 Dogfood"
+
+models:
+  - id: gemma4:e4b
+    provider: ollama
+    model: gemma4:e4b
+    host: "${OLLAMA_HOST:-localhost:11434}"
+    tags: [local, free, gemma, general, reasoning, coding, multimodal]
+    timeout_ms: 180000
+    max_tokens: 2048
+
+  - id: qwen2.5:7b
+    provider: ollama
+    model: qwen2.5:7b
+    host: "${OLLAMA_HOST:-localhost:11434}"
+    tags: [local, free, baseline, judge]
+    timeout_ms: 120000
+    max_tokens: 2048
+
+  - id: llama3.2:3b
+    provider: ollama
+    model: llama3.2:3b
+    host: "${OLLAMA_HOST:-localhost:11434}"
+    tags: [local, free, baseline, fast]
+    timeout_ms: 120000
+    max_tokens: 2048
+
+judge:
+  model: qwen2.5:7b
+  blind: true
+  rubric:
+    accuracy: 0.4
+    completeness: 0.4
+    conciseness: 0.2
+  embedding_model:
+    base_url: "http://${OLLAMA_HOST:-localhost:11434}/v1"
+    api_key: "none"
+    model: nomic-embed-text
+
+packs:
+  - ../../eval-packs/general.yaml
+  - ../../eval-packs/format-compliance.yaml
+  - ../../eval-packs/integration-test.yaml
+
+run:
+  concurrency: 1
+  retries: 1
+  cache: false
+
+output:
+  dir: ./results
+  formats: [json, markdown]

--- a/configs/model-catalog.yaml
+++ b/configs/model-catalog.yaml
@@ -112,6 +112,13 @@ models:
     family: gemma
     tags: [general]
 
+  - name: "gemma4:e4b"
+    provider: ollama
+    params_b: 8
+    default_quant: q4_K_M
+    family: gemma
+    tags: [general, reasoning, coding, multimodal, local]
+
   - name: "mistral:7b"
     provider: ollama
     params_b: 7

--- a/docs/getting-started.md
+++ b/docs/getting-started.md
@@ -79,6 +79,25 @@ verdict run --pack quantization,moe
 verdict run --models local-fast,cloud-mini
 ```
 
+## Local Gemma 4 dogfood
+
+Verdict includes example configs for exercising local runs with official
+Ollama `gemma4:e4b`:
+
+```bash
+ollama pull gemma4:e4b
+ollama pull nomic-embed-text
+ollama pull qwen2.5:7b
+ollama pull llama3.2:3b
+
+npm run dev -- run --config configs/examples/gemma4-dogfood.yaml --dry-run
+npm run dev -- run --config configs/examples/gemma4-dogfood.yaml --resume
+npm run dev -- run --config configs/examples/gemma4-dogfood-self-judge.yaml --resume
+```
+
+See [Provider setup](./providers.md#gemma-4-local-dogfood) for the Qwen-judged
+and Gemma self-judge paths.
+
 ## Next steps
 
 - [Writing eval packs](./writing-eval-packs.md)

--- a/docs/providers.md
+++ b/docs/providers.md
@@ -35,6 +35,43 @@ ollama pull mixtral:8x7b
 
 verdict auto-detects MoE models by name and tags them.
 
+### Gemma 4 local dogfood
+
+Use the official Ollama `gemma4:e4b` tag when you want to dogfood Verdict
+with a recent local Gemma model. The tag is about 9.6 GB, so keep at least
+12 GB of free disk before pulling it. On a 24 GB RAM Verdict dogfood machine
+with tight disk headroom, `gemma4:e4b` should fit, but avoid parallel local
+generations by using `run.concurrency: 1`.
+
+Pull the models used by the included dogfood configs:
+
+```bash
+ollama pull gemma4:e4b
+ollama pull nomic-embed-text
+ollama pull qwen2.5:7b
+ollama pull llama3.2:3b
+```
+
+Run the Qwen-judged path first. It evaluates Gemma 4 against local baselines
+while keeping the judge consistent with existing Verdict local runs:
+
+```bash
+npm run dev -- models --config configs/examples/gemma4-dogfood.yaml
+npm run dev -- run --config configs/examples/gemma4-dogfood.yaml --dry-run
+npm run dev -- run --config configs/examples/gemma4-dogfood.yaml --resume
+```
+
+Then run the fully Gemma-driven path, where Gemma 4 is both the model under
+test and the judge:
+
+```bash
+npm run dev -- run --config configs/examples/gemma4-dogfood-self-judge.yaml --resume
+```
+
+The self-judge run intentionally uses the existing judge parser. If Gemma emits
+extra thinking text around the required JSON, treat that as dogfood feedback and
+document the limitation rather than changing parser behavior for this config.
+
 ## MLX (Apple Silicon)
 
 Runs models natively on M-series chips. Generally faster than Ollama on Apple Silicon.

--- a/src/judge/faithfulness.ts
+++ b/src/judge/faithfulness.ts
@@ -1,6 +1,7 @@
 import OpenAI from 'openai'
 import type { ModelConfig, JudgeConfig, JudgeScore } from '../types/index.js'
 import type { OpenClawConfig } from '../providers/openclaw.js'
+import { callOllamaChatNative } from '../providers/ollama-native.js'
 
 const faithfulnessClientCache = new Map<string, OpenAI>()
 
@@ -81,6 +82,14 @@ export async function judgeFaithfulness(
       temperature: 0.0,
     })
     text = result.choices[0]?.message?.content ?? ''
+    if (!text && judgeModel.provider === 'ollama') {
+      const native = await callOllamaChatNative(
+        { ...judgeModel, max_tokens: 256 },
+        [{ role: 'user', content: faithfulnessPrompt }],
+        { max_tokens: 256, temperature: 0 }
+      )
+      text = native?.text ?? text
+    }
   }
 
   const parsed = parseFaithfulnessJson(text)

--- a/src/judge/llm.ts
+++ b/src/judge/llm.ts
@@ -2,6 +2,7 @@ import OpenAI from 'openai'
 import type { ModelConfig, JudgeConfig, JudgeScore, CotChoice } from '../types/index.js'
 import { callOpenClaw, type OpenClawConfig } from '../providers/openclaw.js'
 import { callSubAgent, type SubAgentConfig } from '../providers/subagent.js'
+import { callOllamaChatNative } from '../providers/ollama-native.js'
 import { log as vlog } from '../utils/logger.js'
 
 const judgeClientCache = new Map<string, OpenAI>()
@@ -136,6 +137,14 @@ export async function judgeResponse(
     })
 
     text = result.choices[0]?.message?.content ?? ''
+    if (!text && judgeModel.provider === 'ollama') {
+      const native = await callOllamaChatNative(
+        { ...judgeModel, max_tokens: 256 },
+        [{ role: 'user', content: judgePrompt }],
+        { max_tokens: 256, temperature: 0 }
+      )
+      text = native?.text ?? text
+    }
   }
   vlog('debug', `judge ${judgeModel.id}: response`, text)
   const parsed = parseJudgeJson(text)

--- a/src/onboarding/templates.ts
+++ b/src/onboarding/templates.ts
@@ -4,6 +4,9 @@
  * strips comments, which matter here for user-facing docs in the file.
  */
 
+import fs from 'fs'
+import path from 'path'
+import { fileURLToPath } from 'url'
 import type { Plan } from './events.js'
 
 // ─── verdict.yaml ───────────────────────────────────────────────────────────
@@ -249,6 +252,36 @@ cases:
     criteria: "Correct SQL with GROUP BY, SUM, ORDER BY DESC, LIMIT 3. Reasonable index suggestion (customer_id or composite)."
     tags: [coding, sql, performance]
 `
+
+// ─── eval-packs/quantization.yaml ──────────────────────────────────────────
+
+export const QUANTIZATION_PACK_STUB = `# eval-packs/quantization.yaml
+name: Quantization
+version: 1.0.0
+description: Minimal fallback pack for checking structured output degradation.
+
+cases:
+  - id: quant-001
+    prompt: "Return only this JSON object: {\"status\":\"ok\",\"count\":3}"
+    criteria: "Valid JSON only, exact status and count fields"
+    scorer: json
+    expected: "{\"status\":\"ok\",\"count\":3}"
+    tags: [json, structured-output, quantization-sensitive]
+`
+
+export function loadQuantizationPack(): string | null {
+  const here = path.dirname(fileURLToPath(import.meta.url))
+  const candidates = [
+    path.resolve(here, '..', '..', 'eval-packs', 'quantization.yaml'),
+    path.resolve(process.cwd(), 'eval-packs', 'quantization.yaml'),
+  ]
+
+  for (const candidate of candidates) {
+    if (fs.existsSync(candidate)) return fs.readFileSync(candidate, 'utf8')
+  }
+
+  return null
+}
 
 // ─── .env.example ───────────────────────────────────────────────────────────
 

--- a/src/providers/compat.ts
+++ b/src/providers/compat.ts
@@ -11,6 +11,7 @@ import fs from 'fs'
 import type { ModelConfig, ModelResponse, ToolDef } from '../types/index.js'
 import { callOpenClaw, type OpenClawConfig } from './openclaw.js'
 import { callSubAgent, type SubAgentConfig } from './subagent.js'
+import { callOllamaChatNative, type OllamaChatMessage } from './ollama-native.js'
 import { log as vlog } from '../utils/logger.js'
 import { humanizeProviderError, formatHumanError } from '../utils/errors.js'
 
@@ -128,9 +129,22 @@ export async function callModel(
     })
 
     const latency_ms = Date.now() - start
-    const text = response.choices[0]?.message?.content ?? ''
-    const input_tokens = response.usage?.prompt_tokens ?? 0
-    const output_tokens = response.usage?.completion_tokens ?? 0
+    let text = response.choices[0]?.message?.content ?? ''
+    let input_tokens = response.usage?.prompt_tokens ?? 0
+    let output_tokens = response.usage?.completion_tokens ?? 0
+
+    if (!text && config.provider === 'ollama') {
+      const native = await callOllamaChatNative(config, messages as OllamaChatMessage[], {
+        max_tokens: config.max_tokens,
+        temperature: 0,
+      })
+      if (native?.text) {
+        text = native.text
+        input_tokens = native.input_tokens || input_tokens
+        output_tokens = native.output_tokens || output_tokens
+      }
+    }
+
     const cost_usd = config.cost_per_1m_input && config.cost_per_1m_output
       ? (input_tokens / 1_000_000) * config.cost_per_1m_input
         + (output_tokens / 1_000_000) * config.cost_per_1m_output
@@ -203,9 +217,22 @@ export async function callModelMultiTurn(
     })
 
     const latency_ms = Date.now() - start
-    const text = response.choices[0]?.message?.content ?? ''
-    const input_tokens = response.usage?.prompt_tokens ?? 0
-    const output_tokens = response.usage?.completion_tokens ?? 0
+    let text = response.choices[0]?.message?.content ?? ''
+    let input_tokens = response.usage?.prompt_tokens ?? 0
+    let output_tokens = response.usage?.completion_tokens ?? 0
+
+    if (!text && config.provider === 'ollama') {
+      const native = await callOllamaChatNative(config, allMessages as OllamaChatMessage[], {
+        max_tokens: config.max_tokens,
+        temperature: 0,
+      })
+      if (native?.text) {
+        text = native.text
+        input_tokens = native.input_tokens || input_tokens
+        output_tokens = native.output_tokens || output_tokens
+      }
+    }
+
     const cost_usd = config.cost_per_1m_input && config.cost_per_1m_output
       ? (input_tokens / 1_000_000) * config.cost_per_1m_input
         + (output_tokens / 1_000_000) * config.cost_per_1m_output

--- a/src/providers/ollama-native.ts
+++ b/src/providers/ollama-native.ts
@@ -1,0 +1,71 @@
+import type { ModelConfig } from '../types/index.js'
+
+export interface OllamaChatMessage {
+  role: string
+  content: string
+}
+
+export interface OllamaChatResult {
+  text: string
+  input_tokens: number
+  output_tokens: number
+}
+
+function ollamaApiBase(config: ModelConfig): string | null {
+  if (config.provider !== 'ollama' && !config.base_url?.includes('11434')) return null
+
+  if (config.host) return `http://${config.host}`
+  if (config.base_url) return config.base_url.replace(/\/v1\/?$/, '')
+
+  const host = process.env['OLLAMA_HOST'] ?? 'localhost:11434'
+  return host.startsWith('http://') || host.startsWith('https://') ? host : `http://${host}`
+}
+
+export async function callOllamaChatNative(
+  config: ModelConfig,
+  messages: OllamaChatMessage[],
+  opts: { max_tokens?: number; temperature?: number } = {},
+): Promise<OllamaChatResult | null> {
+  const base = ollamaApiBase(config)
+  if (!base) return null
+
+  const controller = new AbortController()
+  const timeout = setTimeout(() => controller.abort(), config.timeout_ms)
+
+  try {
+    const response = await fetch(`${base}/api/chat`, {
+      method: 'POST',
+      headers: { 'Content-Type': 'application/json' },
+      signal: controller.signal,
+      body: JSON.stringify({
+        model: config.model,
+        messages,
+        stream: false,
+        think: false,
+        options: {
+          temperature: opts.temperature ?? 0,
+          num_predict: opts.max_tokens ?? config.max_tokens,
+        },
+      }),
+    })
+
+    if (!response.ok) {
+      const text = await response.text()
+      throw new Error(`Ollama native chat failed (${response.status}): ${text}`)
+    }
+
+    const data = await response.json() as {
+      message?: { content?: string }
+      prompt_eval_count?: number
+      eval_count?: number
+    }
+
+    return {
+      text: data.message?.content ?? '',
+      input_tokens: data.prompt_eval_count ?? 0,
+      output_tokens: data.eval_count ?? 0,
+    }
+  } finally {
+    clearTimeout(timeout)
+  }
+}


### PR DESCRIPTION
## What

Adds official Ollama `gemma4:e4b` to the model catalog, two local dogfood configs, docs for Qwen-judged and Gemma self-judge runs, and an Ollama-native chat fallback for thinking models that return empty OpenAI-compatible `content`.

## Why

This lets Verdict dogfood fully local Gemma 4 runs and fixes the empty-response behavior observed from Gemma 4 through Ollama’s OpenAI-compatible chat API.

## Testing

- [x] `npm run typecheck` passes
- [x] Tested with `verdict run --dry-run`
- [x] Tested against a real model: `gemma4:e4b` with the Qwen-judged dogfood config completed 29 cases and wrote JSON, Markdown, receipt, and DB history.

## Checklist

- [x] No em dashes in copy or comments
- [x] New eval packs have unique case IDs
- [x] Deterministic scorer used where appropriate (JSON output, exact match)
- [ ] README updated if this is a user-visible change; provider and getting-started docs were updated instead
