### PR TITLE
feat(local): machine inspect and resource guard

### DIFF
--- a/configs/local-m4pro-24gb-frontier.yaml
+++ b/configs/local-m4pro-24gb-frontier.yaml
@@ -1,0 +1,91 @@
+# Frontier benchmark config — Mac mini M4 Pro 24 GB
+#
+# WARNING: This config is for BENCHMARKING ONLY. Do NOT run it as part of the
+# always-on daemon. The candidate models below (gemma3:27b, qwen3:32b) each
+# claim ~17–20 GB of RAM and need exclusive use of the machine. Plan for:
+#
+#  - Quit Chrome / Slack / Docker / anything else heavy before starting.
+#  - Expect the machine to be unresponsive for the duration of the run.
+#  - Free disk before running — each model is 17–20 GB to download.
+#
+# The resource_guard here is *stricter than the quiet config*: a tight disk
+# reserve, an active swap-delta sample, and a short mid-run cooldown. We
+# accept `warn` pressure (Mac compressor often runs in warn under load) but
+# refuse `critical`.
+#
+# Pull the candidates first (and verify you have room before each pull):
+#   verdict machine inspect --fast
+#   ollama pull gemma3:27b
+#   ollama pull qwen3:32b
+#
+# Then run:
+#   verdict run -c configs/local-m4pro-24gb-frontier.yaml --resume
+
+version: "0.4"
+name: "Local M4 Pro 24GB — frontier (benchmark-only)"
+
+models:
+  # Always include the safe default as a baseline so the frontier candidates
+  # have something to beat.
+  - id: qwen2.5:7b
+    model: qwen2.5:7b
+    provider: ollama
+    base_url: http://localhost:11434/v1
+    api_key: none
+    max_tokens: 1024
+    timeout_ms: 300000
+    tags: [local, free, baseline]
+
+  - id: gemma3:27b
+    model: gemma3:27b
+    provider: ollama
+    base_url: http://localhost:11434/v1
+    api_key: none
+    max_tokens: 1024
+    timeout_ms: 600000
+    tags: [local, free, large, benchmark-only]
+
+  - id: qwen3:32b
+    model: qwen3:32b
+    provider: ollama
+    base_url: http://localhost:11434/v1
+    api_key: none
+    max_tokens: 1024
+    timeout_ms: 600000
+    tags: [local, free, large, benchmark-only]
+
+# Use the small model as judge — the candidates are the subjects of
+# evaluation, not the scorers. Using a 30B judge on a 30B candidate is
+# expensive and doesn't add accuracy at this size. The runner resolves the
+# judge's `model` id against models[] above, so the judge inherits
+# qwen2.5:7b's local Ollama endpoint.
+judge:
+  model: qwen2.5:7b
+
+packs:
+  - ../eval-packs/general.yaml
+
+run:
+  concurrency: 1
+  retries: 1
+  cache: true
+  resource_guard:
+    enabled: true
+    on_fail: abort
+    max_concurrency: 1
+    # Just enough headroom to recover from one failed pull. A larger reserve
+    # is unreachable here: 27B + 32B = 37 GB of pulls; even at 50 GB free,
+    # post-pull free disk is ~13 GB. Set higher only after both models are
+    # already pulled.
+    min_free_disk_gb: 10
+    max_memory_pressure: warn
+    # Active swap-growth gating — frontier runs are short and one-off, so
+    # paying 2 s per check is fine.
+    swap_sample_ms: 2000
+    max_swap_delta_mb: 100
+    mid_run_check_seconds: 30
+
+output:
+  dir: ./results
+  formats: [json, markdown]
+  delta: true

--- a/configs/local-m4pro-24gb-quiet.yaml
+++ b/configs/local-m4pro-24gb-quiet.yaml
@@ -1,0 +1,92 @@
+# Verdict config for a 24 GB Mac mini M4 Pro running evals in the background
+# while you keep using the machine. Optimized for "quiet default" — preserves
+# normal foreground responsiveness over peak local-model quality.
+#
+# - One model resident at a time (concurrency: 1).
+# - Short max_tokens to keep KV cache and total memory low.
+# - Local judge — runner looks up `judge.model` by id in `models[]`, so the
+#   judge inherits qwen2.5:7b's ollama endpoint automatically (no network
+#   calls during scoring).
+# - resource_guard gates the run on live machine state; the run aborts before
+#   starting if memory pressure exceeds `warn` or free disk is below 25 GB.
+#
+# Usage:
+#   verdict machine inspect --fast       # check state before kicking off
+#   verdict run -c configs/local-m4pro-24gb-quiet.yaml --resume
+#
+# For an exclusive-use frontier benchmark (gemma3:27b, qwen3:32b), see
+# configs/local-m4pro-24gb-frontier.yaml — do NOT keep that one always-on.
+
+version: "0.4"
+name: "Local M4 Pro 24GB — quiet"
+
+models:
+  - id: qwen2.5:7b
+    model: qwen2.5:7b
+    provider: ollama
+    base_url: http://localhost:11434/v1
+    api_key: none
+    max_tokens: 512
+    timeout_ms: 240000
+    tags: [local, free, quiet-default]
+
+  - id: qwen2.5-coder:7b
+    model: qwen2.5-coder:7b
+    provider: ollama
+    base_url: http://localhost:11434/v1
+    api_key: none
+    max_tokens: 512
+    timeout_ms: 240000
+    tags: [local, free, coding]
+
+  - id: llama3.1:8b
+    model: llama3.1:8b
+    provider: ollama
+    base_url: http://localhost:11434/v1
+    api_key: none
+    max_tokens: 512
+    timeout_ms: 240000
+    tags: [local, free]
+
+  - id: gemma4:e4b
+    model: gemma4:e4b
+    provider: ollama
+    base_url: http://localhost:11434/v1
+    api_key: none
+    max_tokens: 512
+    timeout_ms: 240000
+    tags: [local, free, multimodal]
+
+# The judge's `model` field is an id that the runner resolves against the
+# models[] entries above. That's why only `model` appears here — the rest
+# (provider, base_url, etc.) come from qwen2.5:7b's entry.
+judge:
+  model: qwen2.5:7b
+
+packs:
+  - ../eval-packs/general.yaml
+
+run:
+  concurrency: 1
+  retries: 1
+  cache: true
+  resource_guard:
+    enabled: true
+    on_fail: abort
+    max_concurrency: 1
+    min_free_disk_gb: 25
+    max_memory_pressure: warn
+    # Swap-delta is OFF by default in the quiet config (swap_sample_ms: 0)
+    # so the pre-run check stays fast. The max_swap_delta_mb threshold below
+    # only takes effect if you raise swap_sample_ms above 0 (try 2000 if you
+    # want active swap-growth gating during long runs).
+    swap_sample_ms: 0
+    max_swap_delta_mb: 200
+    # Re-check between cases every 60 s. The runner retries once after 2 s on
+    # the first failure, so transient spikes don't kill the run.
+    mid_run_check_seconds: 60
+
+output:
+  dir: ./results
+  formats: [json, markdown]
+  delta: true

--- a/configs/local-m4pro-24gb-quiet.yaml
+++ b/configs/local-m4pro-24gb-quiet.yaml
@@ -76,14 +76,13 @@ run:
     max_concurrency: 1
     min_free_disk_gb: 25
     max_memory_pressure: warn
-    # Swap-delta is OFF by default in the quiet config (swap_sample_ms: 0)
-    # so the pre-run check stays fast. The max_swap_delta_mb threshold below
-    # only takes effect if you raise swap_sample_ms above 0 (try 2000 if you
-    # want active swap-growth gating during long runs).
-    swap_sample_ms: 0
+    # Active swap-growth gating. This adds a short sample before the run and
+    # during mid-run checks, but catches the failure mode that matters on a
+    # 24 GB unified-memory machine: swap growing while evals are still running.
+    swap_sample_ms: 2000
     max_swap_delta_mb: 200
-    # Re-check between cases every 60 s. The runner retries once after 2 s on
-    # the first failure, so transient spikes don't kill the run.
+    # Re-check between cases every 60 s. If a threshold fails mid-run, the
+    # runner pauses before the next case and rechecks until the machine recovers.
     mid_run_check_seconds: 60
 
 output:

--- a/configs/model-catalog.yaml
+++ b/configs/model-catalog.yaml
@@ -110,7 +110,28 @@ models:
     params_b: 12
     default_quant: q4_K_M
     family: gemma
-    tags: [general]
+    tags: [general, long-context]
+
+  - name: "gemma3:27b"
+    provider: ollama
+    params_b: 27
+    default_quant: q4_K_M
+    family: gemma
+    tags: [general, long-context, large, benchmark-only]
+
+  - name: "qwen3:14b"
+    provider: ollama
+    params_b: 14
+    default_quant: q4_K_M
+    family: qwen
+    tags: [general, reasoning]
+
+  - name: "qwen3:32b"
+    provider: ollama
+    params_b: 32
+    default_quant: q4_K_M
+    family: qwen
+    tags: [general, reasoning, large, benchmark-only]
 
   - name: "gemma4:e4b"
     provider: ollama

--- a/src/cli/commands/__tests__/tiers.test.ts
+++ b/src/cli/commands/__tests__/tiers.test.ts
@@ -1,0 +1,23 @@
+import { afterEach, describe, expect, it, vi } from 'vitest'
+import { tiersShowCommand } from '../tiers.js'
+
+describe('tiers show command', () => {
+  afterEach(() => {
+    vi.restoreAllMocks()
+  })
+
+  it('keeps frontier pull commands out of the default pull guidance', () => {
+    const lines: string[] = []
+    vi.spyOn(console, 'log').mockImplementation((...args: unknown[]) => {
+      lines.push(args.join(' '))
+    })
+
+    tiersShowCommand('24gb')
+
+    const output = lines.join('\n')
+    expect(output).toContain('ollama pull qwen3:14b')
+    expect(output).not.toContain('ollama pull gemma3:27b')
+    expect(output).not.toContain('ollama pull qwen3:32b')
+    expect(output).toContain('verdict run --tier 24gb --frontier')
+  })
+})

--- a/src/cli/commands/machine.ts
+++ b/src/cli/commands/machine.ts
@@ -1,0 +1,104 @@
+/**
+ * `verdict machine inspect` — capture the live state of this machine and
+ * print a verdict that the rest of Verdict (and downstream agents) can use to
+ * decide whether to keep models warm, run a benchmark, or back off.
+ *
+ * Exit codes are 0 on any successful inspection. Use `--exit-on=<state>` to
+ * make CI scripts fail on a specific verdict; otherwise the verdict shows up
+ * in the printed summary and the JSON output but never crashes scripts.
+ */
+
+import chalk from 'chalk'
+import { createRealProbe, inspect, DEFAULT_THRESHOLDS, assertSupportedPlatform, type MachineSnapshot, type Verdict } from '../../core/machine.js'
+
+interface InspectOpts {
+  json?: boolean
+  fast?: boolean         // skip the 10 s swap-delta sample
+  exitOn?: string        // 'benchmark' | 'unsafe' — comma-separated also accepted
+}
+
+const VALID_EXIT_STATES: Verdict[] = ['quiet', 'benchmark', 'unsafe']
+
+export async function machineInspectCommand(opts: InspectOpts): Promise<void> {
+  try {
+    assertSupportedPlatform()
+  } catch (err) {
+    const msg = (err as Error).message
+    if (opts.json) {
+      process.stdout.write(JSON.stringify({ error: msg }) + '\n')
+    } else {
+      console.error(chalk.red('  ' + msg))
+    }
+    process.exitCode = 3
+    return
+  }
+
+  const probe = createRealProbe()
+  probe.onSampleStart = (delayMs: number) => {
+    if (opts.json) return
+    if (delayMs >= 1000) {
+      process.stderr.write(chalk.dim(`  sampling swap for ${Math.round(delayMs / 1000)}s...\n`))
+    }
+  }
+
+  const snap = await inspect(probe, DEFAULT_THRESHOLDS, {
+    swapSampleMs: opts.fast ? 0 : 10_000,
+  })
+
+  if (opts.json) {
+    process.stdout.write(JSON.stringify(snap) + '\n')
+  } else {
+    printSummary(snap)
+  }
+
+  // Default: exit 0 even on `unsafe`. CI scripts opt in to non-zero with --exit-on.
+  if (opts.exitOn) {
+    const states = opts.exitOn.split(',').map(s => s.trim()).filter(Boolean)
+    const bad = states.filter(s => !VALID_EXIT_STATES.includes(s as Verdict))
+    if (bad.length > 0) {
+      process.stderr.write(chalk.red(`  --exit-on: unknown state(s): ${bad.join(', ')} (valid: ${VALID_EXIT_STATES.join(', ')})\n`))
+      process.exitCode = 3
+      return
+    }
+    if (states.includes(snap.verdict.state)) process.exitCode = 1
+  }
+}
+
+function badge(state: Verdict): string {
+  if (state === 'quiet') return chalk.bgGreen.black(' QUIET ')
+  if (state === 'benchmark') return chalk.bgYellow.black(' BENCHMARK ')
+  return chalk.bgRed.white(' UNSAFE ')
+}
+
+function pressureBadge(p: 'normal' | 'warn' | 'critical'): string {
+  if (p === 'normal') return chalk.green(p)
+  if (p === 'warn') return chalk.yellow(p)
+  return chalk.red(p)
+}
+
+function printSummary(s: MachineSnapshot): void {
+  const hw = s.hardware
+  console.log()
+  console.log('  ' + chalk.bold('verdict') + chalk.dim(' machine inspect'))
+  console.log()
+  console.log('  ' + badge(s.verdict.state) + '  ' + chalk.dim(s.verdict.reasons.join(' / ')))
+  console.log()
+  console.log('  ' + chalk.dim('hardware  ') + `${hw.cpu} - ${hw.cpu_cores} cores - ${hw.ram_gb} GB ${hw.unified_memory ? '(unified)' : ''} - ${hw.os} ${hw.os_version}`)
+  console.log('  ' + chalk.dim('load      ') + `${s.load.load1.toFixed(2)} / ${s.load.load5.toFixed(2)} / ${s.load.load15.toFixed(2)}  ` + chalk.dim(`(load1/core ${s.load.load1_per_core.toFixed(2)})`))
+  const presSrc = s.memory.pressure_source === 'sysctl' ? '' : chalk.dim(` [${s.memory.pressure_source}]`)
+  console.log('  ' + chalk.dim('memory    ') + `pressure ${pressureBadge(s.memory.pressure)}${presSrc}  ` + chalk.dim(`free ${s.memory.free_pct.toFixed(0)}% / compressed ${s.memory.compressed_pct.toFixed(0)}% / wired ${s.memory.wired_pct.toFixed(0)}%`))
+  const deltaTxt = s.swap.delta_mb_over_sample === undefined
+    ? chalk.dim('(no sample)')
+    : `${s.swap.delta_mb_over_sample >= 0 ? '+' : ''}${s.swap.delta_mb_over_sample.toFixed(0)} MB over ${Math.round(s.swap.sample_ms / 1000)}s`
+  console.log('  ' + chalk.dim('swap      ') + `${s.swap.used_mb.toFixed(0)} / ${s.swap.total_mb.toFixed(0)} MB used - ${deltaTxt}`)
+  console.log('  ' + chalk.dim('disk      ') + `${s.disk.free_gb.toFixed(1)} GB free ` + chalk.dim(`(reserve ${s.disk.min_reserve_gb} GB)`))
+  if (s.ollama.available) {
+    const runningPart = s.ollama.running.length > 0
+      ? `${s.ollama.running.length} running (${s.ollama.running_total_gb.toFixed(1)} GB)`
+      : '0 running'
+    console.log('  ' + chalk.dim('ollama    ') + `${s.ollama.installed.length} installed - ${s.ollama.installed_total_gb.toFixed(1)} GB on disk - ${runningPart}`)
+  } else {
+    console.log('  ' + chalk.dim('ollama    ') + chalk.dim('not installed'))
+  }
+  console.log()
+}

--- a/src/cli/commands/run.ts
+++ b/src/cli/commands/run.ts
@@ -22,6 +22,7 @@ interface RunOptions {
   eval?: string
   models?: string
   tier?: string
+  frontier?: boolean
   dryRun?: boolean
   resume?: boolean
   question?: string
@@ -61,12 +62,15 @@ export async function runCommand(opts: RunOptions): Promise<void> {
   }
 
   if (opts.tier) {
-    const resolved = resolveTier(opts.tier)
+    const resolved = resolveTier(opts.tier, { mode: opts.frontier ? 'frontier' : 'default' })
     if (!resolved) {
       console.error(chalk.red(`  Unknown tier: ${opts.tier}`))
       console.error(chalk.dim(`  Available: ${listTierNames().join(', ')}`))
       console.error(chalk.dim(`  Run \`verdict tiers\` to see details.`))
       process.exit(1)
+    }
+    if (opts.frontier && (!resolved.tier.frontier || resolved.tier.frontier.length === 0)) {
+      log(chalk.yellow(`  --frontier: tier ${resolved.tier.name} has no frontier candidates; using the standard list.`))
     }
     // Replace the config's models with the tier preset, and override the judge
     // if the user hasn't explicitly set one in their config.
@@ -74,7 +78,10 @@ export async function runCommand(opts: RunOptions): Promise<void> {
     if (!config.judge?.model || config.judge.model === '') {
       config.judge = { ...config.judge, model: resolved.judge }
     }
-    log(`  ${chalk.bold('Tier:')}   ${chalk.cyan(resolved.tier.name)} ${chalk.dim('— ' + resolved.tier.description)}`)
+    const modeNote = opts.frontier && resolved.tier.frontier && resolved.tier.frontier.length > 0
+      ? chalk.yellow(' (frontier)')
+      : ''
+    log(`  ${chalk.bold('Tier:')}   ${chalk.cyan(resolved.tier.name)}${modeNote} ${chalk.dim('— ' + resolved.tier.description)}`)
   }
 
   if (opts.models) {

--- a/src/cli/commands/tiers.ts
+++ b/src/cli/commands/tiers.ts
@@ -90,12 +90,14 @@ export function tiersShowCommand(name: string): void {
   }
 
   console.log()
-  console.log(chalk.dim('  Pull the missing ones with:'))
-  const allModels = [...tier.models, ...(tier.frontier ?? [])]
-  for (const m of allModels) {
+  console.log(chalk.dim('  Pull the default-tier models with:'))
+  for (const m of tier.models) {
     if (m.provider === 'ollama') {
       console.log(chalk.dim('    ollama pull ') + chalk.white(m.model))
     }
+  }
+  if (tier.frontier && tier.frontier.length > 0) {
+    console.log(chalk.dim('  Frontier pulls are intentionally separate; use them only with --frontier.'))
   }
   console.log()
   console.log(chalk.dim('  Then run:'))

--- a/src/cli/commands/tiers.ts
+++ b/src/cli/commands/tiers.ts
@@ -74,9 +74,25 @@ export function tiersShowCommand(name: string): void {
       chalk.dim(m.notes ?? '')
     )
   }
+
+  if (tier.frontier && tier.frontier.length > 0) {
+    console.log()
+    console.log('  ' + chalk.yellow('frontier (benchmark-only — not for 24/7 use):'))
+    for (const m of tier.frontier) {
+      console.log(
+        '  ' +
+        chalk.white(m.id.padEnd(28)) +
+        chalk.cyan(m.provider.padEnd(12)) +
+        chalk.white(`${m.size_gb} GB`.padEnd(10)) +
+        chalk.dim(m.notes ?? '')
+      )
+    }
+  }
+
   console.log()
   console.log(chalk.dim('  Pull the missing ones with:'))
-  for (const m of tier.models) {
+  const allModels = [...tier.models, ...(tier.frontier ?? [])]
+  for (const m of allModels) {
     if (m.provider === 'ollama') {
       console.log(chalk.dim('    ollama pull ') + chalk.white(m.model))
     }
@@ -84,5 +100,8 @@ export function tiersShowCommand(name: string): void {
   console.log()
   console.log(chalk.dim('  Then run:'))
   console.log('    ' + chalk.cyan(`verdict run --tier ${tier.name}`))
+  if (tier.frontier && tier.frontier.length > 0) {
+    console.log('    ' + chalk.cyan(`verdict run --tier ${tier.name} --frontier`) + chalk.dim('   # include frontier candidates'))
+  }
   console.log()
 }

--- a/src/cli/index.ts
+++ b/src/cli/index.ts
@@ -25,6 +25,7 @@ import { badgeCommand } from './commands/badge.js'
 import { quantsCommand } from './commands/quants.js'
 import { tiersListCommand, tiersShowCommand } from './commands/tiers.js'
 import { shareCommand } from './commands/share.js'
+import { machineInspectCommand } from './commands/machine.js'
 import { onboardingCommand } from '../onboarding/cli.js'
 import { readMark } from '../onboarding/persistence.js'
 import fs from 'fs'
@@ -62,6 +63,7 @@ program
   .option('-e, --eval <names>', 'Run named eval(s) from registry, comma-separated')
   .option('-m, --models <ids>', 'Run specific model(s), comma-separated')
   .option('--tier <name>', 'Use a hardware-tier preset (8gb, 16gb, 24gb, 32gb, 64gb). Replaces the config models. Run `verdict tiers` to see.')
+  .option('--frontier', 'When combined with --tier, include the tier\'s frontier (benchmark-only) candidates — larger models that are too tight to keep resident 24/7.')
   .option('--dry-run', 'Preview without calling any APIs')
   .option('--resume', 'Resume from last checkpoint')
   .option('--question <text>', 'Question for synthesis agent to answer after eval')
@@ -184,6 +186,18 @@ program
   .option('--port <n>', 'Port to listen on', '4000')
   .option('--ui', 'Also serve a local read-only dashboard at / (no auth, localhost only)')
   .action(serveCommand)
+
+const machine = program
+  .command('machine')
+  .description('Inspect this machine — CPU load, memory pressure, swap, disk, and an actionable verdict')
+
+machine
+  .command('inspect')
+  .description('Snapshot the current machine state and return a quiet/benchmark/unsafe verdict')
+  .option('--json', 'Output snapshot as JSON (single line, machine-readable)')
+  .option('--fast', 'Skip the 10 s swap-delta sample (lower fidelity, faster)')
+  .option('--exit-on <states>', 'Exit non-zero if verdict matches one of: quiet,benchmark,unsafe (comma-separated)')
+  .action(machineInspectCommand)
 
 program
   .command('share <result-json>')

--- a/src/core/__tests__/hardware.test.ts
+++ b/src/core/__tests__/hardware.test.ts
@@ -1,13 +1,24 @@
 import { describe, expect, it } from 'vitest'
-import { checkFit, estimateRamGB, type HardwareInfo } from '../hardware.js'
+import { checkFit, estimateRamGB, estimateKvCacheGB, type HardwareInfo } from '../hardware.js'
 
+// Non-Apple Silicon by default so existing tests don't pick up the new
+// auto-detected unified-memory reserve. Tests that care about Apple Silicon
+// set cpuArch + os explicitly.
 const baseHardware: HardwareInfo = {
   cpu: 'Test CPU',
   cpuCores: 8,
-  cpuArch: 'arm64',
+  cpuArch: 'x64',
   ram: '32 GB',
   ramGB: 32,
   freeDiskGB: 100,
+  os: 'Linux',
+  osVersion: '6.0',
+}
+
+const appleSiliconHardware: HardwareInfo = {
+  ...baseHardware,
+  cpu: 'Apple M4 Pro',
+  cpuArch: 'arm64',
   os: 'macOS',
   osVersion: '15.0',
 }
@@ -30,35 +41,185 @@ describe('estimateRamGB', () => {
   })
 })
 
+describe('estimateKvCacheGB', () => {
+  it('is zero at zero context', () => {
+    expect(estimateKvCacheGB(7, 0)).toBe(0)
+  })
+
+  it('is zero for zero-param models', () => {
+    expect(estimateKvCacheGB(0, 8192)).toBe(0)
+  })
+
+  it('scales linearly with context (within rounding tolerance)', () => {
+    // Use a model size large enough that toFixed(2) rounding doesn't dominate.
+    const at8k = estimateKvCacheGB(70, 8192)
+    const at32k = estimateKvCacheGB(70, 32768)
+    expect(at32k / at8k).toBeCloseTo(4, 0)
+  })
+
+  it('grows with model size at fixed context', () => {
+    expect(estimateKvCacheGB(14, 8192)).toBeGreaterThan(estimateKvCacheGB(7, 8192))
+  })
+
+  it('does not blow up at 70B at 128K (modern GQA assumption)', () => {
+    // Real GQA models at this scale need ~10-15 GB KV. A formula that
+    // predicted 78 GB would falsely reject every 70B pull at high context.
+    expect(estimateKvCacheGB(70, 128_000)).toBeLessThan(20)
+  })
+})
+
 describe('checkFit', () => {
-  it('allows a model that fits comfortably', () => {
+  it('allows a model that fits comfortably and returns a full details breakdown', () => {
     const fit = checkFit(
       { name: 'qwen2.5:7b', params_b: 7, quant: 'q4_K_M' },
       baseHardware
     )
 
     expect(fit.fits).toBe(true)
-    expect(fit.needs_gb).toBe(4.2)
-    expect(fit.available_gb).toBe(28)
+    expect(fit.needs_gb).toBeGreaterThan(0)
+    expect(fit.available_gb).toBe(28) // 32 - 4 headroom on non-Apple-Silicon
+    expect(fit.details.weights_gb).toBeCloseTo(3.5, 1)        // 7 * 0.5
+    expect(fit.details.activation_overhead_gb).toBeCloseTo(0.53, 1) // 3.5 * 0.15
+    expect(fit.details.kv_cache_gb).toBeGreaterThan(0)
+    expect(fit.details.unified_reserve_gb).toBe(0)            // not Apple Silicon
+    expect(fit.details.free_disk_after_pull_gb).toBeDefined()
   })
 
-  it('rejects a model that exceeds available RAM', () => {
+  it('rejects a model that exceeds available RAM with a decomposed reason', () => {
     const fit = checkFit(
       { name: 'llama3.1:70b', params_b: 70, quant: 'q4_K_M' },
       baseHardware
     )
 
     expect(fit.fits).toBe(false)
-    expect(fit.reason).toContain('needs 42 GB RAM')
+    expect(fit.reason).toContain('weights')
+    expect(fit.reason).toContain('kv')
   })
 
-  it('rejects a model when disk space is too low', () => {
+  it('rejects when free disk drops below the reserve after pull', () => {
+    // 7B q4 ≈ ~3.7 GB on disk; min reserve 25; free 28 → 24.3 < 25 → reject.
+    const fit = checkFit(
+      { name: 'qwen2.5:7b', params_b: 7, quant: 'q4_K_M' },
+      { ...baseHardware, freeDiskGB: 28 },
+      { min_free_disk_gb: 25 },
+    )
+    expect(fit.fits).toBe(false)
+    expect(fit.reason).toMatch(/reserve is 25/)
+    expect(fit.details.free_disk_after_pull_gb).toBeLessThan(25)
+  })
+
+  it('reserve boundary uses unrounded math (24.95 is still < 25)', () => {
+    // Construct a case where rounded free-after-pull == 25.0 but real < 25.
+    // 7B q4 on-disk ≈ 7 * 0.5 * 1.05 = 3.675 GB. Free 28.625 → exact 24.95 → rounds to 25.0 but should reject.
+    const fit = checkFit(
+      { name: 'qwen2.5:7b', params_b: 7, quant: 'q4_K_M' },
+      { ...baseHardware, freeDiskGB: 28.625 },
+      { min_free_disk_gb: 25 },
+    )
+    expect(fit.fits).toBe(false)
+  })
+
+  it('reports "needs N GB" when the download is bigger than free disk (oversize branch)', () => {
     const fit = checkFit(
       { name: 'qwen2.5:7b', params_b: 7, quant: 'q4_K_M' },
       { ...baseHardware, freeDiskGB: 2 }
     )
 
     expect(fit.fits).toBe(false)
-    expect(fit.reason).toContain('free disk')
+    expect(fit.reason).toMatch(/needs about/)
+    expect(fit.reason).not.toMatch(/reserve is/)
+  })
+
+  it('critical pressure tightens headroom (3×) but still allows tiny models on big machines', () => {
+    // 1B q4 on a 64 GB machine: weights 0.5 + activations 0.075 + tiny KV.
+    // Headroom under critical = 4 * 3 = 12 GB. Available = 52 GB. Easy fit.
+    const fit = checkFit(
+      { name: 'tiny:1b', params_b: 1, quant: 'q4_K_M' },
+      { ...baseHardware, ramGB: 64 },
+      { memory_pressure: 'critical' },
+    )
+    expect(fit.fits).toBe(true)
+    expect(fit.details.headroom_gb).toBe(12)
+  })
+
+  it('critical pressure rejects a big model that would otherwise just fit', () => {
+    // 14B q4: weights 7, activations 1.05, KV ~0.15 → ~8.2 GB.
+    // 16 GB machine, headroom 4 default → 12 GB available → fits at normal.
+    // Under critical, headroom = 12 → 4 GB available → rejected.
+    const normal = checkFit(
+      { name: 'mid:14b', params_b: 14, quant: 'q4_K_M' },
+      { ...baseHardware, ramGB: 16 },
+      { memory_pressure: 'normal' },
+    )
+    expect(normal.fits).toBe(true)
+    const critical = checkFit(
+      { name: 'mid:14b', params_b: 14, quant: 'q4_K_M' },
+      { ...baseHardware, ramGB: 16 },
+      { memory_pressure: 'critical' },
+    )
+    expect(critical.fits).toBe(false)
+    expect(critical.reason).toMatch(/pressure critical/)
+  })
+
+  it('warn pressure tightens default headroom but respects caller-supplied headroom_gb', () => {
+    const warnDefault = checkFit(
+      { name: 'fake', params_b: 7, quant: 'q4_K_M' },
+      baseHardware,
+      { memory_pressure: 'warn' },
+    )
+    expect(warnDefault.details.headroom_gb).toBe(6) // 4 * 1.5
+
+    const warnCustom = checkFit(
+      { name: 'fake', params_b: 7, quant: 'q4_K_M' },
+      baseHardware,
+      { memory_pressure: 'warn', headroom_gb: 8 },
+    )
+    // Caller-supplied 8 is NOT bumped by the pressure multiplier.
+    expect(warnCustom.details.headroom_gb).toBe(8)
+  })
+
+  it('auto-detects Apple Silicon and adds the unified-memory reserve', () => {
+    const fit = checkFit(
+      { name: 'qwen2.5:7b', params_b: 7, quant: 'q4_K_M' },
+      appleSiliconHardware,
+    )
+    expect(fit.details.unified_reserve_gb).toBe(2)
+    expect(fit.available_gb).toBe(26) // 32 - 4 headroom - 2 unified
+  })
+
+  it('respects explicit unified_memory: false on Apple Silicon', () => {
+    const fit = checkFit(
+      { name: 'qwen2.5:7b', params_b: 7, quant: 'q4_K_M' },
+      appleSiliconHardware,
+      { unified_memory: false },
+    )
+    expect(fit.details.unified_reserve_gb).toBe(0)
+  })
+
+  it('scales the KV cache budget with the context window', () => {
+    const small = checkFit(
+      { name: 'qwen2.5:14b', params_b: 14, quant: 'q4_K_M' },
+      baseHardware,
+      { context_tokens: 4096 },
+    )
+    const huge = checkFit(
+      { name: 'qwen2.5:14b', params_b: 14, quant: 'q4_K_M' },
+      baseHardware,
+      { context_tokens: 128_000 },
+    )
+    expect(huge.details.kv_cache_gb).toBeGreaterThan(small.details.kv_cache_gb)
+    expect(huge.needs_gb).toBeGreaterThan(small.needs_gb)
+  })
+
+  it('rejection details always include the model size breakdown (no zeros)', () => {
+    // The previous critical-pressure short-circuit zeroed these out.
+    const fit = checkFit(
+      { name: 'big:32b', params_b: 32, quant: 'q4_K_M' },
+      { ...baseHardware, ramGB: 16 },
+      { memory_pressure: 'critical' },
+    )
+    expect(fit.fits).toBe(false)
+    expect(fit.details.weights_gb).toBeGreaterThan(0)
+    expect(fit.details.activation_overhead_gb).toBeGreaterThan(0)
   })
 })

--- a/src/core/__tests__/machine.test.ts
+++ b/src/core/__tests__/machine.test.ts
@@ -1,0 +1,337 @@
+import { describe, expect, it } from 'vitest'
+import {
+  computeMemoryPressureFallback,
+  computeVerdict,
+  inspect,
+  DEFAULT_THRESHOLDS,
+  _internals,
+  type Probe,
+} from '../machine.js'
+
+const { parseVmStat, parseSwapusage, parseOllamaList, parseOllamaPs, parsePressureLevel, parseFixedWidthTable, sizeStringToBytes } = _internals
+
+describe('parseVmStat', () => {
+  it('extracts free/compressed/wired percentages with resident-only denominator', () => {
+    const sample = `Mach Virtual Memory Statistics: (page size of 16384 bytes)
+Pages free:                               13390.
+Pages active:                            212848.
+Pages inactive:                          211560.
+Pages speculative:                          638.
+Pages throttled:                              0.
+Pages wired down:                        548260.
+Pages purgeable:                           5321.
+"Translation faults":                1848998619.
+Pages copy-on-write:                 1125438525.
+Pages zero filled:                    610233789.
+Pages reactivated:                     30098147.
+Pages purged:                           8163814.
+File-backed pages:                       135240.
+Anonymous pages:                         289806.
+Pages stored in compressor:             1397820.`
+    const out = parseVmStat(sample)
+    expect(out).toBeDefined()
+    expect(out!.free_pct).toBeGreaterThan(0)
+    expect(out!.wired_pct).toBeGreaterThan(0)
+    // Six-class denominator: percentages must each be in [0, 100].
+    expect(out!.free_pct).toBeLessThanOrEqual(100)
+    expect(out!.compressed_pct).toBeLessThanOrEqual(100)
+    expect(out!.wired_pct).toBeLessThanOrEqual(100)
+    // And they cannot exceed 100 in aggregate.
+    expect(out!.free_pct + out!.compressed_pct + out!.wired_pct).toBeLessThanOrEqual(100)
+  })
+
+  it('returns undefined on malformed input', () => {
+    expect(parseVmStat('not a vm_stat output')).toBeUndefined()
+  })
+
+  it('returns undefined when required page-class lines are missing', () => {
+    expect(parseVmStat('Mach Virtual Memory Statistics: (page size of 16384 bytes)\nPages free: 100.')).toBeUndefined()
+  })
+})
+
+describe('parseSwapusage', () => {
+  it('parses total/used from sysctl output', () => {
+    expect(parseSwapusage('total = 3072.00M  used = 2334.19M  free = 737.81M  (encrypted)')).toEqual({
+      total_mb: 3072,
+      used_mb: 2334.19,
+    })
+  })
+
+  it('returns undefined on missing fields', () => {
+    expect(parseSwapusage('garbage')).toBeUndefined()
+  })
+})
+
+describe('parsePressureLevel', () => {
+  it('maps 0/1/2+ to normal/warn/critical', () => {
+    expect(parsePressureLevel('0')).toBe('normal')
+    expect(parsePressureLevel('1')).toBe('warn')
+    expect(parsePressureLevel('2')).toBe('critical')
+    expect(parsePressureLevel('4')).toBe('critical')
+  })
+
+  it('returns undefined on non-numeric input', () => {
+    expect(parsePressureLevel('garbage')).toBeUndefined()
+  })
+})
+
+describe('parseFixedWidthTable + size parsing', () => {
+  it('preserves spaces inside columns (e.g. "100% GPU")', () => {
+    const out = `NAME              ID      SIZE    PROCESSOR      CONTEXT    UNTIL
+qwen2.5:7b        abc123  5.0 GB  100% GPU       4096       4 minutes from now`
+    const rows = parseFixedWidthTable(out)
+    expect(rows).toHaveLength(1)
+    expect(rows[0]['NAME']).toBe('qwen2.5:7b')
+    expect(rows[0]['SIZE']).toBe('5.0 GB')
+    expect(rows[0]['PROCESSOR']).toBe('100% GPU')
+    expect(rows[0]['CONTEXT']).toBe('4096')
+  })
+
+  it('sizeStringToBytes handles GB/MB/KB', () => {
+    expect(sizeStringToBytes('4.7 GB')).toBeCloseTo(4.7 * 1024 ** 3, -3)
+    expect(sizeStringToBytes('250 MB')).toBeCloseTo(250 * 1024 ** 2, -3)
+    expect(sizeStringToBytes('  9.3GB ')).toBeCloseTo(9.3 * 1024 ** 3, -3)
+    expect(sizeStringToBytes('garbage')).toBe(0)
+  })
+})
+
+describe('parseOllamaList', () => {
+  it('parses rows from a realistic ollama list output', () => {
+    const out = `NAME                       ID              SIZE      MODIFIED
+qwen2.5:7b                 845dbda0ea48    4.7 GB    3 days ago
+llama3.2:3b                a80c4f17acd5    2.0 GB    3 days ago`
+    const rows = parseOllamaList(out)
+    expect(rows).toHaveLength(2)
+    expect(rows[0].name).toBe('qwen2.5:7b')
+    expect(rows[0].size_bytes).toBeCloseTo(4.7 * 1024 ** 3, -6)
+    expect(rows[0].modified).toBe('3 days ago')
+  })
+})
+
+describe('parseOllamaPs', () => {
+  it('extracts SIZE and CONTEXT correctly even when PROCESSOR has spaces', () => {
+    const out = `NAME              ID      SIZE    PROCESSOR      CONTEXT    UNTIL
+qwen2.5:7b        abc123  5.0 GB  100% GPU       4096       4 minutes from now
+gemma3:12b        def456  8.1 GB  50% CPU/GPU    8192       1 minute from now`
+    const rows = parseOllamaPs(out)
+    expect(rows).toHaveLength(2)
+    expect(rows[0].name).toBe('qwen2.5:7b')
+    expect(rows[0].size_bytes).toBeCloseTo(5.0 * 1024 ** 3, -3)
+    expect(rows[0].processor).toBe('100% GPU')
+    expect(rows[0].context).toBe(4096)
+    expect(rows[1].processor).toBe('50% CPU/GPU')
+  })
+
+  it('returns no rows for an empty `ollama ps` (header only)', () => {
+    expect(parseOllamaPs('NAME    ID    SIZE    PROCESSOR    CONTEXT    UNTIL')).toEqual([])
+  })
+})
+
+describe('computeMemoryPressureFallback', () => {
+  it('returns normal when free is high and swap is small', () => {
+    expect(computeMemoryPressureFallback({ free_pct: 50, compressed_pct: 5 }, { used_mb: 0 }, DEFAULT_THRESHOLDS)).toBe('normal')
+  })
+
+  it('returns critical when free is below critical threshold', () => {
+    expect(computeMemoryPressureFallback({ free_pct: 3, compressed_pct: 0 }, { used_mb: 0 }, DEFAULT_THRESHOLDS)).toBe('critical')
+  })
+
+  it('returns critical when swap usage exceeds 4 GB', () => {
+    expect(computeMemoryPressureFallback({ free_pct: 30, compressed_pct: 0 }, { used_mb: 5000 }, DEFAULT_THRESHOLDS)).toBe('critical')
+  })
+
+  it('returns warn on heavy compression', () => {
+    expect(computeMemoryPressureFallback({ free_pct: 50, compressed_pct: 45 }, { used_mb: 0 }, DEFAULT_THRESHOLDS)).toBe('warn')
+  })
+
+  it('returns warn when vm stat is unavailable', () => {
+    expect(computeMemoryPressureFallback(undefined, undefined, DEFAULT_THRESHOLDS)).toBe('warn')
+  })
+})
+
+describe('computeVerdict', () => {
+  const base = {
+    load1_per_core: 0.2,
+    pressure: 'normal' as const,
+    swap_delta_mb: 0,
+    free_disk_gb: 100,
+    running_total_gb: 0,
+    ram_gb: 24,
+    t: DEFAULT_THRESHOLDS,
+  }
+
+  it('is quiet when everything is nominal', () => {
+    expect(computeVerdict(base).state).toBe('quiet')
+  })
+
+  it('escalates to benchmark on high load', () => {
+    expect(computeVerdict({ ...base, load1_per_core: 0.8 }).state).toBe('benchmark')
+  })
+
+  it('escalates to unsafe on critical load', () => {
+    expect(computeVerdict({ ...base, load1_per_core: 1.5 }).state).toBe('unsafe')
+  })
+
+  it('escalates to unsafe on critical pressure', () => {
+    expect(computeVerdict({ ...base, pressure: 'critical' }).state).toBe('unsafe')
+  })
+
+  it('escalates to unsafe on swap growth above threshold', () => {
+    expect(computeVerdict({ ...base, swap_delta_mb: 500 }).state).toBe('unsafe')
+  })
+
+  it('escalates to benchmark when free disk dips below reserve', () => {
+    expect(computeVerdict({ ...base, free_disk_gb: 20 }).state).toBe('benchmark')
+  })
+
+  it('escalates to unsafe when free disk is critically low', () => {
+    expect(computeVerdict({ ...base, free_disk_gb: 5 }).state).toBe('unsafe')
+  })
+
+  it('escalates to benchmark when running models claim >=60% of RAM', () => {
+    expect(computeVerdict({ ...base, running_total_gb: 15, ram_gb: 24 }).state).toBe('benchmark')
+  })
+
+  it('escalates to unsafe when running models claim >=85% of RAM', () => {
+    expect(computeVerdict({ ...base, running_total_gb: 22, ram_gb: 24 }).state).toBe('unsafe')
+  })
+
+  it('keeps the worst state across multiple signals', () => {
+    const v = computeVerdict({ ...base, load1_per_core: 0.8, pressure: 'critical' })
+    expect(v.state).toBe('unsafe')
+    expect(v.reasons.length).toBeGreaterThanOrEqual(2)
+  })
+})
+
+describe('inspect()', () => {
+  function fakeProbe(overrides: Partial<Probe> = {}): Probe {
+    return {
+      loadAvg: () => [0.2, 0.2, 0.2],
+      pressureSysctl: () => 'normal',
+      vmStat: () => ({ free_pct: 50, compressed_pct: 5, wired_pct: 20 }),
+      swapUsage: () => ({ total_mb: 3072, used_mb: 100 }),
+      swapUsageAfterDelay: async () => ({ total_mb: 3072, used_mb: 110 }),
+      freeDiskGB: () => 100,
+      ollamaList: () => [
+        { name: 'qwen2.5:7b', size_bytes: 4.7 * 1024 ** 3 },
+      ],
+      ollamaPs: () => [],
+      hardware: () => ({
+        cpu: 'Apple M4 Pro',
+        cpu_cores: 12,
+        cpu_arch: 'arm64',
+        apple_silicon: true,
+        unified_memory: true,
+        ram_gb: 24,
+        os: 'macOS',
+        os_version: '15.0',
+      }),
+      ...overrides,
+    }
+  }
+
+  it('produces a quiet verdict on a nominal machine using sysctl pressure', async () => {
+    const snap = await inspect(fakeProbe(), DEFAULT_THRESHOLDS, { swapSampleMs: 0 })
+    expect(snap.verdict.state).toBe('quiet')
+    expect(snap.memory.pressure_source).toBe('sysctl')
+    expect(snap.swap.delta_mb_over_sample).toBe(10)
+    expect(snap.swap.sample_ms).toBe(0)
+    expect(snap.ollama.available).toBe(true)
+  })
+
+  it('produces an unsafe verdict when probes report a thrashing system', async () => {
+    const snap = await inspect(
+      fakeProbe({
+        loadAvg: () => [15, 12, 10],
+        pressureSysctl: () => 'critical',
+        swapUsage: () => ({ total_mb: 3072, used_mb: 2800 }),
+        swapUsageAfterDelay: async () => ({ total_mb: 3072, used_mb: 3300 }),
+        freeDiskGB: () => 8,
+      }),
+      DEFAULT_THRESHOLDS,
+      { swapSampleMs: 0 },
+    )
+    expect(snap.verdict.state).toBe('unsafe')
+    expect(snap.verdict.reasons.length).toBeGreaterThan(1)
+  })
+
+  it('falls back to vm_stat when sysctl pressure is unavailable', async () => {
+    const snap = await inspect(
+      fakeProbe({
+        pressureSysctl: () => undefined,
+        vmStat: () => ({ free_pct: 3, compressed_pct: 0, wired_pct: 30 }),
+      }),
+      DEFAULT_THRESHOLDS,
+      { swapSampleMs: 0 },
+    )
+    expect(snap.memory.pressure_source).toBe('vm_stat')
+    expect(snap.memory.pressure).toBe('critical')
+  })
+
+  it('reports pressure_source unavailable when neither sysctl nor vm_stat work', async () => {
+    const snap = await inspect(
+      fakeProbe({ pressureSysctl: () => undefined, vmStat: () => undefined }),
+      DEFAULT_THRESHOLDS,
+      { swapSampleMs: 0 },
+    )
+    expect(snap.memory.pressure_source).toBe('unavailable')
+  })
+
+  it('feeds running ollama models into the verdict', async () => {
+    const snap = await inspect(
+      fakeProbe({
+        ollamaPs: () => [
+          { name: 'qwen3:32b', size_bytes: 22 * 1024 ** 3, processor: '100% GPU', context: 8192 },
+        ],
+      }),
+      DEFAULT_THRESHOLDS,
+      { swapSampleMs: 0 },
+    )
+    expect(snap.ollama.running_total_gb).toBeCloseTo(22, 1)
+    expect(snap.verdict.state).toBe('unsafe')
+    expect(snap.verdict.reasons.some(r => r.includes('running models claim'))).toBe(true)
+  })
+
+  it('handles missing Ollama gracefully', async () => {
+    const snap = await inspect(
+      fakeProbe({ ollamaList: () => undefined, ollamaPs: () => undefined }),
+      DEFAULT_THRESHOLDS,
+      { swapSampleMs: 0 },
+    )
+    expect(snap.ollama.available).toBe(false)
+    expect(snap.ollama.installed).toEqual([])
+    expect(snap.ollama.running).toEqual([])
+  })
+
+  it('handles missing swap probe (returns undefined delta)', async () => {
+    const snap = await inspect(
+      fakeProbe({
+        swapUsage: () => undefined,
+        swapUsageAfterDelay: async () => undefined,
+      }),
+      DEFAULT_THRESHOLDS,
+      { swapSampleMs: 0 },
+    )
+    expect(snap.swap.delta_mb_over_sample).toBeUndefined()
+  })
+
+  it('invokes the onSampleStart hook when the sample duration is > 0', async () => {
+    const calls: number[] = []
+    await inspect(
+      fakeProbe({ onSampleStart: (ms) => calls.push(ms) }),
+      DEFAULT_THRESHOLDS,
+      { swapSampleMs: 5 },
+    )
+    expect(calls).toEqual([5])
+  })
+
+  it('does not invoke onSampleStart in --fast mode (sample 0)', async () => {
+    const calls: number[] = []
+    await inspect(
+      fakeProbe({ onSampleStart: (ms) => calls.push(ms) }),
+      DEFAULT_THRESHOLDS,
+      { swapSampleMs: 0 },
+    )
+    expect(calls).toEqual([])
+  })
+})

--- a/src/core/__tests__/resource-guard.test.ts
+++ b/src/core/__tests__/resource-guard.test.ts
@@ -1,0 +1,179 @@
+import { describe, expect, it } from 'vitest'
+import {
+  evaluateGuard,
+  effectiveConcurrency,
+  describeDisabledMisconfig,
+  type ResourceGuardConfig,
+} from '../resource-guard.js'
+import type { MachineSnapshot } from '../machine.js'
+
+const baseConfig: ResourceGuardConfig = {
+  enabled: true,
+  on_fail: 'abort',
+  min_free_disk_gb: 25,
+  max_memory_pressure: 'warn',
+  max_swap_delta_mb: 200,
+  swap_sample_ms: 0,
+  mid_run_check_seconds: 0,
+}
+
+function snapshot(overrides: Partial<MachineSnapshot> = {}): MachineSnapshot {
+  return {
+    ts: '2026-05-24T18:00:00.000Z',
+    hardware: {
+      cpu: 'Apple M4 Pro', cpu_cores: 12, cpu_arch: 'arm64',
+      apple_silicon: true, unified_memory: true, ram_gb: 24,
+      os: 'macOS', os_version: '15.0',
+    },
+    load: { load1: 1, load5: 1, load15: 1, load1_per_core: 0.083 },
+    memory: { free_pct: 30, compressed_pct: 10, wired_pct: 20, pressure: 'normal', pressure_source: 'sysctl' },
+    swap: { total_mb: 3072, used_mb: 100, delta_mb_over_sample: 5, sample_ms: 0 },
+    disk: { free_gb: 50, min_reserve_gb: 25 },
+    ollama: { available: true, installed: [], running: [], installed_total_gb: 0, running_total_gb: 0 },
+    verdict: { state: 'quiet', reasons: ['nominal'] },
+    ...overrides,
+  }
+}
+
+describe('evaluateGuard', () => {
+  it('passes a nominal snapshot', () => {
+    const r = evaluateGuard(snapshot(), baseConfig)
+    expect(r.ok).toBe(true)
+    expect(r.reason).toBeUndefined()
+  })
+
+  it('fails when memory pressure exceeds max_memory_pressure', () => {
+    const r = evaluateGuard(snapshot({
+      memory: { free_pct: 5, compressed_pct: 50, wired_pct: 20, pressure: 'critical', pressure_source: 'sysctl' },
+    }), baseConfig)
+    expect(r.ok).toBe(false)
+    expect(r.reason).toMatch(/pressure critical/)
+  })
+
+  it('passes when pressure equals max_memory_pressure (warn === warn)', () => {
+    const r = evaluateGuard(snapshot({
+      memory: { free_pct: 8, compressed_pct: 30, wired_pct: 20, pressure: 'warn', pressure_source: 'sysctl' },
+    }), baseConfig)
+    expect(r.ok).toBe(true)
+  })
+
+  it('tightening max_memory_pressure to normal rejects a machine in warn', () => {
+    const r = evaluateGuard(snapshot({
+      memory: { free_pct: 8, compressed_pct: 30, wired_pct: 20, pressure: 'warn', pressure_source: 'sysctl' },
+    }), { ...baseConfig, max_memory_pressure: 'normal' })
+    expect(r.ok).toBe(false)
+  })
+
+  it('fails when free disk is below the reserve', () => {
+    const r = evaluateGuard(snapshot({
+      disk: { free_gb: 20, min_reserve_gb: 25 },
+    }), baseConfig)
+    expect(r.ok).toBe(false)
+    expect(r.reason).toMatch(/free disk/)
+  })
+
+  it('skips the disk check when the probe reported 0 GB free', () => {
+    const r = evaluateGuard(snapshot({
+      disk: { free_gb: 0, min_reserve_gb: 25 },
+    }), baseConfig)
+    expect(r.ok).toBe(true)
+    const disk = r.checks.find(c => c.rule === 'free_disk')
+    expect(disk?.skipped).toBe(true)
+  })
+
+  it('skips the swap-delta check when swap_sample_ms is 0', () => {
+    const r = evaluateGuard(snapshot({
+      swap: { total_mb: 3072, used_mb: 100, delta_mb_over_sample: 9999, sample_ms: 0 },
+    }), { ...baseConfig, swap_sample_ms: 0 })
+    const swap = r.checks.find(c => c.rule === 'swap_delta')
+    expect(swap?.skipped).toBe(true)
+    expect(r.ok).toBe(true) // skipped, so doesn't fail
+  })
+
+  it('evaluates swap-delta when swap_sample_ms > 0 and snapshot has a delta', () => {
+    const r = evaluateGuard(snapshot({
+      swap: { total_mb: 3072, used_mb: 100, delta_mb_over_sample: 500, sample_ms: 2000 },
+    }), { ...baseConfig, swap_sample_ms: 2000 })
+    expect(r.ok).toBe(false)
+    expect(r.reason).toMatch(/swap grew/)
+  })
+
+  it('skips swap-delta when sample window > 0 but delta is unavailable from snapshot', () => {
+    const r = evaluateGuard(snapshot({
+      swap: { total_mb: 3072, used_mb: 100, delta_mb_over_sample: undefined, sample_ms: 2000 },
+    }), { ...baseConfig, swap_sample_ms: 2000 })
+    const swap = r.checks.find(c => c.rule === 'swap_delta')
+    expect(swap?.skipped).toBe(true)
+  })
+
+  it('surfaces a concurrency conflict but does not fail the gate', () => {
+    const r = evaluateGuard(snapshot(), {
+      ...baseConfig,
+      max_concurrency: 1,
+    }, /* configuredConcurrency */ 4)
+    expect(r.ok).toBe(true)
+    const conc = r.checks.find(c => c.rule === 'concurrency')
+    expect(conc).toBeDefined()
+    expect(conc!.ok).toBe(false)
+    expect(conc!.detail).toMatch(/will be clamped/)
+  })
+
+  it('reports multiple failures concatenated in reason', () => {
+    const r = evaluateGuard(snapshot({
+      memory: { free_pct: 2, compressed_pct: 60, wired_pct: 20, pressure: 'critical', pressure_source: 'sysctl' },
+      disk: { free_gb: 10, min_reserve_gb: 25 },
+      swap: { total_mb: 3072, used_mb: 100, delta_mb_over_sample: 800, sample_ms: 2000 },
+    }), { ...baseConfig, swap_sample_ms: 2000 })
+    expect(r.ok).toBe(false)
+    expect(r.reason).toMatch(/pressure critical/)
+    expect(r.reason).toMatch(/free disk/)
+    expect(r.reason).toMatch(/swap grew/)
+  })
+
+  it('includes verdict from the snapshot in the result', () => {
+    const r = evaluateGuard(snapshot({ verdict: { state: 'unsafe', reasons: ['x'] } }), baseConfig)
+    expect(r.verdict).toBe('unsafe')
+  })
+})
+
+describe('effectiveConcurrency', () => {
+  it('returns the configured value when the guard is disabled', () => {
+    expect(effectiveConcurrency(4, undefined)).toBe(4)
+    expect(effectiveConcurrency(4, { ...baseConfig, enabled: false })).toBe(4)
+  })
+
+  it('returns the configured value when no max_concurrency is set', () => {
+    expect(effectiveConcurrency(4, baseConfig)).toBe(4)
+  })
+
+  it('clamps to max_concurrency when configured concurrency is higher', () => {
+    expect(effectiveConcurrency(4, { ...baseConfig, max_concurrency: 1 })).toBe(1)
+  })
+
+  it('does not raise concurrency when configured is lower than max_concurrency', () => {
+    expect(effectiveConcurrency(1, { ...baseConfig, max_concurrency: 4 })).toBe(1)
+  })
+})
+
+describe('describeDisabledMisconfig', () => {
+  it('returns undefined when the guard is enabled', () => {
+    expect(describeDisabledMisconfig({ ...baseConfig, max_concurrency: 1 })).toBeUndefined()
+  })
+
+  it('returns undefined when disabled and no non-default fields set', () => {
+    expect(describeDisabledMisconfig({ ...baseConfig, enabled: false })).toBeUndefined()
+  })
+
+  it('warns when disabled but the user set thresholds that will be ignored', () => {
+    const msg = describeDisabledMisconfig({
+      ...baseConfig,
+      enabled: false,
+      max_concurrency: 1,
+      min_free_disk_gb: 50,
+    })
+    expect(msg).toBeDefined()
+    expect(msg).toMatch(/max_concurrency=1/)
+    expect(msg).toMatch(/min_free_disk_gb=50/)
+    expect(msg).toMatch(/ignored/)
+  })
+})

--- a/src/core/__tests__/runner.test.ts
+++ b/src/core/__tests__/runner.test.ts
@@ -1,4 +1,4 @@
-import { describe, it, expect, vi, beforeEach } from 'vitest'
+import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest'
 import type { Config, EvalPack, ModelResponse, JudgeScore } from '../../types/index.js'
 
 // Mock providers and judge before importing runner
@@ -10,6 +10,22 @@ vi.mock('../../providers/compat.js', () => ({
 
 vi.mock('../../judge/llm.js', () => ({
   judgeResponse: vi.fn(),
+}))
+
+vi.mock('../preload.js', () => ({
+  preloadModels: vi.fn().mockResolvedValue([]),
+}))
+
+vi.mock('../machine.js', () => ({
+  createRealProbe: vi.fn(() => ({ kind: 'probe' })),
+}))
+
+vi.mock('../resource-guard.js', () => ({
+  evaluateGuardLive: vi.fn(),
+  effectiveConcurrency: vi.fn((configured: number, cfg?: { enabled?: boolean; max_concurrency?: number }) => (
+    cfg?.enabled && cfg.max_concurrency !== undefined ? Math.min(configured, cfg.max_concurrency) : configured
+  )),
+  describeDisabledMisconfig: vi.fn(() => undefined),
 }))
 
 // Mock fs to avoid writing checkpoint files during tests
@@ -36,6 +52,8 @@ vi.mock('fs', async (importOriginal) => {
 import { runEvals, computeConfigHash } from '../runner.js'
 import { callModel, callModelMultiTurn, callModelWithTools } from '../../providers/compat.js'
 import { judgeResponse } from '../../judge/llm.js'
+import { preloadModels } from '../preload.js'
+import { evaluateGuardLive, effectiveConcurrency, describeDisabledMisconfig } from '../resource-guard.js'
 
 // --- Helpers ---
 
@@ -57,6 +75,31 @@ function makeJudgeScore(total = 8): JudgeScore {
     total,
     reasoning: 'Good response.',
   }
+}
+
+function makeResourceGuardConfig() {
+  return {
+    enabled: true,
+    on_fail: 'abort' as const,
+    max_concurrency: 1,
+    min_free_disk_gb: 25,
+    max_memory_pressure: 'warn' as const,
+    max_swap_delta_mb: 200,
+    swap_sample_ms: 2000,
+    mid_run_check_seconds: 0,
+  }
+}
+
+function makeGuardLiveResult(ok = true, reason?: string) {
+  return {
+    snapshot: { verdict: { state: ok ? 'quiet' : 'unsafe' } },
+    guard: {
+      ok,
+      verdict: ok ? 'quiet' : 'unsafe',
+      checks: [],
+      reason,
+    },
+  } as unknown as Awaited<ReturnType<typeof evaluateGuardLive>>
 }
 
 function makeConfig(overrides?: Partial<Config>): Config {
@@ -99,6 +142,16 @@ function makePack(cases: Array<Partial<EvalPack['cases'][number]> & { id: string
 
 beforeEach(() => {
   vi.clearAllMocks()
+  vi.mocked(preloadModels).mockResolvedValue([])
+  vi.mocked(evaluateGuardLive).mockResolvedValue(makeGuardLiveResult())
+  vi.mocked(effectiveConcurrency).mockImplementation((configured: number, cfg?: { enabled?: boolean; max_concurrency?: number }) => (
+    cfg?.enabled && cfg.max_concurrency !== undefined ? Math.min(configured, cfg.max_concurrency) : configured
+  ))
+  vi.mocked(describeDisabledMisconfig).mockReturnValue(undefined)
+})
+
+afterEach(() => {
+  vi.useRealTimers()
 })
 
 describe('computeConfigHash', () => {
@@ -260,6 +313,83 @@ describe('runEvals', () => {
     ])
 
     await expect(runEvals(config, [pack])).rejects.toThrow("Judge model 'nonexistent-model' not found")
+  })
+
+  it('runs resource_guard before preloading models', async () => {
+    const order: string[] = []
+    const config = makeConfig({
+      run: { concurrency: 3, retries: 2, cache: true, resource_guard: makeResourceGuardConfig() },
+    })
+    const pack = makePack([
+      { id: 'case-1', prompt: 'Hello', criteria: 'Be polite', scorer: 'llm', tags: [], judge_type: 'llm', max_tokens: undefined },
+    ])
+
+    vi.mocked(evaluateGuardLive).mockImplementation(async () => {
+      order.push('guard')
+      return makeGuardLiveResult()
+    })
+    vi.mocked(preloadModels).mockImplementation(async () => {
+      order.push('preload')
+      return []
+    })
+    vi.mocked(callModel).mockResolvedValue(makeModelResponse('model-a'))
+    vi.mocked(judgeResponse).mockResolvedValue(makeJudgeScore(8))
+
+    await runEvals(config, [pack])
+
+    expect(order.slice(0, 2)).toEqual(['guard', 'preload'])
+  })
+
+  it('aborts before preload when the start resource_guard fails', async () => {
+    const config = makeConfig({
+      run: { concurrency: 3, retries: 2, cache: true, resource_guard: makeResourceGuardConfig() },
+    })
+    const pack = makePack([
+      { id: 'case-1', prompt: 'Hello', criteria: 'Be polite', scorer: 'llm', tags: [], judge_type: 'llm', max_tokens: undefined },
+    ])
+
+    vi.mocked(evaluateGuardLive).mockResolvedValueOnce(makeGuardLiveResult(false, 'pressure critical'))
+
+    await expect(runEvals(config, [pack])).rejects.toThrow(/resource_guard refused to start/)
+    expect(preloadModels).not.toHaveBeenCalled()
+    expect(callModel).not.toHaveBeenCalled()
+  })
+
+  it('pauses mid-run until resource_guard recovers when on_fail is abort', async () => {
+    vi.useFakeTimers()
+    vi.setSystemTime(0)
+    const messages: string[] = []
+    const config = makeConfig({
+      run: {
+        concurrency: 3,
+        retries: 2,
+        cache: true,
+        resource_guard: { ...makeResourceGuardConfig(), mid_run_check_seconds: 0.001 },
+      },
+    })
+    const pack = makePack([
+      { id: 'case-1', prompt: 'Hello', criteria: 'Be polite', scorer: 'llm', tags: [], judge_type: 'llm', max_tokens: undefined },
+    ])
+
+    vi.mocked(preloadModels).mockImplementation(async () => {
+      vi.setSystemTime(1000)
+      return []
+    })
+    vi.mocked(evaluateGuardLive)
+      .mockResolvedValueOnce(makeGuardLiveResult())
+      .mockResolvedValueOnce(makeGuardLiveResult(false, 'swap grew 500 MB during sample'))
+      .mockResolvedValueOnce(makeGuardLiveResult())
+    vi.mocked(callModel).mockResolvedValue(makeModelResponse('model-a'))
+    vi.mocked(judgeResponse).mockResolvedValue(makeJudgeScore(8))
+
+    const runPromise = runEvals(config, [pack], msg => messages.push(msg))
+    await vi.advanceTimersByTimeAsync(2000)
+    const result = await runPromise
+
+    expect(result.cases).toHaveLength(1)
+    expect(messages.some(m => m.includes('pause before case-1'))).toBe(true)
+    expect(messages.some(m => m.includes('recovered; resuming before case-1'))).toBe(true)
+    expect(callModel).toHaveBeenCalled()
   })
 
   it('handles model errors gracefully with zero scores', async () => {

--- a/src/core/__tests__/tiers.test.ts
+++ b/src/core/__tests__/tiers.test.ts
@@ -102,5 +102,34 @@ describe('tiers', () => {
       expect(a?.tier.name).toBe(b?.tier.name)
       expect(a?.models.length).toBe(b?.models.length)
     })
+
+    it('default mode does not include frontier models', () => {
+      const r = resolveTier('24gb')
+      const ids = r!.models.map(m => m.id)
+      expect(ids).not.toContain('qwen3:32b')
+      expect(ids).not.toContain('gemma3:27b')
+    })
+
+    it('frontier mode includes the larger benchmark-only candidates', () => {
+      const r = resolveTier('24gb', { mode: 'frontier' })
+      const ids = r!.models.map(m => m.id)
+      expect(ids).toContain('qwen3:32b')
+      expect(ids).toContain('gemma3:27b')
+      // Safe defaults still present
+      expect(ids).toContain('qwen2.5:7b')
+    })
+
+    it('frontier mode is a no-op for tiers without a frontier list', () => {
+      const r = resolveTier('8gb', { mode: 'frontier' })
+      const base = resolveTier('8gb')
+      expect(r!.models.length).toBe(base!.models.length)
+    })
+
+    it('24gb tier includes qwen3:14b and gemma3:12b as primary candidates', () => {
+      const r = resolveTier('24gb')
+      const ids = r!.models.map(m => m.id)
+      expect(ids).toContain('qwen3:14b')
+      expect(ids).toContain('gemma3:12b')
+    })
   })
 })

--- a/src/core/hardware.ts
+++ b/src/core/hardware.ts
@@ -23,7 +23,13 @@ function quantBytesPerParam(quant: string): number {
 }
 
 /**
- * Estimate RAM needed to run a quantized model, including KV cache and runtime overhead.
+ * Estimate RAM needed to run a quantized model, including a baseline KV cache
+ * at the common 8K context. Keep this function stable — onboarding/planner
+ * and the catalog UI use it for at-a-glance estimates.
+ *
+ * `checkFit` does its own decomposition (weights + overhead + KV) so it can
+ * scale the KV cache by the actual context window the caller plans to use,
+ * without changing this function's contract.
  */
 export function estimateRamGB(params_b: number, quant: string): number {
   return +(params_b * quantBytesPerParam(quant) * 1.2).toFixed(1)
@@ -31,6 +37,35 @@ export function estimateRamGB(params_b: number, quant: string): number {
 
 function estimateDiskGB(params_b: number, quant: string): number {
   return +(params_b * quantBytesPerParam(quant) * 1.05).toFixed(1)
+}
+
+/** Raw weights at the given quantization, no overhead, no KV cache. */
+function estimateWeightsGB(params_b: number, quant: string): number {
+  return +(params_b * quantBytesPerParam(quant)).toFixed(2)
+}
+
+/** Activations, kernels, framework overhead. Empirically ~15% of weights. */
+function estimateActivationOverheadGB(weights_gb: number): number {
+  return +(weights_gb * 0.15).toFixed(2)
+}
+
+/**
+ * Estimate KV-cache footprint for a given context window. This is a *rough*
+ * heuristic intended for headroom-gating, not exact memory accounting:
+ *
+ *  - The constant is calibrated for modern GQA architectures (Llama-3, Qwen2,
+ *    Mistral). Non-GQA models (older Llama-1/2, some 3B research models) will
+ *    use more cache than this estimate predicts; flag this in the fit reason
+ *    rather than refusing the pull.
+ *  - llama.cpp can quantize the cache (`-ctk q4_0`). We assume fp16 cache;
+ *    callers using a quantized cache will be over-budgeted, which is the
+ *    safer error direction.
+ *
+ * 7B at 8K ≈ 0.07 GB; 14B at 32K ≈ 0.6 GB; 70B at 128K ≈ 12 GB. Linear in both.
+ */
+export function estimateKvCacheGB(params_b: number, context_tokens: number): number {
+  if (context_tokens <= 0 || params_b <= 0) return 0
+  return +(params_b * context_tokens * 0.0000013).toFixed(2)
 }
 
 function detectFreeDiskGB(): number | undefined {
@@ -47,34 +82,145 @@ function detectFreeDiskGB(): number | undefined {
   }
 }
 
+export interface CheckFitOpts {
+  /** OS headroom (GB) reserved for the rest of the system. Default 4. */
+  headroom_gb?: number
+  /**
+   * Minimum free disk we want to keep after the download. Default 25 GB
+   * (matches the Phase-1 resource_guard default). The pull is rejected if
+   * accepting it would push free disk below this threshold.
+   */
+  min_free_disk_gb?: number
+  /**
+   * Current memory pressure (from `verdict machine inspect`, or any caller).
+   * Multiplies the *default* OS headroom — not a caller-supplied
+   * `headroom_gb`, so callers can pin their own budget. critical = 3×, warn
+   * = 1.5×, normal = 1×. Critical does NOT short-circuit-reject; small
+   * models that fit even under tight headroom still pass.
+   */
+  memory_pressure?: 'normal' | 'warn' | 'critical'
+  /**
+   * Context window the model will be used at. Default 8192 — matches the
+   * common case. Larger contexts pay for themselves in KV cache headroom.
+   */
+  context_tokens?: number
+  /**
+   * Apple Silicon shares RAM between CPU and GPU. When true (or
+   * auto-detected from `hw.cpuArch === 'arm64' && hw.os === 'macOS'`), reserve
+   * an extra 2 GB because Metal allocations and macOS UI all come out of the
+   * same pool. Pass `false` to force-disable.
+   */
+  unified_memory?: boolean
+}
+
+export interface CheckFitResult {
+  fits: boolean
+  needs_gb: number
+  available_gb: number
+  reason?: string
+  details: {
+    weights_gb: number
+    activation_overhead_gb: number
+    kv_cache_gb: number
+    headroom_gb: number
+    unified_reserve_gb: number
+    free_disk_after_pull_gb?: number
+  }
+}
+
 /**
- * Check whether the current machine has enough RAM and disk for a model.
+ * Check whether the current machine has enough RAM and disk for a model,
+ * given current memory pressure, KV-cache requirements at the planned
+ * context window, and the disk reserve we want to keep free.
+ *
+ * The budget is decomposed into weights + activations + KV cache so callers
+ * can show users *why* a model is tight or rejected. The check is intended
+ * to be called from runtime gating code (e.g. `verdict run`) as well as the
+ * onboarding planner.
  */
 export function checkFit(
   model: { name: string; params_b: number; quant: string },
   hw: HardwareInfo,
-  opts?: { headroom_gb?: number }
-): { fits: boolean; needs_gb: number; available_gb: number; reason?: string } {
-  const headroomGB = opts?.headroom_gb ?? 4
-  const needsGB = estimateRamGB(model.params_b, model.quant)
-  const availableGB = Math.max(0, +(hw.ramGB - headroomGB).toFixed(1))
+  opts?: CheckFitOpts
+): CheckFitResult {
+  const callerHeadroom = opts?.headroom_gb
+  const pressure = opts?.memory_pressure ?? 'normal'
+  const contextTokens = opts?.context_tokens ?? 8192
+  const minFreeDisk = opts?.min_free_disk_gb ?? 25
 
-  if (needsGB > availableGB) {
+  // Pressure multiplier applies only to the *default* OS headroom, not to a
+  // caller-supplied value. A pro user who deliberately set headroom_gb: 8
+  // shouldn't have it secretly bumped to 12 when pressure spikes.
+  const pressureMultiplier = pressure === 'critical' ? 3 : pressure === 'warn' ? 1.5 : 1
+  const headroomGB = callerHeadroom !== undefined
+    ? callerHeadroom
+    : +(4 * pressureMultiplier).toFixed(1)
+
+  // Auto-detect Apple Silicon when caller didn't specify. Unified-memory
+  // machines pay an extra reserve for Metal + OS UI.
+  const isAppleSilicon = hw.cpuArch === 'arm64' && hw.os === 'macOS'
+  const unifiedMemory = opts?.unified_memory ?? isAppleSilicon
+  const unifiedReserveGB = unifiedMemory ? 2 : 0
+
+  // Decompose the RAM budget so we don't double-count KV (the legacy
+  // `estimateRamGB` already had an implicit KV allowance baked into its 1.2×
+  // overhead — checkFit avoids that by going to first principles).
+  const weightsGB = estimateWeightsGB(model.params_b, model.quant)
+  const activationGB = estimateActivationOverheadGB(weightsGB)
+  const kvCacheGB = estimateKvCacheGB(model.params_b, contextTokens)
+  const needsGBraw = weightsGB + activationGB + kvCacheGB
+  const needsGB = +needsGBraw.toFixed(1)
+  const availableGBraw = Math.max(0, hw.ramGB - headroomGB - unifiedReserveGB)
+  const availableGB = +availableGBraw.toFixed(1)
+
+  const details: CheckFitResult['details'] = {
+    weights_gb: weightsGB,
+    activation_overhead_gb: activationGB,
+    kv_cache_gb: kvCacheGB,
+    headroom_gb: headroomGB,
+    unified_reserve_gb: unifiedReserveGB,
+  }
+
+  if (needsGBraw > availableGBraw) {
+    const pressureNote = pressure !== 'normal' ? ` (pressure ${pressure} → ${pressureMultiplier}× default headroom)` : ''
     return {
       fits: false,
       needs_gb: needsGB,
       available_gb: availableGB,
-      reason: `${model.name} needs ${needsGB} GB RAM at ${model.quant}; ${availableGB} GB available after ${headroomGB} GB headroom`,
+      reason: `${model.name} needs ${needsGB} GB (weights ${weightsGB} + activations ${activationGB} + kv ${kvCacheGB} at ${contextTokens} ctx) at ${model.quant}; ${availableGB} GB available after ${headroomGB} GB OS headroom${unifiedReserveGB ? ` + ${unifiedReserveGB} GB unified-memory reserve` : ''}${pressureNote}`,
+      details,
     }
   }
 
   const diskGB = estimateDiskGB(model.params_b, model.quant)
-  if (hw.freeDiskGB !== undefined && diskGB > hw.freeDiskGB) {
+  if (hw.freeDiskGB !== undefined) {
+    // Check oversize first (clearer error than "would leave -X GB").
+    if (diskGB > hw.freeDiskGB) {
+      return {
+        fits: false,
+        needs_gb: needsGB,
+        available_gb: availableGB,
+        reason: `${model.name} needs about ${diskGB} GB free disk to download; ${hw.freeDiskGB} GB available`,
+        details: { ...details, free_disk_after_pull_gb: +(hw.freeDiskGB - diskGB).toFixed(1) },
+      }
+    }
+    const freeAfterPullRaw = hw.freeDiskGB - diskGB
+    const freeAfterPull = +freeAfterPullRaw.toFixed(1)
+    // Use the *unrounded* comparison so 24.95 isn't presented as "25 GB free, OK".
+    if (freeAfterPullRaw < minFreeDisk) {
+      return {
+        fits: false,
+        needs_gb: needsGB,
+        available_gb: availableGB,
+        reason: `${model.name} would leave ${freeAfterPull} GB free after pull; reserve is ${minFreeDisk} GB`,
+        details: { ...details, free_disk_after_pull_gb: freeAfterPull },
+      }
+    }
     return {
-      fits: false,
+      fits: true,
       needs_gb: needsGB,
       available_gb: availableGB,
-      reason: `${model.name} needs about ${diskGB} GB free disk to download; ${hw.freeDiskGB} GB available`,
+      details: { ...details, free_disk_after_pull_gb: freeAfterPull },
     }
   }
 
@@ -82,6 +228,7 @@ export function checkFit(
     fits: true,
     needs_gb: needsGB,
     available_gb: availableGB,
+    details,
   }
 }
 

--- a/src/core/machine.ts
+++ b/src/core/machine.ts
@@ -1,0 +1,490 @@
+/**
+ * Machine-headroom inspection (macOS).
+ *
+ * Captures the live state of this machine — CPU load, memory pressure, swap,
+ * free disk, installed/running Ollama models — and produces a single verdict
+ * (`quiet` / `benchmark` / `unsafe`) that the rest of Verdict uses to decide
+ * whether to keep models warm, run a benchmark, or back off.
+ *
+ * Pure logic lives here so it can be unit-tested with a fake `Probe`. The CLI
+ * wrapper at `src/cli/commands/machine.ts` is the only place that runs real
+ * subprocesses.
+ *
+ * Phase 1 scope is macOS only; non-Darwin platforms get a clear error rather
+ * than a half-baked snapshot.
+ */
+
+import { execSync } from 'child_process'
+import os from 'os'
+
+export type Verdict = 'quiet' | 'benchmark' | 'unsafe'
+export type MemoryPressure = 'normal' | 'warn' | 'critical'
+
+export interface OllamaModel {
+  name: string
+  size_bytes: number
+  modified?: string
+}
+
+export interface OllamaRunning {
+  name: string
+  size_bytes: number
+  context?: number
+  processor?: string
+}
+
+export interface MachineSnapshot {
+  ts: string
+  hardware: {
+    cpu: string
+    cpu_cores: number
+    cpu_arch: string
+    apple_silicon: boolean
+    unified_memory: boolean
+    ram_gb: number
+    os: string
+    os_version: string
+  }
+  load: {
+    load1: number
+    load5: number
+    load15: number
+    load1_per_core: number
+  }
+  memory: {
+    free_pct: number
+    compressed_pct: number
+    wired_pct: number
+    pressure: MemoryPressure
+    pressure_source: 'sysctl' | 'vm_stat' | 'unavailable'
+  }
+  swap: {
+    total_mb: number
+    used_mb: number
+    delta_mb_over_sample?: number
+    sample_ms: number
+  }
+  disk: {
+    free_gb: number
+    min_reserve_gb: number
+  }
+  ollama: {
+    available: boolean
+    installed: OllamaModel[]
+    running: OllamaRunning[]
+    installed_total_gb: number
+    running_total_gb: number
+  }
+  verdict: {
+    state: Verdict
+    reasons: string[]
+  }
+}
+
+export interface Thresholds {
+  /** Disk reserve we want to keep free; below this we refuse pulls. */
+  min_free_disk_gb: number
+  /** Swap growth (MB) during the sample beyond which swap is "growing fast". */
+  max_swap_delta_mb: number
+  /** load1 / cpu_cores ratio above which load is "high". */
+  load_high_ratio: number
+  /** load1 / cpu_cores ratio above which load is "critical". */
+  load_critical_ratio: number
+  /** Free memory % below which we're in `warn` (fallback path only). */
+  mem_free_warn_pct: number
+  /** Free memory % below which we're in `critical` (fallback path only). */
+  mem_free_critical_pct: number
+  /**
+   * Fraction of total RAM that running Ollama models are allowed to occupy
+   * before we escalate to `benchmark`. 0.7 means: if running models claim more
+   * than 70% of RAM (e.g. 17 GB on a 24 GB machine), back off.
+   */
+  running_model_ram_warn_ratio: number
+  /** Same as above but escalates to `unsafe`. */
+  running_model_ram_critical_ratio: number
+}
+
+export const DEFAULT_THRESHOLDS: Thresholds = {
+  min_free_disk_gb: 25,
+  max_swap_delta_mb: 200,
+  load_high_ratio: 0.7,
+  load_critical_ratio: 1.0,
+  mem_free_warn_pct: 10,
+  mem_free_critical_pct: 5,
+  running_model_ram_warn_ratio: 0.6,
+  running_model_ram_critical_ratio: 0.85,
+}
+
+/**
+ * Pluggable probe — real impl lives in this file (createRealProbe), fake impl
+ * in tests. Every probe call returns `undefined` on failure rather than
+ * throwing, so partial machines (e.g. no Ollama installed) still snapshot.
+ */
+export interface Probe {
+  loadAvg(): [number, number, number]
+  /** Canonical macOS pressure (0=normal, 1=warn, 2=critical) via sysctl. */
+  pressureSysctl(): MemoryPressure | undefined
+  /** Page-class breakdown, used for display + fallback when sysctl is unavailable. */
+  vmStat(): { free_pct: number; compressed_pct: number; wired_pct: number } | undefined
+  swapUsage(): { total_mb: number; used_mb: number } | undefined
+  swapUsageAfterDelay(delayMs: number): Promise<{ total_mb: number; used_mb: number } | undefined>
+  freeDiskGB(): number | undefined
+  ollamaList(): OllamaModel[] | undefined
+  ollamaPs(): OllamaRunning[] | undefined
+  hardware(): MachineSnapshot['hardware']
+  /** Optional progress hook, called once just before the swap sample sleep. */
+  onSampleStart?(delayMs: number): void
+}
+
+/** Compute pressure when the canonical sysctl is unavailable (e.g. on a fake probe). */
+export function computeMemoryPressureFallback(
+  vm: { free_pct: number; compressed_pct: number } | undefined,
+  swap: { used_mb: number } | undefined,
+  t: Thresholds,
+): MemoryPressure {
+  if (!vm) return 'warn'
+  const free = vm.free_pct
+  const swapUsedMb = swap?.used_mb ?? 0
+  if (free < t.mem_free_critical_pct) return 'critical'
+  if (swapUsedMb > 4096) return 'critical'
+  if (free < t.mem_free_warn_pct) return 'warn'
+  if (swapUsedMb > 1024) return 'warn'
+  if (vm.compressed_pct > 40) return 'warn'
+  return 'normal'
+}
+
+export function computeVerdict(args: {
+  load1_per_core: number
+  pressure: MemoryPressure
+  swap_delta_mb: number | undefined
+  free_disk_gb: number | undefined
+  running_total_gb: number
+  ram_gb: number
+  t: Thresholds
+}): { state: Verdict; reasons: string[] } {
+  const { load1_per_core, pressure, swap_delta_mb, free_disk_gb, running_total_gb, ram_gb, t } = args
+  const reasons: string[] = []
+  let state: Verdict = 'quiet'
+
+  const rank: Record<Verdict, number> = { quiet: 0, benchmark: 1, unsafe: 2 }
+  const escalate = (next: Verdict, reason: string) => {
+    reasons.push(reason)
+    if (rank[next] > rank[state]) state = next
+  }
+
+  if (load1_per_core >= t.load_critical_ratio) {
+    escalate('unsafe', `load1/core ${load1_per_core.toFixed(2)} >= ${t.load_critical_ratio}`)
+  } else if (load1_per_core >= t.load_high_ratio) {
+    escalate('benchmark', `load1/core ${load1_per_core.toFixed(2)} >= ${t.load_high_ratio}`)
+  }
+
+  if (pressure === 'critical') {
+    escalate('unsafe', 'memory pressure critical')
+  } else if (pressure === 'warn') {
+    escalate('benchmark', 'memory pressure warn')
+  }
+
+  if (swap_delta_mb !== undefined && swap_delta_mb > t.max_swap_delta_mb) {
+    escalate('unsafe', `swap grew ${swap_delta_mb.toFixed(0)} MB during sample`)
+  } else if (swap_delta_mb !== undefined && swap_delta_mb > t.max_swap_delta_mb / 2) {
+    escalate('benchmark', `swap grew ${swap_delta_mb.toFixed(0)} MB during sample`)
+  }
+
+  if (free_disk_gb !== undefined) {
+    if (free_disk_gb < t.min_free_disk_gb / 2) {
+      escalate('unsafe', `free disk ${free_disk_gb.toFixed(1)} GB below half of ${t.min_free_disk_gb} GB reserve`)
+    } else if (free_disk_gb < t.min_free_disk_gb) {
+      escalate('benchmark', `free disk ${free_disk_gb.toFixed(1)} GB < ${t.min_free_disk_gb} GB reserve`)
+    }
+  }
+
+  if (ram_gb > 0 && running_total_gb > 0) {
+    const ratio = running_total_gb / ram_gb
+    if (ratio >= t.running_model_ram_critical_ratio) {
+      escalate('unsafe', `running models claim ${running_total_gb.toFixed(1)} GB (>= ${(t.running_model_ram_critical_ratio * 100).toFixed(0)}% of RAM)`)
+    } else if (ratio >= t.running_model_ram_warn_ratio) {
+      escalate('benchmark', `running models claim ${running_total_gb.toFixed(1)} GB (>= ${(t.running_model_ram_warn_ratio * 100).toFixed(0)}% of RAM)`)
+    }
+  }
+
+  if (reasons.length === 0) reasons.push('all thresholds nominal')
+  return { state, reasons }
+}
+
+/** Build a full snapshot from a Probe. Public entry-point for the CLI. */
+export async function inspect(probe: Probe, t: Thresholds = DEFAULT_THRESHOLDS, opts?: { swapSampleMs?: number }): Promise<MachineSnapshot> {
+  const swapSampleMs = opts?.swapSampleMs ?? 10_000
+  const hardware = probe.hardware()
+  const [l1, l5, l15] = probe.loadAvg()
+  const vm = probe.vmStat()
+  const swap0 = probe.swapUsage()
+
+  if (swapSampleMs > 0) probe.onSampleStart?.(swapSampleMs)
+  const swap1 = await probe.swapUsageAfterDelay(swapSampleMs)
+
+  const free_disk_gb = probe.freeDiskGB()
+  const installed = probe.ollamaList()
+  const running = probe.ollamaPs()
+
+  // Canonical pressure first, vm_stat-based fallback only if unavailable.
+  const sysctlPressure = probe.pressureSysctl()
+  const pressure: MemoryPressure = sysctlPressure ?? computeMemoryPressureFallback(vm, swap0, t)
+  const pressure_source: 'sysctl' | 'vm_stat' | 'unavailable' =
+    sysctlPressure ? 'sysctl' : (vm ? 'vm_stat' : 'unavailable')
+
+  const swap_delta_mb = (swap0 && swap1)
+    ? +(swap1.used_mb - swap0.used_mb).toFixed(1)
+    : undefined
+
+  const load1_per_core = hardware.cpu_cores > 0 ? l1 / hardware.cpu_cores : l1
+
+  const installed_total_gb = (installed ?? []).reduce((acc, m) => acc + m.size_bytes / (1024 ** 3), 0)
+  const running_total_gb = (running ?? []).reduce((acc, m) => acc + m.size_bytes / (1024 ** 3), 0)
+
+  const verdict = computeVerdict({
+    load1_per_core,
+    pressure,
+    swap_delta_mb,
+    free_disk_gb,
+    running_total_gb,
+    ram_gb: hardware.ram_gb,
+    t,
+  })
+
+  return {
+    ts: new Date().toISOString(),
+    hardware,
+    load: {
+      load1: l1,
+      load5: l5,
+      load15: l15,
+      load1_per_core: +load1_per_core.toFixed(3),
+    },
+    memory: {
+      free_pct: vm?.free_pct ?? 0,
+      compressed_pct: vm?.compressed_pct ?? 0,
+      wired_pct: vm?.wired_pct ?? 0,
+      pressure,
+      pressure_source,
+    },
+    swap: {
+      total_mb: swap0?.total_mb ?? 0,
+      used_mb: swap0?.used_mb ?? 0,
+      delta_mb_over_sample: swap_delta_mb,
+      sample_ms: swapSampleMs,
+    },
+    disk: {
+      free_gb: free_disk_gb ?? 0,
+      min_reserve_gb: t.min_free_disk_gb,
+    },
+    ollama: {
+      available: installed !== undefined,
+      installed: installed ?? [],
+      running: running ?? [],
+      installed_total_gb: +installed_total_gb.toFixed(1),
+      running_total_gb: +running_total_gb.toFixed(1),
+    },
+    verdict,
+  }
+}
+
+// ---- Real probe (live system) ----------------------------------------------
+
+function safe<T>(fn: () => T): T | undefined {
+  try { return fn() } catch { return undefined }
+}
+
+function parseVmStat(out: string): { free_pct: number; compressed_pct: number; wired_pct: number } | undefined {
+  // Display-only percentages: the verdict's `pressure` comes from
+  // kern.memorystatus_vm_pressure_level (canonical macOS signal), not these
+  // numbers. On macOS, "Pages stored in compressor" represents pages that
+  // hold compressed copies of anonymous memory — they are physical pages
+  // resident in the compressor pool, not counted in active/inactive. So the
+  // denominator includes all six classes and the resulting percentages sum
+  // to at most 100%.
+  const pageSizeMatch = out.match(/page size of (\d+) bytes/)
+  if (!pageSizeMatch) return undefined
+  const pick = (label: string): number | undefined => {
+    const m = out.match(new RegExp(`${label}:\\s+(\\d+)`))
+    return m ? Number(m[1]) : undefined
+  }
+  const free = pick('Pages free')
+  const active = pick('Pages active')
+  const inactive = pick('Pages inactive')
+  const speculative = pick('Pages speculative') ?? 0
+  const wired = pick('Pages wired down')
+  const compressed = pick('Pages stored in compressor') ?? 0
+  if (free === undefined || active === undefined || inactive === undefined || wired === undefined) return undefined
+  const total = free + active + inactive + speculative + wired + compressed
+  if (total === 0) return undefined
+  return {
+    free_pct: +((free + speculative) / total * 100).toFixed(1),
+    compressed_pct: +(compressed / total * 100).toFixed(1),
+    wired_pct: +(wired / total * 100).toFixed(1),
+  }
+}
+
+function parseSwapusage(out: string): { total_mb: number; used_mb: number } | undefined {
+  const m = out.match(/total = ([\d.]+)M\s+used = ([\d.]+)M/)
+  if (!m) return undefined
+  return { total_mb: Number(m[1]), used_mb: Number(m[2]) }
+}
+
+function sizeStringToBytes(s: string): number {
+  // Tolerates "4.7 GB", "4.7GB", "470 MB", etc.
+  const m = s.match(/([\d.]+)\s*(GB|MB|KB|B)/i)
+  if (!m) return 0
+  const n = Number(m[1])
+  const unit = m[2].toUpperCase()
+  const mult = unit === 'GB' ? 1024 ** 3 : unit === 'MB' ? 1024 ** 2 : unit === 'KB' ? 1024 : 1
+  return n * mult
+}
+
+/**
+ * Parse a fixed-width table (used for both `ollama list` and `ollama ps`).
+ * Returns one record per data row keyed by header column.
+ *
+ * We can't split on whitespace alone — `ollama ps`'s PROCESSOR column contains
+ * strings like "100% GPU" with internal spaces. Instead we record the column
+ * start positions from the header row and slice each data line by position.
+ */
+function parseFixedWidthTable(out: string): Array<Record<string, string>> {
+  const lines = out.split('\n').filter(l => l.length > 0)
+  if (lines.length < 2) return []
+  const header = lines[0]
+  const cols: Array<{ name: string; start: number; end: number }> = []
+  const tokens = [...header.matchAll(/\S+/g)]
+  for (let i = 0; i < tokens.length; i++) {
+    const tok = tokens[i]
+    const start = tok.index ?? 0
+    const next = tokens[i + 1]
+    const end = next ? (next.index ?? header.length) : header.length
+    cols.push({ name: tok[0], start, end })
+  }
+  const rows: Array<Record<string, string>> = []
+  for (let i = 1; i < lines.length; i++) {
+    const line = lines[i]
+    const row: Record<string, string> = {}
+    for (const c of cols) {
+      row[c.name] = line.slice(c.start, c.end === header.length ? line.length : c.end).trim()
+    }
+    rows.push(row)
+  }
+  return rows
+}
+
+function parseOllamaList(out: string): OllamaModel[] {
+  return parseFixedWidthTable(out).map(r => ({
+    name: r['NAME'] ?? '',
+    size_bytes: sizeStringToBytes(r['SIZE'] ?? ''),
+    modified: r['MODIFIED'] || undefined,
+  })).filter(m => m.name.length > 0)
+}
+
+function parseOllamaPs(out: string): OllamaRunning[] {
+  return parseFixedWidthTable(out).map(r => ({
+    name: r['NAME'] ?? '',
+    size_bytes: sizeStringToBytes(r['SIZE'] ?? ''),
+    context: r['CONTEXT'] ? Number(r['CONTEXT']) || undefined : undefined,
+    processor: r['PROCESSOR'] || undefined,
+  })).filter(m => m.name.length > 0)
+}
+
+function parsePressureLevel(out: string): MemoryPressure | undefined {
+  const m = out.match(/(\d+)/)
+  if (!m) return undefined
+  const n = Number(m[1])
+  if (n === 0) return 'normal'
+  if (n === 1) return 'warn'
+  if (n >= 2) return 'critical'
+  return undefined
+}
+
+export function createRealProbe(): Probe {
+  return {
+    loadAvg: () => os.loadavg() as [number, number, number],
+
+    pressureSysctl: () => safe(() => {
+      const out = execSync('sysctl -n kern.memorystatus_vm_pressure_level', { encoding: 'utf-8', timeout: 1500 })
+      return parsePressureLevel(out)
+    }),
+
+    vmStat: () => safe(() => {
+      const out = execSync('vm_stat', { encoding: 'utf-8', timeout: 2000 })
+      return parseVmStat(out)
+    }),
+
+    swapUsage: () => safe(() => {
+      const out = execSync('sysctl -n vm.swapusage', { encoding: 'utf-8', timeout: 2000 })
+      return parseSwapusage(out)
+    }),
+
+    swapUsageAfterDelay: async (delayMs) => {
+      await new Promise(r => setTimeout(r, delayMs))
+      return safe(() => {
+        const out = execSync('sysctl -n vm.swapusage', { encoding: 'utf-8', timeout: 2000 })
+        return parseSwapusage(out)
+      })
+    },
+
+    freeDiskGB: () => safe(() => {
+      // -P is POSIX format — single-line per FS, never wraps even on long
+      // device names like /dev/disk3s1s1. Columns: 1024-blocks, Used, Available.
+      const out = execSync('df -k -P /', { encoding: 'utf-8', timeout: 2000 })
+      const line = out.split('\n')[1]
+      if (!line) return undefined as unknown as number
+      const parts = line.trim().split(/\s+/)
+      const availableKb = Number(parts[3])
+      if (!Number.isFinite(availableKb)) return undefined as unknown as number
+      return +(availableKb / (1024 ** 2)).toFixed(1)
+    }),
+
+    ollamaList: () => safe(() => {
+      const out = execSync('ollama list', { encoding: 'utf-8', timeout: 3000 })
+      return parseOllamaList(out)
+    }),
+
+    ollamaPs: () => safe(() => {
+      const out = execSync('ollama ps', { encoding: 'utf-8', timeout: 3000 })
+      return parseOllamaPs(out)
+    }),
+
+    hardware: () => {
+      const platform = os.platform()
+      const cpuCores = os.cpus().length
+      const ramGB = Math.round(os.totalmem() / (1024 ** 3))
+      let cpu = os.cpus()[0]?.model || 'Unknown'
+      let osVersion = os.release()
+      let appleSilicon = false
+      if (platform === 'darwin') {
+        try { cpu = execSync('sysctl -n machdep.cpu.brand_string', { encoding: 'utf-8' }).trim() || cpu } catch {}
+        try { osVersion = execSync('sw_vers -productVersion', { encoding: 'utf-8' }).trim() || osVersion } catch {}
+        try { appleSilicon = execSync('sysctl -n hw.optional.arm64', { encoding: 'utf-8' }).trim() === '1' } catch {}
+      }
+      return {
+        cpu,
+        cpu_cores: cpuCores,
+        cpu_arch: os.arch(),
+        apple_silicon: appleSilicon,
+        unified_memory: appleSilicon,
+        ram_gb: ramGB,
+        os: platform === 'darwin' ? 'macOS' : platform,
+        os_version: osVersion,
+      }
+    },
+  }
+}
+
+/**
+ * Guard rail for `verdict machine inspect`. Phase 1 of this command is macOS
+ * only — Linux/Windows return a half-baked snapshot today, which is worse
+ * than refusing. Tests bypass this by using a fake probe.
+ */
+export function assertSupportedPlatform(): void {
+  if (os.platform() !== 'darwin') {
+    throw new Error(`'verdict machine inspect' currently supports macOS only (got ${os.platform()}). Linux support is tracked for a later phase.`)
+  }
+}
+
+// Exposed for tests.
+export const _internals = { parseVmStat, parseSwapusage, parseOllamaList, parseOllamaPs, parsePressureLevel, parseFixedWidthTable, sizeStringToBytes }

--- a/src/core/resource-guard.ts
+++ b/src/core/resource-guard.ts
@@ -1,0 +1,193 @@
+/**
+ * Resource guard — gates a run on live machine state.
+ *
+ * Compares a `MachineSnapshot` (from `verdict machine inspect`) against the
+ * `run.resource_guard` config block and reports whether it's safe to start
+ * (`gateStart`) or to keep going between cases (`gateBetweenCases`).
+ *
+ * Pure logic — no subprocesses. Callers supply a probe / snapshot. Designed
+ * so the runner can paste the result straight into its log without further
+ * formatting.
+ */
+
+import type { Verdict, MemoryPressure, MachineSnapshot, Thresholds } from './machine.js'
+import { inspect, DEFAULT_THRESHOLDS, type Probe } from './machine.js'
+
+export interface ResourceGuardConfig {
+  enabled: boolean
+  on_fail: 'abort' | 'warn'
+  max_concurrency?: number
+  min_free_disk_gb: number
+  max_memory_pressure: MemoryPressure
+  max_swap_delta_mb: number
+  /** When 0, the swap-delta check is skipped entirely. */
+  swap_sample_ms: number
+  mid_run_check_seconds: number
+}
+
+export interface GuardResult {
+  ok: boolean
+  /** Verdict on the current snapshot (mirrors `MachineSnapshot.verdict.state`). */
+  verdict: Verdict
+  /** Per-rule breakdown. Each entry is a human-readable status string. */
+  checks: GuardCheck[]
+  /** Concatenation of failing-check reasons, ready for log/error output. */
+  reason?: string
+}
+
+export interface GuardCheck {
+  rule: 'memory_pressure' | 'free_disk' | 'swap_delta' | 'concurrency'
+  ok: boolean
+  /**
+   * `true` when the rule was deliberately not evaluated (e.g. swap-delta
+   * with `swap_sample_ms: 0`, or free-disk when the probe returned 0 GB).
+   * Skipped rules are reported in `checks` but excluded from the pass/fail
+   * aggregate.
+   */
+  skipped?: boolean
+  detail: string
+}
+
+const PRESSURE_RANK: Record<MemoryPressure, number> = { normal: 0, warn: 1, critical: 2 }
+
+/**
+ * Evaluate the guard against a snapshot. Pure, no I/O — pair with `inspect()`
+ * to get the snapshot, or build a `MachineSnapshot` shape in tests.
+ *
+ * `configuredConcurrency` is what `config.run.concurrency` resolves to, so
+ * the guard can flag when the user set 4 but `max_concurrency: 1`.
+ */
+export function evaluateGuard(
+  snap: MachineSnapshot,
+  cfg: ResourceGuardConfig,
+  configuredConcurrency?: number,
+): GuardResult {
+  const checks: GuardCheck[] = []
+
+  // 1. Memory pressure. Field name reads as "the max pressure I allow." A
+  //    machine *at* the threshold passes; anything worse fails.
+  const ok_pressure = PRESSURE_RANK[snap.memory.pressure] <= PRESSURE_RANK[cfg.max_memory_pressure]
+  checks.push({
+    rule: 'memory_pressure',
+    ok: ok_pressure,
+    detail: ok_pressure
+      ? `pressure ${snap.memory.pressure} within max_memory_pressure=${cfg.max_memory_pressure}`
+      : `pressure ${snap.memory.pressure} exceeds max_memory_pressure=${cfg.max_memory_pressure}`,
+  })
+
+  // 2. Free disk. Snapshot may have `free_gb: 0` when the probe failed;
+  //    treat that as "skip" rather than "fail" — we'd rather not block a
+  //    run on missing telemetry.
+  if (snap.disk.free_gb > 0) {
+    const ok_disk = snap.disk.free_gb >= cfg.min_free_disk_gb
+    checks.push({
+      rule: 'free_disk',
+      ok: ok_disk,
+      detail: ok_disk
+        ? `free disk ${snap.disk.free_gb.toFixed(1)} GB >= ${cfg.min_free_disk_gb} GB`
+        : `free disk ${snap.disk.free_gb.toFixed(1)} GB < ${cfg.min_free_disk_gb} GB reserve`,
+    })
+  } else {
+    checks.push({
+      rule: 'free_disk',
+      ok: true,
+      skipped: true,
+      detail: 'free disk probe returned 0 GB — skipped',
+    })
+  }
+
+  // 3. Swap delta. Only meaningful when `swap_sample_ms > 0`; otherwise
+  //    `swap0` and `swap1` are read back-to-back and the delta is always
+  //    ~0. We report the rule as skipped in that case so users don't think
+  //    a 200 MB threshold is gating anything when it isn't.
+  if (cfg.swap_sample_ms <= 0) {
+    checks.push({
+      rule: 'swap_delta',
+      ok: true,
+      skipped: true,
+      detail: `swap_sample_ms=0 — swap-delta check disabled`,
+    })
+  } else if (snap.swap.delta_mb_over_sample === undefined) {
+    checks.push({
+      rule: 'swap_delta',
+      ok: true,
+      skipped: true,
+      detail: 'swap delta unavailable — skipped',
+    })
+  } else {
+    const ok_swap = snap.swap.delta_mb_over_sample <= cfg.max_swap_delta_mb
+    checks.push({
+      rule: 'swap_delta',
+      ok: ok_swap,
+      detail: ok_swap
+        ? `swap delta ${snap.swap.delta_mb_over_sample.toFixed(0)} MB over ${Math.round(snap.swap.sample_ms / 1000)}s <= ${cfg.max_swap_delta_mb} MB`
+        : `swap grew ${snap.swap.delta_mb_over_sample.toFixed(0)} MB during ${Math.round(snap.swap.sample_ms / 1000)}s sample (max ${cfg.max_swap_delta_mb})`,
+    })
+  }
+
+  // 4. Concurrency. Surface the conflict but don't fail the gate — the runner
+  //    decides whether to clamp or warn.
+  if (cfg.max_concurrency !== undefined && configuredConcurrency !== undefined) {
+    const ok_conc = configuredConcurrency <= cfg.max_concurrency
+    checks.push({
+      rule: 'concurrency',
+      ok: ok_conc,
+      detail: ok_conc
+        ? `concurrency ${configuredConcurrency} <= ${cfg.max_concurrency}`
+        : `concurrency ${configuredConcurrency} exceeds guard limit ${cfg.max_concurrency} (will be clamped)`,
+    })
+  }
+
+  const failing = checks.filter(c => !c.ok && !c.skipped && c.rule !== 'concurrency')
+  const ok = failing.length === 0
+  return {
+    ok,
+    verdict: snap.verdict.state,
+    checks,
+    reason: ok ? undefined : failing.map(c => c.detail).join('; '),
+  }
+}
+
+/**
+ * Resolve the effective concurrency a run should use: the config's
+ * `concurrency` clamped to `resource_guard.max_concurrency` (if set).
+ */
+export function effectiveConcurrency(configured: number, cfg: ResourceGuardConfig | undefined): number {
+  if (!cfg || !cfg.enabled || cfg.max_concurrency === undefined) return configured
+  return Math.min(configured, cfg.max_concurrency)
+}
+
+/**
+ * Detect a guard config that has been silently disabled — `enabled: false`
+ * but with non-default thresholds set. Returns a message if the config will
+ * surprise the user, otherwise `undefined`.
+ */
+export function describeDisabledMisconfig(cfg: ResourceGuardConfig | undefined): string | undefined {
+  if (!cfg || cfg.enabled) return undefined
+  const hints: string[] = []
+  if (cfg.max_concurrency !== undefined) hints.push(`max_concurrency=${cfg.max_concurrency}`)
+  if (cfg.min_free_disk_gb !== 25) hints.push(`min_free_disk_gb=${cfg.min_free_disk_gb}`)
+  if (cfg.max_memory_pressure !== 'warn') hints.push(`max_memory_pressure=${cfg.max_memory_pressure}`)
+  if (cfg.max_swap_delta_mb !== 200) hints.push(`max_swap_delta_mb=${cfg.max_swap_delta_mb}`)
+  if (cfg.swap_sample_ms !== 0) hints.push(`swap_sample_ms=${cfg.swap_sample_ms}`)
+  if (cfg.mid_run_check_seconds !== 0) hints.push(`mid_run_check_seconds=${cfg.mid_run_check_seconds}`)
+  if (hints.length === 0) return undefined
+  return `resource_guard is disabled (enabled: false) but you set ${hints.join(', ')} — these settings will be ignored`
+}
+
+/**
+ * Run the guard against a live probe. Convenience wrapper for the runner so
+ * it doesn't need to know about `inspect()` and `Thresholds` directly.
+ *
+ * The swap-sample window is taken from `cfg.swap_sample_ms`. When 0, the
+ * swap-delta check is reported as skipped.
+ */
+export async function evaluateGuardLive(
+  probe: Probe,
+  cfg: ResourceGuardConfig,
+  opts: { configuredConcurrency?: number; thresholds?: Thresholds } = {},
+): Promise<{ snapshot: MachineSnapshot; guard: GuardResult }> {
+  const snapshot = await inspect(probe, opts.thresholds ?? DEFAULT_THRESHOLDS, { swapSampleMs: cfg.swap_sample_ms })
+  const guard = evaluateGuard(snapshot, cfg, opts.configuredConcurrency)
+  return { snapshot, guard }
+}

--- a/src/core/runner.ts
+++ b/src/core/runner.ts
@@ -10,6 +10,8 @@ import { scoreSimilar } from '../judge/similar.js'
 import { scoreDeterministic, isDeterministic, scoreToolCall, scoreLatency, scoreCost } from '../judge/deterministic.js'
 import { detectHardware, toRunResultFormat } from './hardware.js'
 import { preloadModels } from './preload.js'
+import { createRealProbe } from './machine.js'
+import { evaluateGuardLive, effectiveConcurrency, describeDisabledMisconfig, type ResourceGuardConfig, type GuardResult } from './resource-guard.js'
 
 /**
  * Detect environment information
@@ -269,7 +271,36 @@ export async function runEvals(
 
   const cases: CaseResult[] = checkpoint ? [...checkpoint.partialResults] : []
   const completedIds = new Set(checkpoint?.completedCaseIds ?? [])
-  const { concurrency } = config.run
+
+  // Resource guard — gate the run on live machine state before any model call.
+  // The guard config defaults to undefined (off); when present but
+  // `enabled: false`, we warn if the user set thresholds that we'll ignore.
+  const guardCfg = config.run.resource_guard as ResourceGuardConfig | undefined
+  const misconfig = describeDisabledMisconfig(guardCfg)
+  if (misconfig) log(`resource_guard: ${misconfig}`)
+
+  const probe = guardCfg?.enabled ? createRealProbe() : null
+  let lastGuardCheckAt = 0
+  const guardLog: Array<{ phase: 'start' | 'mid_run'; ts: string; result: GuardResult }> = []
+
+  if (probe && guardCfg) {
+    const { snapshot, guard } = await evaluateGuardLive(probe, guardCfg, {
+      configuredConcurrency: config.run.concurrency,
+    })
+    guardLog.push({ phase: 'start', ts: new Date().toISOString(), result: guard })
+    log(`resource_guard: ${guard.ok ? 'ok' : 'fail'} (verdict ${guard.verdict})`)
+    for (const c of guard.checks) log(`  - ${c.rule}: ${c.detail}${c.skipped ? ' [skipped]' : ''}`)
+    if (!guard.ok) {
+      const msg = `resource_guard refused to start: ${guard.reason} (machine verdict: ${snapshot.verdict.state})`
+      if (guardCfg.on_fail === 'abort') throw new Error(msg)
+      log(`resource_guard: on_fail=warn — continuing despite: ${guard.reason}`)
+    }
+    lastGuardCheckAt = Date.now()
+  }
+  const concurrency = effectiveConcurrency(config.run.concurrency, guardCfg)
+  if (probe && guardCfg && concurrency !== config.run.concurrency) {
+    log(`resource_guard: clamping concurrency ${config.run.concurrency} -> ${concurrency}`)
+  }
 
   for (const evalCase of allCases) {
     // Skip already-completed cases when resuming
@@ -295,6 +326,34 @@ export async function runEvals(
         }
       }
       continue
+    }
+
+    // Mid-run resource_guard check — gates each subsequent case once the
+    // user-configured cooldown has elapsed. Default cooldown is 0 (off).
+    // On the first failure we wait 2 s and re-check once, so a transient
+    // spike (e.g. Time Machine kicking off) doesn't kill a 30-minute run.
+    if (probe && guardCfg && guardCfg.mid_run_check_seconds > 0) {
+      const elapsedMs = Date.now() - lastGuardCheckAt
+      if (elapsedMs >= guardCfg.mid_run_check_seconds * 1000) {
+        let { guard } = await evaluateGuardLive(probe, guardCfg, {
+          configuredConcurrency: concurrency,
+        })
+        if (!guard.ok) {
+          log(`resource_guard: ${guard.reason} — retrying after 2s`)
+          await new Promise(r => setTimeout(r, 2000))
+          guard = (await evaluateGuardLive(probe, guardCfg, { configuredConcurrency: concurrency })).guard
+        }
+        guardLog.push({ phase: 'mid_run', ts: new Date().toISOString(), result: guard })
+        lastGuardCheckAt = Date.now()
+        if (!guard.ok) {
+          const msg = `resource_guard tripped between cases (after retry): ${guard.reason}`
+          if (guardCfg.on_fail === 'abort') {
+            log(`resource_guard: pause before ${evalCase.id} — ${guard.reason}`)
+            throw new Error(msg)
+          }
+          log(`resource_guard: on_fail=warn — continuing despite: ${guard.reason}`)
+        }
+      }
     }
 
     log(`${evalCase.id}: running ${modelIds.length} model(s)`)
@@ -435,6 +494,16 @@ export async function runEvals(
     config_file: configFile || 'verdict.yaml',
     verdict_version: environment.verdict_version,
     hardware: `${hwFormat.cpu} ${hwFormat.ram_gb}GB`,
+    ...(guardLog.length > 0 && {
+      resource_guard: guardLog.map(e => ({
+        phase: e.phase,
+        ts: e.ts,
+        ok: e.result.ok,
+        verdict: e.result.verdict,
+        checks: e.result.checks.map(c => ({ rule: c.rule, ok: c.ok, skipped: c.skipped, detail: c.detail })),
+        reason: e.result.reason,
+      })),
+    }),
   }
 
   return {

--- a/src/core/runner.ts
+++ b/src/core/runner.ts
@@ -220,6 +220,16 @@ async function runMultiTurn(
   return lastResponse
 }
 
+function sleep(ms: number): Promise<void> {
+  return new Promise(resolve => setTimeout(resolve, ms))
+}
+
+function midRunPauseMs(cfg: ResourceGuardConfig): number {
+  const configuredMs = cfg.mid_run_check_seconds * 1000
+  if (!Number.isFinite(configuredMs) || configuredMs <= 0) return 5000
+  return Math.min(Math.max(configuredMs, 2000), 30000)
+}
+
 export async function runEvals(
   config: Config,
   packs: EvalPack[],
@@ -236,43 +246,11 @@ export async function runEvals(
   )
   const modelIds = config.models.map(m => m.id)
 
-  // Pre-load models if enabled
-  if (preload) {
-    await preloadModels(config.models, false)
-  }
-
-  // Resume from checkpoint if requested
-  let checkpoint: Checkpoint | null = null
-  let runId: string
-  if (resume) {
-    checkpoint = loadCheckpoint(config.output.dir, configHash)
-    if (checkpoint) {
-      runId = checkpoint.runId
-      log(`Resuming run ${runId} — ${checkpoint.completedCaseIds.length}/${allCases.length} cases already done`)
-    } else {
-      runId = new Date().toISOString().replace(/[:.]/g, '-').slice(0, 19)
-      log('No checkpoint found, starting fresh run')
-    }
-  } else {
-    runId = new Date().toISOString().replace(/[:.]/g, '-').slice(0, 19)
-  }
-
   const judgeModel = config.models.find(m => m.id === config.judge.model)
   if (!judgeModel) throw new Error(`Judge model '${config.judge.model}' not found in models list`)
 
-  const summary: Record<string, ModelSummary> = {}
-  for (const id of modelIds) {
-    summary[id] = {
-      model_id: id, avg_total: 0, avg_accuracy: 0, avg_completeness: 0,
-      avg_conciseness: 0, avg_latency_ms: 0, avg_tokens_per_sec: 0,
-      total_cost_usd: 0, win_rate: 0, wins: 0, cases_run: 0, avg_solve_rate: 0,
-    }
-  }
-
-  const cases: CaseResult[] = checkpoint ? [...checkpoint.partialResults] : []
-  const completedIds = new Set(checkpoint?.completedCaseIds ?? [])
-
-  // Resource guard — gate the run on live machine state before any model call.
+  // Resource guard — gate the run on live machine state before any model call,
+  // including Ollama preload.
   // The guard config defaults to undefined (off); when present but
   // `enabled: false`, we warn if the user set thresholds that we'll ignore.
   const guardCfg = config.run.resource_guard as ResourceGuardConfig | undefined
@@ -302,6 +280,40 @@ export async function runEvals(
     log(`resource_guard: clamping concurrency ${config.run.concurrency} -> ${concurrency}`)
   }
 
+  // Pre-load models only after the start guard has passed. Preload makes real
+  // Ollama calls and can page in several GB per model.
+  if (preload) {
+    await preloadModels(config.models, false)
+  }
+
+  // Resume from checkpoint if requested
+  let checkpoint: Checkpoint | null = null
+  let runId: string
+  if (resume) {
+    checkpoint = loadCheckpoint(config.output.dir, configHash)
+    if (checkpoint) {
+      runId = checkpoint.runId
+      log(`Resuming run ${runId} — ${checkpoint.completedCaseIds.length}/${allCases.length} cases already done`)
+    } else {
+      runId = new Date().toISOString().replace(/[:.]/g, '-').slice(0, 19)
+      log('No checkpoint found, starting fresh run')
+    }
+  } else {
+    runId = new Date().toISOString().replace(/[:.]/g, '-').slice(0, 19)
+  }
+
+  const summary: Record<string, ModelSummary> = {}
+  for (const id of modelIds) {
+    summary[id] = {
+      model_id: id, avg_total: 0, avg_accuracy: 0, avg_completeness: 0,
+      avg_conciseness: 0, avg_latency_ms: 0, avg_tokens_per_sec: 0,
+      total_cost_usd: 0, win_rate: 0, wins: 0, cases_run: 0, avg_solve_rate: 0,
+    }
+  }
+
+  const cases: CaseResult[] = checkpoint ? [...checkpoint.partialResults] : []
+  const completedIds = new Set(checkpoint?.completedCaseIds ?? [])
+
   for (const evalCase of allCases) {
     // Skip already-completed cases when resuming
     if (completedIds.has(evalCase.id)) {
@@ -330,28 +342,30 @@ export async function runEvals(
 
     // Mid-run resource_guard check — gates each subsequent case once the
     // user-configured cooldown has elapsed. Default cooldown is 0 (off).
-    // On the first failure we wait 2 s and re-check once, so a transient
-    // spike (e.g. Time Machine kicking off) doesn't kill a 30-minute run.
+    // Start failures can abort; mid-run failures pause between cases until
+    // the machine recovers so completed checkpointed work is preserved.
     if (probe && guardCfg && guardCfg.mid_run_check_seconds > 0) {
       const elapsedMs = Date.now() - lastGuardCheckAt
       if (elapsedMs >= guardCfg.mid_run_check_seconds * 1000) {
         let { guard } = await evaluateGuardLive(probe, guardCfg, {
           configuredConcurrency: concurrency,
         })
-        if (!guard.ok) {
-          log(`resource_guard: ${guard.reason} — retrying after 2s`)
-          await new Promise(r => setTimeout(r, 2000))
-          guard = (await evaluateGuardLive(probe, guardCfg, { configuredConcurrency: concurrency })).guard
-        }
         guardLog.push({ phase: 'mid_run', ts: new Date().toISOString(), result: guard })
         lastGuardCheckAt = Date.now()
         if (!guard.ok) {
-          const msg = `resource_guard tripped between cases (after retry): ${guard.reason}`
-          if (guardCfg.on_fail === 'abort') {
-            log(`resource_guard: pause before ${evalCase.id} — ${guard.reason}`)
-            throw new Error(msg)
+          if (guardCfg.on_fail === 'warn') {
+            log(`resource_guard: on_fail=warn — continuing despite: ${guard.reason}`)
+          } else {
+            const pauseMs = midRunPauseMs(guardCfg)
+            while (!guard.ok) {
+              log(`resource_guard: pause before ${evalCase.id} — ${guard.reason}; rechecking in ${Math.round(pauseMs / 1000)}s`)
+              await sleep(pauseMs)
+              guard = (await evaluateGuardLive(probe, guardCfg, { configuredConcurrency: concurrency })).guard
+              guardLog.push({ phase: 'mid_run', ts: new Date().toISOString(), result: guard })
+              lastGuardCheckAt = Date.now()
+            }
+            log(`resource_guard: recovered; resuming before ${evalCase.id}`)
           }
-          log(`resource_guard: on_fail=warn — continuing despite: ${guard.reason}`)
         }
       }
     }

--- a/src/core/tiers.ts
+++ b/src/core/tiers.ts
@@ -2,12 +2,17 @@
  * Hardware-tier model presets.
  *
  * Removes the "which models do I even pick?" cold-start cognitive load by
- * mapping a RAM envelope to a curated set of ~4-6 models that fit. Used by
+ * mapping a RAM envelope to a curated set of models that fit. Used by
  * `verdict run --tier <name>` and the `verdict tiers` command.
  *
- * Models are listed in priority order (most-recommended first). The judge
- * is whichever model is fastest + good-enough at that tier — usually the
- * smallest 7B in the list.
+ * Each tier has two lists:
+ *   - `models`     — primary candidates safe to keep warm 24/7. Listed in
+ *                    priority order (most-recommended first). The judge is
+ *                    typically the smallest 7B in the list.
+ *   - `frontier?`  — larger benchmark-only candidates that need exclusive
+ *                    use of the machine. Returned only when callers pass
+ *                    `{ mode: 'frontier' }` to `resolveTier`. Reachable from
+ *                    the CLI via `verdict run --tier <name> --frontier`.
  */
 
 import type { ModelConfig } from '../types/index.js'
@@ -26,6 +31,11 @@ export interface Tier {
   ram_gb: number                               // approximate RAM envelope
   judge_id: string                             // which model in `models` should be the judge
   models: TierModelSpec[]
+  /**
+   * Larger candidates that *can* run on this tier but are too tight to keep
+   * resident. Used with `resolveTier(name, { mode: 'frontier' })`.
+   */
+  frontier?: TierModelSpec[]
   aliases?: string[]                           // alternate names (e.g. 'm4-pro', 'mac-mini')
 }
 
@@ -70,11 +80,19 @@ export const TIERS: Tier[] = [
     judge_id: 'qwen2.5:7b',
     aliases: ['mac-mini-pro', 'm4-pro', 'macbook-pro-m3'],
     models: [
-      { id: 'qwen2.5:7b',       model: 'qwen2.5:7b',       provider: 'ollama', size_gb: 4.7 },
+      { id: 'qwen2.5:7b',       model: 'qwen2.5:7b',       provider: 'ollama', size_gb: 4.7, notes: 'safe default · judge' },
       { id: 'qwen2.5-coder:7b', model: 'qwen2.5-coder:7b', provider: 'ollama', size_gb: 4.7, notes: 'code' },
       { id: 'llama3.1:8b',      model: 'llama3.1:8b',      provider: 'ollama', size_gb: 4.9 },
-      { id: 'qwen2.5:14b',      model: 'qwen2.5:14b',      provider: 'ollama', size_gb: 9.0, notes: 'frontier of the tier' },
-      { id: 'phi3.5',           model: 'phi3.5',           provider: 'ollama', size_gb: 2.2 },
+      { id: 'qwen3:14b',        model: 'qwen3:14b',        provider: 'ollama', size_gb: 9.3, notes: 'qwen3 — strong reasoning' },
+      { id: 'gemma3:12b',       model: 'gemma3:12b',       provider: 'ollama', size_gb: 8.1, notes: '128K context' },
+      { id: 'qwen2.5:14b',      model: 'qwen2.5:14b',      provider: 'ollama', size_gb: 9.0 },
+      { id: 'phi3.5',           model: 'phi3.5',           provider: 'ollama', size_gb: 2.2, notes: 'fastest fallback' },
+    ],
+    // Larger candidates — pulled and benchmarked on demand, not kept warm 24/7.
+    // On 24 GB Apple Silicon these need exclusive use of the machine.
+    frontier: [
+      { id: 'gemma3:27b',  model: 'gemma3:27b',  provider: 'ollama', size_gb: 17,  notes: 'benchmark-only — needs ~21 GB RAM' },
+      { id: 'qwen3:32b',   model: 'qwen3:32b',   provider: 'ollama', size_gb: 20,  notes: 'benchmark-only — tight on 24 GB' },
     ],
   },
   {
@@ -146,10 +164,23 @@ export function expandTierModel(spec: TierModelSpec): ModelConfig {
 /**
  * Resolve a tier name to a full model list + recommended judge model id.
  * Returns null if the tier is unknown.
+ *
+ * `mode: 'frontier'` includes the tier's `frontier` candidates (e.g. larger
+ * models that need exclusive use of the machine — for benchmarking only).
+ * In frontier mode the judge is still drawn from the safe `models` list,
+ * since the larger candidates are the *subjects* of evaluation, not the
+ * scorers.
  */
-export function resolveTier(name: string): { tier: Tier; models: ModelConfig[]; judge: string } | null {
+export function resolveTier(
+  name: string,
+  opts: { mode?: 'default' | 'frontier' } = {},
+): { tier: Tier; models: ModelConfig[]; judge: string } | null {
   const tier = findTier(name)
   if (!tier) return null
-  const models = tier.models.map(expandTierModel)
+  const mode = opts.mode ?? 'default'
+  const specs = mode === 'frontier' && tier.frontier
+    ? [...tier.models, ...tier.frontier]
+    : tier.models
+  const models = specs.map(expandTierModel)
   return { tier, models, judge: tier.judge_id }
 }

--- a/src/types/index.ts
+++ b/src/types/index.ts
@@ -68,6 +68,41 @@ export const ConfigSchema = z.object({
     concurrency: z.number().default(3),
     retries: z.number().default(2),
     cache: z.boolean().default(true),
+    /**
+     * Resource guard — gates a run on live machine state. Aborts before
+     * starting if thresholds fail; pauses between cases if they fail mid-run.
+     * See src/core/resource-guard.ts for the evaluator.
+     */
+    resource_guard: z.object({
+      enabled: z.boolean().default(false),
+      /** Behavior on failure. 'abort' throws and stops the run; 'warn' logs and continues. */
+      on_fail: z.enum(['abort', 'warn']).default('abort'),
+      max_concurrency: z.number().int().positive().optional(),
+      min_free_disk_gb: z.number().nonnegative().default(25),
+      /**
+       * Highest memory pressure the guard accepts. Field reads naturally as
+       * "the maximum pressure I allow" — `warn` means warn-or-better passes,
+       * `normal` means only normal passes, `critical` means anything passes.
+       */
+      max_memory_pressure: z.enum(['normal', 'warn', 'critical']).default('warn'),
+      /**
+       * MB of swap growth tolerated within the sample window. Disabled
+       * unless `swap_sample_ms > 0`; otherwise the sample is back-to-back
+       * and the delta is always ~0.
+       */
+      max_swap_delta_mb: z.number().nonnegative().default(200),
+      /**
+       * Window over which to measure swap-delta. 0 disables the swap-delta
+       * check entirely (the field is reported as "skipped" in the result).
+       * 1000–2000 ms is plenty for catching active growth.
+       */
+      swap_sample_ms: z.number().nonnegative().default(0),
+      /**
+       * Seconds to wait between mid-run checks. The pre-run check always
+       * runs once; mid-run checks happen before each case if `> 0`.
+       */
+      mid_run_check_seconds: z.number().nonnegative().default(0),
+    }).optional(),
   }).default({}),
   output: z.object({
     dir: z.string().default('./results'),
@@ -286,6 +321,22 @@ export interface RunMeta {
   config_file: string
   verdict_version: string
   hardware: string
+  /** When the resource guard was enabled, the entries captured at start + each mid-run check. */
+  resource_guard?: ResourceGuardLogEntry[]
+}
+
+export interface ResourceGuardLogEntry {
+  phase: 'start' | 'mid_run'
+  ts: string
+  ok: boolean
+  verdict: 'quiet' | 'benchmark' | 'unsafe'
+  checks: Array<{
+    rule: 'memory_pressure' | 'free_disk' | 'swap_delta' | 'concurrency'
+    ok: boolean
+    skipped?: boolean
+    detail: string
+  }>
+  reason?: string
 }
 
 export interface StructuredReasoning {

--- a/src/types/index.ts
+++ b/src/types/index.ts
@@ -75,7 +75,11 @@ export const ConfigSchema = z.object({
      */
     resource_guard: z.object({
       enabled: z.boolean().default(false),
-      /** Behavior on failure. 'abort' throws and stops the run; 'warn' logs and continues. */
+      /**
+       * Behavior on failure. At start, 'abort' throws before any model calls
+       * and 'warn' logs/continues. Mid-run, 'abort' pauses between cases until
+       * the machine recovers, while 'warn' logs/continues.
+       */
       on_fail: z.enum(['abort', 'warn']).default('abort'),
       max_concurrency: z.number().int().positive().optional(),
       min_free_disk_gb: z.number().nonnegative().default(25),


### PR DESCRIPTION
## What

Adds `verdict machine inspect`, macOS machine telemetry, `run.resource_guard`, 24 GB quiet/frontier configs, and updated local model tier/catalog support.

## Why

This finishes Local LLM Phase 1 by giving local runs an explicit machine headroom check before model calls and between cases.

## Links

- Epic: Local LLM Phase 1
- RFC or discovery doc: N/A
- JTBDs addressed: Safer local eval runs on 24 GB Apple Silicon

## Testing

- [x] `npm run typecheck` passes
- [x] Tested with `verdict run --dry-run`
- [x] Tested against a real model: quiet config completed 10/10 cases using qwen2.5:7b, qwen2.5-coder:7b, llama3.1:8b, and gemma4:e4b

## Checklist

- [ ] No em dashes in copy or comments
- [ ] New eval packs have unique case IDs
- [ ] Deterministic scorer used where appropriate (JSON output, exact match)
- [ ] README updated if this is a user-visible change
- [ ] If part of an epic, PR title carries the phase code (e.g. `AD2`)
- [ ] If this decides something reversible-with-pain, the rationale is in a linked RFC or discovery doc
