### PR TITLE
chore(meta): AD0 GitHub scaffolding for agent-driver epic

### DIFF
--- a/.github/ISSUE_TEMPLATE/epic.yml
+++ b/.github/ISSUE_TEMPLATE/epic.yml
@@ -1,0 +1,61 @@
+name: Epic (umbrella tracking issue)
+description: Long-lived issue grouping a multi-PR initiative. One per major feature.
+labels: [epic]
+body:
+  - type: markdown
+    attributes:
+      value: |
+        Epics are tables of contents. The decisions live in linked RFCs and discovery
+        docs; the work lives in linked PRs. Keep the body skimmable. Close when the
+        last workstream checkbox ticks.
+
+  - type: input
+    id: phase-code
+    attributes:
+      label: Phase-code prefix
+      description: Two letters used in PR titles for this epic. e.g. AD for agent-driver.
+      placeholder: "e.g. AD"
+    validations:
+      required: true
+
+  - type: textarea
+    id: one-paragraph
+    attributes:
+      label: What this unlocks (one paragraph)
+      description: What gets unlocked when this is done? Who benefits?
+    validations:
+      required: true
+
+  - type: textarea
+    id: discovery
+    attributes:
+      label: Discovery and research links
+      description: |
+        Bullet list of docs in repo (e.g. docs/discovery/<epic>/*) plus RFC issue
+        numbers. Markdown links preferred.
+    validations:
+      required: true
+
+  - type: textarea
+    id: workstreams
+    attributes:
+      label: Workstreams (phase-code checklist)
+      description: |
+        Checkbox list. Each item is either an RFC or a shippable PR. Use the
+        phase-code prefix, e.g. `- [ ] AD1 transport spike (#TBD)`.
+    validations:
+      required: true
+
+  - type: textarea
+    id: definition-of-done
+    attributes:
+      label: Definition of done
+      description: What is visibly true when this epic closes?
+    validations:
+      required: true
+
+  - type: textarea
+    id: out-of-scope
+    attributes:
+      label: Out of scope
+      description: What this epic intentionally does NOT cover.

--- a/.github/ISSUE_TEMPLATE/rfc.yml
+++ b/.github/ISSUE_TEMPLATE/rfc.yml
@@ -1,0 +1,55 @@
+name: RFC (design proposal)
+description: Propose a design before code. Open for comment, then accepted or rejected with a recorded reason.
+labels: [rfc]
+body:
+  - type: markdown
+    attributes:
+      value: |
+        RFCs are for decisions that will outlive a single PR (transport choice,
+        schema design, auth model). Small? Just open a PR.
+
+        After accept or reject, link the resulting commit or rationale and close.
+        Closed RFCs are the audit trail.
+
+  - type: input
+    id: epic
+    attributes:
+      label: Parent epic (issue #)
+      placeholder: "e.g. #142"
+
+  - type: textarea
+    id: problem
+    attributes:
+      label: Problem
+      description: What user-visible thing isn't possible today, and which JTBD does this serve?
+    validations:
+      required: true
+
+  - type: textarea
+    id: proposal
+    attributes:
+      label: Proposal
+      description: Concrete design. Schemas, signatures, behaviour.
+    validations:
+      required: true
+
+  - type: textarea
+    id: alternatives
+    attributes:
+      label: Alternatives considered (and why rejected)
+      description: |
+        At least two. "We just did the obvious thing" still counts, say so. For
+        each alternative include one line on why it was rejected.
+    validations:
+      required: true
+
+  - type: textarea
+    id: open-questions
+    attributes:
+      label: Open questions
+
+  - type: input
+    id: discovery-doc
+    attributes:
+      label: Discovery doc path (if any)
+      placeholder: "e.g. docs/discovery/agent-driver/04-protocol-scorecard.md"

--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -6,6 +6,13 @@
 
 <!-- Why is this change needed? Link to issue if relevant -->
 
+## Links
+
+<!-- For epic-scoped work, fill these in. Skip for tiny or cleanup PRs. -->
+- Epic: # <!-- include phase-code prefix in PR title, e.g. `feat(agent): AD2 ...` -->
+- RFC or discovery doc:
+- JTBDs addressed:
+
 ## Testing
 
 <!-- How did you test this? -->
@@ -19,3 +26,5 @@
 - [ ] New eval packs have unique case IDs
 - [ ] Deterministic scorer used where appropriate (JSON output, exact match)
 - [ ] README updated if this is a user-visible change
+- [ ] If part of an epic, PR title carries the phase code (e.g. `AD2`)
+- [ ] If this decides something reversible-with-pain, the rationale is in a linked RFC or discovery doc

--- a/docs/discovery/agent-driver/00-README.md
+++ b/docs/discovery/agent-driver/00-README.md
@@ -1,0 +1,50 @@
+# Discovery: External agents drive Verdict over chat (`AD`)
+
+**Phase code:** `AD`
+**Status:** Phase 0 (scaffolding)
+**Epic:** #TBD (will be replaced once the epic issue is opened)
+**Last updated:** 2026-05-22
+
+## What this folder is
+
+Forward-looking discovery for the **agent-driver** epic: letting an external AI
+agent (OpenClaw, Hermes Agent, Claude Desktop, Cline, etc.) drive Verdict
+end-to-end over chat. Discovery is forward; retrospectives live in
+[`docs/research/`](../../research/).
+
+Each file has a `Status:` header. PRs cite stable IDs from these files (e.g.
+`JTBD-3`, `RFC-1`) so the audit trail survives renames and reorgs.
+
+## How to read this folder
+
+1. Start here.
+2. **Personas** ([01](./01-personas.md)) describe who has the problem.
+3. **JTBDs** ([02](./02-jtbds.md)) describe what they're trying to do.
+4. **Prior art** ([03](./03-prior-art.md)) describes who has tried this before and what they learned.
+5. **Protocol scorecard** ([04](./04-protocol-scorecard.md)) chooses how the agent reaches Verdict.
+6. **Synthesis** ([00-synthesis.md](./00-synthesis.md), added after Phase 1) rolls the above into a coherent recommendation.
+7. **Decisions log** ([05](./05-decisions-log.md)) records every accepted-or-rejected call as RFCs close.
+
+## Workflow status
+
+| File | Status | Owner |
+| --- | --- | --- |
+| 01-personas.md | not-started | @hnshah |
+| 02-jtbds.md | not-started | @hnshah |
+| 03-prior-art.md | not-started | @hnshah |
+| 04-protocol-scorecard.md | not-started | @hnshah |
+| 00-synthesis.md | not-started (added end of Phase 1) | @hnshah |
+| 05-decisions-log.md | not-started (populated as RFCs close) | @hnshah |
+
+## Locked-in framing (from the planning conversation)
+
+1. Transport is **genuinely open**. Phase 1 scores MCP vs HTTP vs CLI vs library.
+2. v1 ships **both on-demand chat-driven AND scheduled digests**.
+3. Discovery rigor: standard, no external interviews.
+4. PR titles for epic work use `feat(agent): AD<n> ...`.
+
+## Out of scope (for this epic)
+
+- Cloud-hosted Verdict
+- Multi-tenant agent auth
+- Verdict-as-the-agent (this is about Verdict being driven, not driving)

--- a/docs/discovery/agent-driver/01-personas.md
+++ b/docs/discovery/agent-driver/01-personas.md
@@ -1,0 +1,29 @@
+# 01 Personas: agent-driven Verdict
+
+**Status:** not-started
+**Phase:** 1b (target: 0.5 day)
+**Anchor:** every persona extends the existing Verdict North Star (indie dev on a MacBook deciding cloud vs local).
+
+## Candidate personas (to flesh out)
+
+- **P1 Indie dev + their primary chat agent.** Primary persona. Direct extension of North Star. The chat agent becomes their eval analyst.
+- **P2 Founder/operator shipping LLM features.** Cares more about regression alerts and shareable digests than raw model selection.
+- **P3 DevOps-on-a-Mac-mini (lab in a closet).** Extension of North Star to a scheduled-eval lab. Cares about daemon, cron, weekly summaries. Maps to existing `verdict daemon` + new digest emitter.
+
+## Non-goals (explicit)
+
+- Enterprise ML platform team
+- Researcher with H100s
+- No-code SaaS user
+
+## Format per persona (when filled in)
+
+One page each:
+
+- Goals
+- Current workflow (without the feature)
+- Hardest moment
+- What success looks like
+- Which JTBDs they're hiring this feature for
+
+Written for a public audience so this file can graduate to `docs/personas.md`.

--- a/docs/discovery/agent-driver/02-jtbds.md
+++ b/docs/discovery/agent-driver/02-jtbds.md
@@ -1,0 +1,54 @@
+# 02 Jobs-To-Be-Done: agent-driven Verdict
+
+**Status:** not-started
+**Phase:** 1a (target: 1 day)
+**Convention:** stable `JTBD-N` IDs. PRs cite these by anchor link.
+
+## Candidate JTBDs (to validate)
+
+### JTBD-1 (load-bearing): chat-native eval triggering
+
+> When I'm in my coding chat, I want to ask my agent to run or manage Verdict evals
+> so I don't have to context-switch out to a CLI.
+
+If false, the whole feature is solving the wrong problem.
+
+### JTBD-2 (load-bearing): proactive insights
+
+> When something interesting happens (regression, new winner, anomaly), I want my
+> agent to surface it proactively (hourly, daily, weekly) without me having to ask.
+
+This is the *insights* half. Differentiates the feature from a plain CLI wrapper.
+
+### JTBD-3: streamed progress in chat
+
+> When my evals are running long, I want progress streamed into chat so I don't
+> babysit a terminal.
+
+### JTBD-4: autonomous model-frontier maintenance
+
+> When a new model drops, I want my agent to autonomously add it to my eval suite
+> and report how it stacks up against my current frontier.
+
+### JTBD-5: shareable narrative digests
+
+> I want a model-comparison narrative I can paste into Slack, a PR, or a README
+> without writing it myself.
+
+Bridges to existing `verdict share` (PR #136).
+
+## Validation method
+
+Self-walkthrough. For each candidate:
+
+1. State the JTBD in one paragraph.
+2. Describe the current workaround (without this feature, using today's Verdict CLI).
+3. Mark verdict: **kept** / **merged** / **dropped**.
+4. Capture supporting evidence (existing user notes, ROADMAP excerpts, FAQ entries).
+
+A JTBD only survives if the workaround is painful or impossible today.
+
+## Graduation
+
+Once stable, this file should be promoted to `docs/jtbds.md` at repo root and
+feed the broader Verdict strategy, not just this epic.

--- a/docs/discovery/agent-driver/03-prior-art.md
+++ b/docs/discovery/agent-driver/03-prior-art.md
@@ -1,0 +1,46 @@
+# 03 Prior art: agent-driven Verdict
+
+**Status:** not-started
+**Phase:** 1c (target: 1.5 days)
+
+## Surfaces to inspect (with the lesson to extract)
+
+### Eval tools with programmatic surfaces
+
+- **promptfoo**: CI integration patterns, `promptfoo eval --output`. What's the agent-callable surface? How does it stream progress?
+- **Braintrust**: programmatic API plus dashboards. How are insights exposed?
+- **LangSmith**: trace-driven insights. What does a "narrative" look like?
+- **lm-eval-harness**: CLI ergonomics. Closest peer; what's missing for an agent driver?
+- **Helicone, Honeycomb BubbleUp, Datadog Watchdog**: anomaly-explanation primitives. State of the art for "insights".
+
+### Agent integration patterns
+
+- **MCP server catalog (modelcontextprotocol.io/servers)**: which servers ship insight-style tools vs raw RPC?
+- **Claude Desktop MCP config**: 30 min hands-on. How is the friction?
+- **Cline / Aider tool-use**: what convention do agents expect from a CLI tool?
+- **ChatGPT plugins (deprecated)**: failure modes; why didn't this take off?
+
+### Scheduled-digest prior art (critical for v1 scope)
+
+- LangSmith run analytics digests
+- GitHub weekly digest emails (good UX baseline)
+- Datadog Watchdog narrative alerts
+- Honeycomb BubbleUp "anomaly + example" pattern
+
+## Questions the scan must answer
+
+1. What's the lowest-friction transport for an external agent today?
+2. How do these tools represent *progress* in chat (token-by-token, polling, webhooks)?
+3. What does "good" automated insight look like (narrative, bullets, structured deltas + one example)?
+4. Who has failed at scheduled digests, and why? Spam fatigue is the predictable killer; an explicit answer is required.
+
+## Output format
+
+A table:
+
+| Tool | Surface | Progress representation | Insight format | Lesson for us |
+| --- | --- | --- | --- | --- |
+| ... | ... | ... | ... | ... |
+
+Followed by a one-paragraph synthesis: "based on prior art, the load-bearing
+choice for Verdict is X because Y."

--- a/docs/discovery/agent-driver/04-protocol-scorecard.md
+++ b/docs/discovery/agent-driver/04-protocol-scorecard.md
@@ -1,0 +1,45 @@
+# 04 Protocol scorecard: how the agent reaches Verdict
+
+**Status:** not-started
+**Phase:** 1d (target: 2 days, highest stakes)
+
+Transport choice is irreversible once any external agent ships against it.
+
+## Homework before recommending
+
+1. Read the MCP spec quickstart end to end; sketch `tools/list` for Verdict:
+   `verdict.run`, `verdict.history`, `verdict.diff`, `verdict.digest`, `verdict.subscribe`.
+2. Audit how the existing `verdict serve` (OpenAI-compatible HTTP) and `verdict daemon`
+   (SQLite job queue) would extend vs duplicate per-transport.
+3. Hands-on: Claude Desktop MCP config (30 min); Cline tool-use config (30 min).
+4. Identify the *streaming-progress* primitive each surface offers
+   (SSE, stdio events, polling). Make-or-break for JTBD-3.
+5. Identify the *push/subscribe* primitive each surface offers
+   (webhook, SSE, long-poll). Make-or-break for JTBD-2 (scheduled digests).
+
+## Scorecard structure
+
+Rows are surfaces:
+
+- MCP server (new `verdict mcp` subcommand)
+- Extend `verdict serve` HTTP with new endpoints
+- CLI shell-out with structured JSON output (`verdict run --json`)
+- TypeScript library import (consumers import from `@hnshah/verdict`)
+- Hybrid (e.g. MCP for pull + daemon webhook for push)
+
+Columns are scoring axes, weighted by load-bearing JTBDs:
+
+| Surface | Streaming progress (JTBD-3) | Push to chat (JTBD-2) | Multi-agent compat | Build cost | Future-proof | Fits scheduled-digest v1 | Total |
+| --- | --- | --- | --- | --- | --- | --- | --- |
+
+## Hybrid is likely
+
+v1 includes both on-demand pull and scheduled push. A single transport may not
+suffice (MCP is pull-only; agents need a way to receive push-style digests).
+Sketch how each contender handles BOTH on-demand pull AND scheduled push, and
+flag where a hybrid is unavoidable.
+
+## Final cell
+
+Recommendation in 2 lines, plus the no-going-back checkpoint with the user
+before Phase 2 closes.

--- a/docs/discovery/agent-driver/05-decisions-log.md
+++ b/docs/discovery/agent-driver/05-decisions-log.md
@@ -1,0 +1,24 @@
+# 05 Decisions log: agent-driver
+
+**Status:** not-started (populated as RFCs close)
+**Phase:** continuous, beginning at end of Phase 2
+
+Append-only. Each entry is a one-paragraph ADR-style note recorded when an RFC
+issue closes (accepted or rejected) or when a discovery doc commits to a stance.
+
+## Format
+
+```
+### YYYY-MM-DD AD-RFC-N: <short title>
+
+**Status:** accepted | rejected | superseded by AD-RFC-M
+**Discovery doc:** docs/discovery/agent-driver/<file>
+**Issue:** #N
+**Decision:** one paragraph.
+**Why:** one paragraph.
+**Consequences:** one paragraph.
+```
+
+## Entries
+
+(none yet)


### PR DESCRIPTION
## What

Phase 0 of the **agent-driver epic** (`AD`): GitHub-native scaffolding that hosts the research + design + execution of a new feature where external AI agents (OpenClaw, Hermes Agent, Claude Desktop, Cline, etc.) drive Verdict over chat — including periodic status reports with insights.

This PR lands the scaffolding only, no feature code. Phase 1 (discovery) starts next.

Two commits, separated by reusability:

1. `chore(meta): add epic + rfc issue templates and PR Links section` — reusable by any future epic.
2. `chore(meta): AD0 agent-driver discovery folder skeleton` — AD-specific.

## Why

The user wants the research + JTBDs + transport decision documented in GitHub so the audit trail is durable and the pattern is reusable. Verdict's existing planning lives in `ROADMAP.md` with PR phase-codes (`B3`, `B4`); this PR introduces the smallest possible upgrade to that pattern.

Key locked-in answers from the planning conversation:

1. Transport is **genuinely open** — Phase 1 scores MCP vs HTTP vs CLI vs library.
2. v1 ships **both on-demand chat-driven AND scheduled digests**.
3. Discovery rigor: **standard (~5 days)** — JTBDs, personas, prior-art, protocol scorecard.
4. Phase code: **`AD`**.

Approved plan: `/Users/hitenshah/.claude/plans/system-instruction-you-are-working-stateless-book.md` (local).

## Links

- Epic: to be opened after this PR merges so discovery-folder links resolve from `main`.
- RFC or discovery doc: `docs/discovery/agent-driver/00-README.md` (index for the whole epic).
- JTBDs addressed: meta — this PR introduces the JTBD doc; PRs cite `JTBD-N` once `02-jtbds.md` is populated in Phase 1.

## What's in the discovery folder

| File | Purpose |
| --- | --- |
| `00-README.md` | Index, status banner, locked-in scope, links to epic |
| `01-personas.md` | Candidate personas (P1 indie dev + chat agent primary) |
| `02-jtbds.md` | 5 candidate JTBDs with stable IDs (JTBD-1..5) |
| `03-prior-art.md` | promptfoo, Braintrust, MCP catalog, scheduled-digest tools |
| `04-protocol-scorecard.md` | MCP vs HTTP vs CLI vs library (highest-stakes call) |
| `05-decisions-log.md` | Append-only ADR log; populated as RFCs close |

All files have `Status: not-started` headers; they ship as stubs in this PR. Phase 1 fills them in.

## Side effects (already on remote)

- 4 new labels created via `gh label create`: `epic`, `rfc`, `discovery`, `agent`.

## Testing

- [x] `gh label list` confirms 4 new labels exist
- [x] Issue templates render correctly (form-based YAML, same style as existing `bug.yml`/`eval-pack.yml`)
- [x] PR template diff is additive only; existing What/Why/Testing/Checklist sections preserved
- [x] No em dashes in copy (PR template rule)
- [ ] Tested with `verdict run --dry-run` — N/A, no code changed
- [ ] Tested against a real model — N/A, no code changed

## Checklist

- [x] No em dashes in copy or comments
- [x] New eval packs have unique case IDs — N/A
- [x] Deterministic scorer used where appropriate — N/A
- [x] README updated if this is a user-visible change — not yet user-visible
- [x] If part of an epic, PR title carries the phase code (`AD0`)
- [x] If this decides something reversible-with-pain, the rationale is in a linked RFC or discovery doc — the meta-plan itself is the rationale

## Next

1. Merge this PR.
2. Open the `[Epic] AD` issue using the new `epic.yml` template; pin it; record its number in `00-README.md` as a follow-up commit.
3. Begin Phase 1: 4 parallel discovery tracks (personas, JTBDs, prior art, protocol scorecard).